### PR TITLE
Add expression_classification module (PIRS + BooteJTK)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CIRC — Claude Code Guidelines
+
+## Build & dependency management
+
+This project uses **Poetry** for dependency management and packaging.
+
+- Install dependencies: `poetry install`
+- Run tests: `poetry run pytest`
+- Run a specific test: `poetry run pytest tests/path/to/test.py -v`
+- Run a script / CLI: `poetry run circ <subcommand>`
+- Add a dependency: `poetry add <package>`
+- Add a dev dependency: `poetry add --group dev <package>`
+
+**Never use bare `python3 -m pytest` or `pip install`.** Always prefix with `poetry run`.
+
+## Project layout
+
+```
+circ/                        Main package
+  __init__.py
+  cli.py                     Unified `circ` CLI entry point
+  simulations.py             Shared simulation class (3-class: circadian/linear/constitutive)
+  pirs/                      Prediction Interval Ranking Score
+  bootjtk/                   Bootstrap empirical JTK circadian detection
+  limbr/                     KNN imputation + SVA batch-effect removal
+  expression_classification/ Unified PIRS + BooteJTK classifier
+tests/                       pytest test suite (mirrors circ/ layout)
+```
+
+## Data format
+
+Expression input files are tab-separated with:
+- First column: gene/peptide ID (header cell is `#` or `ID`)
+- Remaining columns: ZT- or CT-prefixed sample names, e.g. `ZT02_1`, `ZT04_2`
+
+## Key conventions
+
+- All modules follow a class-based API (e.g. `ranker`, `sva`, `Classifier`).
+- Pipeline outputs land alongside input files unless routed to a temp dir.
+- BooteJTK ref files live in `circ/bootjtk/ref_files/`.

--- a/circ/__init__.py
+++ b/circ/__init__.py
@@ -5,7 +5,8 @@ Submodules
 ----------
 circ.limbr      KNN imputation and SVA-based batch-effect removal
 circ.pirs       Prediction Interval Ranking Score (constitutive expression)
-circ.bootjtk    Bootstrap empirical JTK circadian rhythm detection
+circ.bootjtk               Bootstrap empirical JTK circadian rhythm detection
+circ.expression_classification  Unified PIRS + BooteJTK expression classifier
 """
 from importlib.metadata import version, PackageNotFoundError
 

--- a/circ/cli.py
+++ b/circ/cli.py
@@ -34,6 +34,29 @@ def _run_rank(args):
     print(f"Ranked {len(sorted_data)} expression profiles → {args.output}")
 
 
+def _run_classify(args):
+    from circ.expression_classification.classify import Classifier
+    clf = Classifier(
+        args.filename,
+        anova=args.anova,
+        reps=args.reps,
+        size=args.size,
+        workers=args.workers,
+    )
+    result = clf.run_all(
+        pirs_alpha=args.pirs_alpha,
+        basic=not args.limma,
+        pirs_percentile=args.pirs_percentile,
+        tau_threshold=args.tau_threshold,
+        emp_p_threshold=args.emp_p_threshold,
+    )
+    result.to_csv(args.output, sep='\t')
+    counts = result['label'].value_counts().to_dict()
+    print(f"Classified {len(result)} genes → {args.output}")
+    for label, n in sorted(counts.items()):
+        print(f"  {label}: {n}")
+
+
 # ---------------------------------------------------------------------------
 # Parser builders
 # ---------------------------------------------------------------------------
@@ -82,6 +105,44 @@ def _add_normalize_parser(subparsers):
     return p
 
 
+def _add_classify_parser(subparsers):
+    p = subparsers.add_parser(
+        "classify",
+        help="Classify expression profiles using PIRS + BooteJTK",
+        description=(
+            "Runs PIRS constitutiveness scoring and BooteJTK rhythmicity detection "
+            "then labels each gene as: constitutive, rhythmic, variable, or noisy_rhythmic."
+        ),
+    )
+    p.add_argument("-f", "--filename", required=True, metavar="FILE",
+                   help="Tab-separated input file (# index + ZT/CT columns)")
+    p.add_argument("-o", "--output", required=True, metavar="FILE",
+                   help="Output TSV with classification results")
+    p.add_argument("--anova", action="store_true",
+                   help="ANOVA-filter differentially expressed genes before PIRS scoring")
+    p.add_argument("--pirs-alpha", type=float, default=0.5, metavar="FLOAT",
+                   dest="pirs_alpha",
+                   help="Prediction interval alpha for PIRS scoring (default: 0.5)")
+    p.add_argument("--pirs-percentile", type=float, default=50, metavar="FLOAT",
+                   dest="pirs_percentile",
+                   help="PIRS percentile cutoff for 'stable' genes (default: 50)")
+    p.add_argument("--tau-threshold", type=float, default=0.5, metavar="FLOAT",
+                   dest="tau_threshold",
+                   help="Minimum TauMean to classify a gene as rhythmic (default: 0.5)")
+    p.add_argument("--emp-p-threshold", type=float, default=0.05, metavar="FLOAT",
+                   dest="emp_p_threshold",
+                   help="Maximum FDR-corrected p-value for rhythmicity (default: 0.05)")
+    p.add_argument("-r", "--reps", type=int, default=2, metavar="N",
+                   help="Replicates per timepoint for BooteJTK (default: 2)")
+    p.add_argument("-z", "--size", type=int, default=50, metavar="N",
+                   help="Bootstrap iterations per gene for BooteJTK (default: 50)")
+    p.add_argument("-j", "--workers", type=int, default=1, metavar="N",
+                   help="Parallel worker processes for BooteJTK (default: 1)")
+    p.add_argument("--limma", action="store_true",
+                   help="Use Limma/Vash variance shrinkage before BooteJTK")
+    return p
+
+
 def _add_rank_parser(subparsers):
     p = subparsers.add_parser(
         "rank",
@@ -119,6 +180,7 @@ def main():
     _add_impute_parser(subparsers)
     _add_normalize_parser(subparsers)
     _add_rank_parser(subparsers)
+    _add_classify_parser(subparsers)
 
     # rhythm and rhythm-calcp: capture remaining args and delegate to BooteJTK parsers
     rhythm_p = subparsers.add_parser(
@@ -147,6 +209,8 @@ def main():
         _run_normalize(args)
     elif args.command == "rank":
         _run_rank(args)
+    elif args.command == "classify":
+        _run_classify(args)
     elif args.command == "rhythm":
         sys.argv = [sys.argv[0]] + (args.bootejtk_args or [])
         from circ.bootjtk.BooteJTK import cli

--- a/circ/expression_classification/__init__.py
+++ b/circ/expression_classification/__init__.py
@@ -1,0 +1,3 @@
+from circ.expression_classification.classify import Classifier
+
+__all__ = ["Classifier"]

--- a/circ/expression_classification/classify.py
+++ b/circ/expression_classification/classify.py
@@ -1,0 +1,288 @@
+"""Expression classification integrating PIRS constitutiveness scores and BooteJTK rhythmicity."""
+import os
+import shutil
+import tempfile
+import types
+
+import numpy as np
+import pandas as pd
+
+_REF_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'bootjtk', 'ref_files')
+)
+
+# (pirs_stable, rhythmic) -> label
+_LABEL_MAP = {
+    (True,  True):  'rhythmic',
+    (True,  False): 'constitutive',
+    (False, True):  'noisy_rhythmic',
+    (False, False): 'variable',
+}
+
+
+class Classifier:
+    """Classify expression profiles by combining PIRS and BooteJTK.
+
+    Genes are assigned one of four labels based on two independent axes:
+
+    - **constitutive**: stable expression (low PIRS score), not rhythmic
+    - **rhythmic**: stable-to-moderate expression, strong circadian rhythm
+    - **variable**: high PIRS score (non-constitutive), not rhythmic
+    - **noisy_rhythmic**: high PIRS score with detectable rhythm signal
+
+    Parameters
+    ----------
+    filename : str
+        Path to the tab-separated expression file.  Must have a ``#`` index
+        column and ``ZT``- or ``CT``-prefixed sample columns.
+    anova : bool
+        Whether PIRS should ANOVA-filter differentially expressed genes
+        before computing scores.  Defaults to ``False`` so all genes receive
+        a PIRS score and can be classified.
+    reps : int
+        Replicates per timepoint passed to BooteJTK (default 2).
+    size : int
+        Bootstrap iterations per gene in BooteJTK (default 50).
+    workers : int
+        Parallel worker processes for BooteJTK.  0 = all CPUs (default 1).
+    """
+
+    def __init__(self, filename, *, anova=False, reps=2, size=50, workers=1):
+        self.filename = os.path.abspath(filename)
+        self.anova = anova
+        self.reps = reps
+        self.size = size
+        self.workers = workers
+        self.pirs_scores: pd.DataFrame | None = None
+        self.rhythm_results: pd.DataFrame | None = None
+        self.classifications: pd.DataFrame | None = None
+
+    # ------------------------------------------------------------------
+    # Individual analysis steps
+    # ------------------------------------------------------------------
+
+    def run_pirs(self, alpha: float = 0.5) -> pd.DataFrame:
+        """Compute PIRS constitutiveness scores for every gene.
+
+        Parameters
+        ----------
+        alpha : float
+            Significance level for prediction interval calculation (default 0.5).
+
+        Returns
+        -------
+        pd.DataFrame
+            Single-column DataFrame with index = gene IDs and column ``score``.
+        """
+        from circ.pirs.rank import ranker
+
+        r = ranker(self.filename, anova=self.anova)
+        r.get_tpoints()
+        if self.anova:
+            r.remove_anova()
+        self.pirs_scores = r.calculate_scores(alpha=alpha)
+        return self.pirs_scores
+
+    def run_bootjtk(self, basic: bool = True) -> pd.DataFrame:
+        """Run the BooteJTK + CalcP pipeline and return empirical results.
+
+        The pipeline runs in an isolated temporary directory so no files are
+        written alongside the original input.  The temp directory is removed
+        when the run completes.
+
+        Parameters
+        ----------
+        basic : bool
+            When ``True`` (default), skip Limma/Vash variance shrinkage and
+            run BooteJTK on the raw data directly.
+
+        Returns
+        -------
+        pd.DataFrame
+            BooteJTK results with empirical p-values added by CalcP.  Index is
+            gene ID; columns include ``TauMean``, ``PeriodMean``, ``PhaseMean``,
+            ``GammaBH``, etc.
+        """
+        from circ.bootjtk.pipeline import main as _pipeline_main
+
+        workdir = tempfile.mkdtemp(prefix='circ_classify_')
+        try:
+            fn_copy = os.path.join(workdir, os.path.basename(self.filename))
+            shutil.copy2(self.filename, fn_copy)
+
+            args = _make_pipeline_args(
+                filename=fn_copy,
+                ref_dir=_REF_DIR,
+                reps=self.reps,
+                size=self.size,
+                workers=self.workers,
+                basic=basic,
+            )
+
+            _pipeline_main(args)
+
+            calcp_files = [
+                f for f in os.listdir(workdir) if f.endswith('_GammaP.txt')
+            ]
+            if not calcp_files:
+                raise FileNotFoundError(
+                    'BooteJTK/CalcP produced no *_GammaP.txt output in the '
+                    f'working directory: {workdir}'
+                )
+            result_path = os.path.join(workdir, calcp_files[0])
+            self.rhythm_results = pd.read_csv(result_path, sep='\t', index_col='ID')
+        finally:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+        return self.rhythm_results
+
+    # ------------------------------------------------------------------
+    # Classification
+    # ------------------------------------------------------------------
+
+    def classify(
+        self,
+        pirs_percentile: float = 50,
+        tau_threshold: float = 0.5,
+        emp_p_threshold: float = 0.05,
+    ) -> pd.DataFrame:
+        """Assign class labels using pre-computed PIRS and BooteJTK results.
+
+        Call :meth:`run_pirs` and :meth:`run_bootjtk` first, or use
+        :meth:`run_all` to do everything in one step.
+
+        Parameters
+        ----------
+        pirs_percentile : float
+            Genes whose PIRS score falls at or below this percentile of all
+            scored genes are considered *stable* (default 50).
+        tau_threshold : float
+            Minimum ``TauMean`` required to call a gene rhythmic (default 0.5).
+        emp_p_threshold : float
+            Maximum ``GammaBH`` FDR-corrected p-value for a rhythmicity call
+            (default 0.05).  Only applied when ``GammaBH`` is present.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame indexed by gene ID with columns:
+
+            * ``pirs_score`` – raw PIRS score
+            * ``tau_mean`` – BooteJTK ``TauMean``
+            * ``emp_p`` – FDR-corrected p-value (``GammaBH``), if available
+            * ``period_mean`` – estimated period, if available
+            * ``phase_mean`` – estimated phase, if available
+            * ``label`` – one of ``constitutive``, ``rhythmic``,
+              ``variable``, ``noisy_rhythmic``
+        """
+        if self.pirs_scores is None:
+            raise RuntimeError("Call run_pirs() before classify().")
+        if self.rhythm_results is None:
+            raise RuntimeError("Call run_bootjtk() before classify().")
+
+        tau_col = 'TauMean' if 'TauMean' in self.rhythm_results.columns else 'Tau'
+
+        all_ids = self.pirs_scores.index.union(self.rhythm_results.index)
+        result = pd.DataFrame(index=all_ids)
+        result.index.name = self.pirs_scores.index.name
+
+        result['pirs_score'] = self.pirs_scores['score']
+        result['tau_mean'] = self.rhythm_results[tau_col]
+
+        for src_col, dst_col in [
+            ('GammaBH', 'emp_p'),
+            ('PeriodMean', 'period_mean'),
+            ('PhaseMean', 'phase_mean'),
+        ]:
+            if src_col in self.rhythm_results.columns:
+                result[dst_col] = self.rhythm_results[src_col]
+
+        pirs_cutoff = np.percentile(result['pirs_score'].dropna(), pirs_percentile)
+        stable = result['pirs_score'] <= pirs_cutoff
+
+        rhythmic = result['tau_mean'] >= tau_threshold
+        if 'emp_p' in result.columns:
+            rhythmic = rhythmic & (result['emp_p'] <= emp_p_threshold)
+
+        result['label'] = [
+            _LABEL_MAP.get((bool(s), bool(r)), 'unclassified')
+            for s, r in zip(stable, rhythmic)
+        ]
+
+        self.classifications = result
+        return self.classifications
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+
+    def run_all(
+        self,
+        *,
+        pirs_alpha: float = 0.5,
+        basic: bool = True,
+        pirs_percentile: float = 50,
+        tau_threshold: float = 0.5,
+        emp_p_threshold: float = 0.05,
+    ) -> pd.DataFrame:
+        """Run PIRS, BooteJTK, and classify in a single call.
+
+        Parameters mirror those of the individual methods.
+
+        Returns
+        -------
+        pd.DataFrame
+            Classification table as returned by :meth:`classify`.
+        """
+        self.run_pirs(alpha=pirs_alpha)
+        self.run_bootjtk(basic=basic)
+        return self.classify(
+            pirs_percentile=pirs_percentile,
+            tau_threshold=tau_threshold,
+            emp_p_threshold=emp_p_threshold,
+        )
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+def _make_pipeline_args(
+    *,
+    filename: str,
+    ref_dir: str,
+    reps: int,
+    size: int,
+    workers: int,
+    basic: bool,
+) -> types.SimpleNamespace:
+    """Build the argparse-compatible namespace that pipeline.main() expects."""
+    return types.SimpleNamespace(
+        filename=filename,
+        means='DEFAULT',
+        sds='DEFAULT',
+        ns='DEFAULT',
+        prefix='classify',
+        waveform='cosine',
+        period=os.path.join(ref_dir, 'period24.txt'),
+        phase=os.path.join(ref_dir, 'phases_00-22_by2.txt'),
+        width=os.path.join(ref_dir, 'asymmetries_02-22_by2.txt'),
+        output='DEFAULT',
+        pickle='DEFAULT',
+        id_list='DEFAULT',
+        null_list='DEFAULT',
+        size=size,
+        reps=reps,
+        workers=workers,
+        write=False,
+        basic=basic,
+        limma=False,
+        vash=False,
+        noreps=False,
+        rnaseq=False,
+        harding=False,
+        normal=False,
+        jtk='DEFAULT',
+        fit=False,
+        null='DEFAULT',
+    )

--- a/tests/expression_classification/conftest.py
+++ b/tests/expression_classification/conftest.py
@@ -1,0 +1,14 @@
+import os
+import pytest
+from circ.simulations import simulate
+
+
+@pytest.fixture(scope="session")
+def simulated_expression_file(tmp_path_factory):
+    """Write a small simulated expression TSV and return its path."""
+    tmp = tmp_path_factory.mktemp("expr")
+    out = str(tmp / "sim_expr.txt")
+    # Small dataset: 30 genes, 6 timepoints, 2 reps — fast enough for CI
+    sim = simulate(tpoints=6, nrows=30, nreps=2, tpoint_space=4, pcirc=0.4, plin=0.2, rseed=42)
+    sim.write_output(out_name=out)
+    return out

--- a/tests/expression_classification/test_classify.py
+++ b/tests/expression_classification/test_classify.py
@@ -1,0 +1,249 @@
+"""Tests for circ.expression_classification.classify."""
+import os
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from circ.expression_classification.classify import Classifier, _make_pipeline_args, _REF_DIR
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: PIRS integration
+# ---------------------------------------------------------------------------
+
+class TestRunPirs:
+    def test_returns_dataframe(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        scores = clf.run_pirs()
+        assert isinstance(scores, pd.DataFrame)
+
+    def test_score_column_present(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        scores = clf.run_pirs()
+        assert 'score' in scores.columns
+
+    def test_all_genes_scored_without_anova(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, anova=False)
+        scores = clf.run_pirs()
+        raw = pd.read_csv(simulated_expression_file, sep='\t', index_col=0)
+        assert len(scores) == len(raw)
+
+    def test_scores_are_non_negative(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        scores = clf.run_pirs()
+        assert (scores['score'] >= 0).all()
+
+    def test_stores_pirs_scores(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        clf.run_pirs()
+        assert clf.pirs_scores is not None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: BooteJTK integration
+# ---------------------------------------------------------------------------
+
+class TestRunBootjtk:
+    def test_returns_dataframe(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        results = clf.run_bootjtk()
+        assert isinstance(results, pd.DataFrame)
+
+    def test_tau_mean_column_present(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        results = clf.run_bootjtk()
+        assert 'TauMean' in results.columns
+
+    def test_gamma_bh_column_present(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        results = clf.run_bootjtk()
+        assert 'GammaBH' in results.columns
+
+    def test_result_covers_all_genes(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        results = clf.run_bootjtk()
+        raw = pd.read_csv(simulated_expression_file, sep='\t', index_col=0)
+        assert len(results) == len(raw)
+
+    def test_no_temp_files_left_behind(self, simulated_expression_file, tmp_path):
+        before = set(os.listdir(tmp_path))
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        clf.run_bootjtk()
+        after = set(os.listdir(tmp_path))
+        assert before == after
+
+    def test_stores_rhythm_results(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        clf.run_bootjtk()
+        assert clf.rhythm_results is not None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: classify()
+# ---------------------------------------------------------------------------
+
+class TestClassify:
+    @pytest.fixture(autouse=True)
+    def _prep(self, simulated_expression_file):
+        self.clf = Classifier(simulated_expression_file, size=10, reps=2)
+        self.clf.run_pirs()
+        self.clf.run_bootjtk()
+
+    def test_returns_dataframe(self):
+        result = self.clf.classify()
+        assert isinstance(result, pd.DataFrame)
+
+    def test_label_column_present(self):
+        result = self.clf.classify()
+        assert 'label' in result.columns
+
+    def test_valid_labels_only(self):
+        result = self.clf.classify()
+        valid = {'constitutive', 'rhythmic', 'variable', 'noisy_rhythmic', 'unclassified'}
+        assert set(result['label'].unique()).issubset(valid)
+
+    def test_all_four_columns_present(self):
+        result = self.clf.classify()
+        for col in ('pirs_score', 'tau_mean', 'emp_p', 'label'):
+            assert col in result.columns
+
+    def test_pirs_score_matches_run_pirs(self):
+        result = self.clf.classify()
+        shared = self.clf.pirs_scores.index.intersection(result.index)
+        pd.testing.assert_series_equal(
+            result.loc[shared, 'pirs_score'],
+            self.clf.pirs_scores.loc[shared, 'score'].rename('pirs_score'),
+            check_names=False,
+        )
+
+    def test_tau_mean_matches_bootjtk(self):
+        result = self.clf.classify()
+        shared = self.clf.rhythm_results.index.intersection(result.index)
+        pd.testing.assert_series_equal(
+            result.loc[shared, 'tau_mean'],
+            self.clf.rhythm_results.loc[shared, 'TauMean'].rename('tau_mean'),
+            check_names=False,
+        )
+
+    def test_raises_without_pirs(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        clf.run_bootjtk = lambda: None  # skip BooteJTK
+        clf.rhythm_results = pd.DataFrame({'TauMean': [0.5]}, index=['g1'])
+        with pytest.raises(RuntimeError, match='run_pirs'):
+            clf.classify()
+
+    def test_raises_without_bootjtk(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file)
+        clf.pirs_scores = pd.DataFrame({'score': [0.1]}, index=['g1'])
+        with pytest.raises(RuntimeError, match='run_bootjtk'):
+            clf.classify()
+
+    def test_pirs_percentile_affects_stable_fraction(self):
+        result_25 = self.clf.classify(pirs_percentile=25)
+        result_75 = self.clf.classify(pirs_percentile=75)
+        stable_labels = {'constitutive', 'rhythmic'}
+        n_stable_25 = result_25['label'].isin(stable_labels).sum()
+        n_stable_75 = result_75['label'].isin(stable_labels).sum()
+        assert n_stable_25 <= n_stable_75
+
+    def test_tau_threshold_affects_rhythmic_fraction(self):
+        result_low = self.clf.classify(tau_threshold=0.1, emp_p_threshold=1.0)
+        result_high = self.clf.classify(tau_threshold=0.9, emp_p_threshold=1.0)
+        rhythmic_labels = {'rhythmic', 'noisy_rhythmic'}
+        n_low = result_low['label'].isin(rhythmic_labels).sum()
+        n_high = result_high['label'].isin(rhythmic_labels).sum()
+        assert n_low >= n_high
+
+
+# ---------------------------------------------------------------------------
+# Integration test: run_all()
+# ---------------------------------------------------------------------------
+
+class TestRunAll:
+    def test_run_all_returns_dataframe(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        result = clf.run_all()
+        assert isinstance(result, pd.DataFrame)
+
+    def test_run_all_sets_all_attributes(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        clf.run_all()
+        assert clf.pirs_scores is not None
+        assert clf.rhythm_results is not None
+        assert clf.classifications is not None
+
+    def test_run_all_label_column(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        result = clf.run_all()
+        assert 'label' in result.columns
+
+    def test_run_all_no_unlabelled_rows(self, simulated_expression_file):
+        clf = Classifier(simulated_expression_file, size=10, reps=2)
+        result = clf.run_all()
+        assert result['label'].notna().all()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _make_pipeline_args helper
+# ---------------------------------------------------------------------------
+
+class TestMakePipelineArgs:
+    def test_returns_namespace(self):
+        args = _make_pipeline_args(
+            filename='/tmp/data.txt',
+            ref_dir=_REF_DIR,
+            reps=2,
+            size=50,
+            workers=1,
+            basic=True,
+        )
+        assert isinstance(args, types.SimpleNamespace)
+
+    def test_period_file_exists(self):
+        args = _make_pipeline_args(
+            filename='/tmp/data.txt',
+            ref_dir=_REF_DIR,
+            reps=2,
+            size=50,
+            workers=1,
+            basic=True,
+        )
+        assert os.path.isfile(args.period), f"Missing ref file: {args.period}"
+
+    def test_phase_file_exists(self):
+        args = _make_pipeline_args(
+            filename='/tmp/data.txt',
+            ref_dir=_REF_DIR,
+            reps=2,
+            size=50,
+            workers=1,
+            basic=True,
+        )
+        assert os.path.isfile(args.phase), f"Missing ref file: {args.phase}"
+
+    def test_width_file_exists(self):
+        args = _make_pipeline_args(
+            filename='/tmp/data.txt',
+            ref_dir=_REF_DIR,
+            reps=2,
+            size=50,
+            workers=1,
+            basic=True,
+        )
+        assert os.path.isfile(args.width), f"Missing ref file: {args.width}"
+
+    def test_reps_and_size_set(self):
+        args = _make_pipeline_args(
+            filename='/tmp/data.txt',
+            ref_dir=_REF_DIR,
+            reps=3,
+            size=20,
+            workers=2,
+            basic=False,
+        )
+        assert args.reps == 3
+        assert args.size == 20
+        assert args.workers == 2
+        assert args.basic is False


### PR DESCRIPTION
## Summary

- Adds `circ/expression_classification/classify.py` with a `Classifier` class that chains **PIRS** constitutiveness scoring and **BooteJTK** rhythmicity detection into a single workflow
- Genes are assigned one of four labels based on a 2×2 grid of PIRS stability vs. rhythmic significance: `constitutive`, `rhythmic`, `variable`, `noisy_rhythmic`
- Adds `circ classify` CLI subcommand with configurable PIRS-percentile, tau, and FDR thresholds
- Adds `CLAUDE.md` documenting the poetry-first dev workflow
- 30 passing tests covering PIRS integration, BooteJTK integration, classification logic, `run_all()`, and the pipeline-args helper

## Classification logic

| PIRS stable (≤ Nth percentile) | Rhythmic (tau ≥ threshold AND FDR ≤ threshold) | Label |
|---|---|---|
| ✓ | ✗ | `constitutive` |
| ✓ | ✓ | `rhythmic` |
| ✗ | ✗ | `variable` |
| ✗ | ✓ | `noisy_rhythmic` |

## Test plan

- [x] `poetry run pytest tests/expression_classification/` — all 30 tests pass
- [x] PIRS scores correctly cover all genes (anova=False default)
- [x] BooteJTK pipeline runs in isolated temp dir; no files left behind alongside input
- [x] CalcP empirical p-values (GammaBH) are included in output
- [x] Threshold parameters affect label distribution in expected direction
- [x] `run_all()` sets all three attributes and returns label column

🤖 Generated with [Claude Code](https://claude.com/claude-code)