### PR TITLE
Add circ.visualization module

### DIFF
--- a/circ/limbr/simulations.py
+++ b/circ/limbr/simulations.py
@@ -6,8 +6,6 @@ from collections import Counter
 
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-from sklearn.metrics import roc_curve, auc
 
 from circ.simulations import simulate  # noqa: F401  re-exported for backward compat
 
@@ -109,29 +107,18 @@ class analyze:
         self.merged[self.i].fillna(1.0, inplace=True)
         self.i += 1
 
-    def generate_roc_curve(self):
-        for j in self.tags.keys():
-            fpr, tpr, _ = roc_curve(
-                self.merged[self.tags[j]]['Circadian'].values,
-                1 - self.merged[self.tags[j]]['GammaBH'].values,
-                pos_label=1,
-            )
-            plt.plot(fpr, tpr, label=j)
-        plt.xlim([0.0, 1.0])
-        plt.ylim([0.0, 1.05])
-        plt.xlabel('False Positive Rate')
-        plt.ylabel('True Positive Rate')
-        plt.title('Receiver Operating Characteristic Comparison')
-        plt.legend(loc="lower right")
-        plt.savefig('ROC.pdf')
+    def _merged_dict(self):
+        """Build the ``{tag: df}`` dict expected by the visualization module."""
+        return {tag: self.merged[idx] for tag, idx in self.tags.items()}
+
+    def generate_roc_curve(self, outpath='ROC.pdf'):
+        """Plot ROC curves for all added datasets and save to *outpath*."""
+        from circ.visualization.benchmarks import roc_curve_plot
+        ax = roc_curve_plot(self._merged_dict(), outpath=outpath)
+        return ax
 
     def calculate_auc(self):
-        out = {}
-        for j in self.tags.keys():
-            fpr, tpr, _ = roc_curve(
-                self.merged[self.tags[j]]['Circadian'].values,
-                1 - self.merged[self.tags[j]]['GammaBH'].values,
-                pos_label=1,
-            )
-            out[j] = auc(fpr, tpr)
-        self.roc_auc = out
+        """Compute AUC for each dataset and store in ``self.roc_auc``."""
+        from circ.visualization.benchmarks import roc_auc
+        self.roc_auc = roc_auc(self._merged_dict())
+        return self.roc_auc

--- a/circ/pirs/simulations.py
+++ b/circ/pirs/simulations.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 from sklearn.metrics import precision_recall_curve
 
 from circ.simulations import simulate  # noqa: F401  re-exported for backward compat
@@ -27,23 +25,21 @@ class analyze:
         else:
             self.merged = pd.concat([self.merged, ranks])
 
-    def generate_pr_curve(self):
-        self.curves = pd.DataFrame(columns=['precision', 'recall', 'method'])
-        colors = ["windows blue", "amber", "light grey", "black"]
-        self.merged = (
+    def _build_curves(self):
+        """Compute per-method precision-recall curves and return as a DataFrame."""
+        curves = pd.DataFrame(columns=['precision', 'recall', 'method', 'rep'])
+        melted = (
             self.merged
             .pivot_table(index=['rep', 'method'], columns='#', values='score')
             .fillna(self.merged.score.max())
             .reset_index()
             .melt(id_vars=['rep', 'method'], value_name='score')
         )
-        for rep in self.merged.rep.unique():
-            for method in self.merged.method.unique():
+        for rep in melted.rep.unique():
+            for method in melted.method.unique():
                 pr = pd.merge(
                     self.true_classes[self.true_classes['rep'] == rep],
-                    self.merged[
-                        (self.merged.rep == rep) & (self.merged.method == method)
-                    ],
+                    melted[(melted.rep == rep) & (melted.method == method)],
                     on=['#', 'rep'],
                 )
                 precision, recall, _ = precision_recall_curve(
@@ -55,25 +51,13 @@ class analyze:
                     'method': method,
                     'rep': rep,
                 })
-                self.curves = pd.concat([self.curves, temp], sort=False)
-        ax = sns.lineplot(
-            x='recall', y='precision', hue='method', units='rep',
-            palette=sns.xkcd_palette(colors), estimator=None, data=self.curves,
-        )
-        ax.set_aspect(aspect=0.5)
-        plt.plot(
-            [0, 1],
-            [np.mean(self.true_classes['Const']), np.mean(self.true_classes['Const'])],
-            color='r', linestyle=':',
-        )
-        plt.xlim([0.0, 1.0])
-        plt.ylim([0.0, 1.05])
-        plt.setp(ax.lines, linewidth=0.5)
-        plt.xlabel('Recall')
-        plt.ylabel('Precision')
-        plt.title('Precision Recall Comparison')
-        leg = plt.legend(loc='upper center', bbox_to_anchor=(1.2, 0.8), shadow=True)
-        sns.despine(offset=10, trim=True)
-        plt.tight_layout()
-        plt.savefig('PR.pdf', dpi=25)
-        plt.close()
+                curves = pd.concat([curves, temp], sort=False)
+        return curves
+
+    def generate_pr_curve(self, outpath='PR.pdf'):
+        """Build precision-recall curves and save to *outpath* (default PR.pdf)."""
+        from circ.visualization.benchmarks import pr_curve
+        self.curves = self._build_curves()
+        baseline = float(np.mean(self.true_classes['Const']))
+        ax = pr_curve(self.curves, baseline=baseline, outpath=outpath)
+        return ax

--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -1,0 +1,72 @@
+"""Visualization utilities for CIRC expression analysis results.
+
+Classification plots
+--------------------
+.. autosummary::
+   label_distribution
+   pirs_vs_tau
+   volcano
+   pirs_score_distribution
+   tau_pval_scatter
+   pirs_pval_scatter
+   slope_pval_scatter
+   slope_vs_rhythm
+   phase_wheel
+   period_distribution
+   classification_summary
+
+Benchmark / evaluation plots
+-----------------------------
+.. autosummary::
+   pr_curve
+   roc_curve_plot
+   roc_auc
+   classification_pr
+   classification_roc
+
+The ``LABEL_COLORS`` dict maps each expression label to a consistent hex
+color and can be imported for use in custom plots.
+"""
+from circ.visualization.classify import (
+    LABEL_COLORS,
+    label_distribution,
+    pirs_vs_tau,
+    volcano,
+    pirs_score_distribution,
+    tau_pval_scatter,
+    pirs_pval_scatter,
+    slope_pval_scatter,
+    slope_vs_rhythm,
+    phase_wheel,
+    period_distribution,
+    classification_summary,
+)
+from circ.visualization.benchmarks import (
+    pr_curve,
+    roc_curve_plot,
+    roc_auc,
+    classification_pr,
+    classification_roc,
+)
+
+__all__ = [
+    # classify
+    'LABEL_COLORS',
+    'label_distribution',
+    'pirs_vs_tau',
+    'volcano',
+    'pirs_score_distribution',
+    'tau_pval_scatter',
+    'pirs_pval_scatter',
+    'slope_pval_scatter',
+    'slope_vs_rhythm',
+    'phase_wheel',
+    'period_distribution',
+    'classification_summary',
+    # benchmarks
+    'pr_curve',
+    'roc_curve_plot',
+    'roc_auc',
+    'classification_pr',
+    'classification_roc',
+]

--- a/circ/visualization/benchmarks.py
+++ b/circ/visualization/benchmarks.py
@@ -1,0 +1,267 @@
+"""Benchmark visualizations: PR curves, ROC curves, and AUC comparison.
+
+The standalone functions here are used by the ``analyze`` classes in
+``circ.pirs.simulations`` and ``circ.limbr.simulations``, and can also be
+called directly with pre-computed data.
+"""
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.metrics import precision_recall_curve, roc_curve, auc
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _ax(ax):
+    return ax if ax is not None else plt.subplots()[1]
+
+
+# ---------------------------------------------------------------------------
+# Precision-recall
+# ---------------------------------------------------------------------------
+
+def pr_curve(curves, baseline=None, ax=None, outpath=None):
+    """Plot one or more precision-recall curves from a pre-computed DataFrame.
+
+    Parameters
+    ----------
+    curves : pd.DataFrame
+        Columns: ``precision``, ``recall``, ``method``, ``rep`` (rep is used
+        as the ``units`` dimension for ``sns.lineplot``).
+    baseline : float or None
+        If given, draw a horizontal dashed line at this precision level (the
+        random-classifier baseline equals the positive-class fraction).
+    ax : matplotlib.axes.Axes, optional
+    outpath : str or None
+        If provided, save the figure to this path.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    palette = sns.color_palette('muted', n_colors=curves['method'].nunique())
+    sns.lineplot(
+        data=curves,
+        x='recall', y='precision',
+        hue='method', units='rep',
+        palette=palette,
+        estimator=None,
+        linewidth=0.8,
+        ax=ax,
+    )
+    if baseline is not None:
+        ax.axhline(baseline, color='#CC4444', ls=':', lw=0.9,
+                   label='random classifier')
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.05)
+    ax.set_xlabel('Recall')
+    ax.set_ylabel('Precision')
+    ax.set_title('Precision–Recall comparison')
+    ax.legend(loc='upper right', bbox_to_anchor=(1.3, 1.0),
+              frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    if outpath:
+        ax.get_figure().savefig(outpath, dpi=150, bbox_inches='tight')
+    return ax
+
+
+def roc_curve_plot(merged_dict, ax=None, outpath=None):
+    """Plot one or more ROC curves.
+
+    Parameters
+    ----------
+    merged_dict : dict[str, pd.DataFrame]
+        ``{tag: df}`` where each ``df`` has a binary truth column and a score
+        column.  The truth column must be named ``truth`` or ``Circadian``, and
+        the score column ``score`` or ``GammaBH``.
+    ax : matplotlib.axes.Axes, optional
+    outpath : str or None
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    for tag, df in merged_dict.items():
+        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
+        score_col = 'score' if 'score' in df.columns else 'GammaBH'
+        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
+        auc_val = auc(fpr, tpr)
+        ax.plot(fpr, tpr, label=f'{tag}  (AUC={auc_val:.3f})')
+    ax.plot([0, 1], [0, 1], color='#999999', ls='--', lw=0.8, label='random')
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.05)
+    ax.set_xlabel('False positive rate')
+    ax.set_ylabel('True positive rate')
+    ax.set_title('ROC comparison')
+    ax.legend(loc='lower right', frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    if outpath:
+        ax.get_figure().savefig(outpath, dpi=150, bbox_inches='tight')
+    return ax
+
+
+def roc_auc(merged_dict):
+    """Compute area under the ROC curve for each method.
+
+    Parameters
+    ----------
+    merged_dict : dict[str, pd.DataFrame]
+        Same format as :func:`roc_curve_plot`.
+
+    Returns
+    -------
+    dict[str, float]
+        ``{tag: auc_value}``.
+    """
+    out = {}
+    for tag, df in merged_dict.items():
+        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
+        score_col = 'score' if 'score' in df.columns else 'GammaBH'
+        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
+        out[tag] = auc(fpr, tpr)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Classification benchmarking (Classifier output + simulation ground truth)
+# ---------------------------------------------------------------------------
+
+def classification_pr(
+    classifications,
+    true_classes,
+    ground_truth_col='Const',
+    score_col='pirs_score',
+    invert_score=True,
+    ax=None,
+    title=None,
+):
+    """PR curve comparing ``Classifier`` output against simulation ground truth.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``, indexed by gene ID.
+    true_classes : pd.DataFrame
+        Simulation ground-truth table (from ``simulate.write_output``), with
+        binary columns such as ``Const``, ``Circadian``, and ``Linear``.
+    ground_truth_col : str
+        Which binary column in *true_classes* to treat as positive (default
+        ``'Const'``).
+    score_col : str
+        Score column from *classifications* to rank by (default
+        ``'pirs_score'``).  Lower PIRS = more constitutive, so the score is
+        inverted before computing the curve when *invert_score* is True.
+    invert_score : bool
+        If ``True`` (default), invert the score so that smaller values rank
+        higher (appropriate for PIRS where low = constitutive).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    merged = classifications[[score_col]].join(
+        true_classes[[ground_truth_col]], how='inner'
+    ).dropna()
+    if merged.empty:
+        ax.set_title((title or 'PR curve') + ' (no matched genes)')
+        return ax
+
+    scores = merged[score_col].values
+    if invert_score:
+        scores = -scores
+    precision, recall, _ = precision_recall_curve(
+        merged[ground_truth_col].values, scores, pos_label=1
+    )
+    baseline = merged[ground_truth_col].mean()
+    ap = np.trapezoid(precision, recall) if hasattr(np, 'trapezoid') else np.trapz(precision, recall)
+    ax.plot(recall, precision, color='#4878CF', lw=1.2,
+            label=f'{score_col} (AP={ap:.3f})')
+    ax.axhline(baseline, color='#CC4444', ls=':', lw=0.9,
+               label='random classifier')
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.05)
+    ax.set_xlabel('Recall')
+    ax.set_ylabel('Precision')
+    ax.set_title(title or f'PR curve: {ground_truth_col}')
+    ax.legend(frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    return ax
+
+
+def classification_roc(
+    classifications,
+    true_classes,
+    tasks=None,
+    ax=None,
+    title='ROC: Classifier scores vs ground truth',
+):
+    """ROC curves for multiple binary classification tasks.
+
+    For each task in *tasks*, the function pairs a ``Classifier`` score column
+    against a binary ground-truth column.  This lets you assess, for example,
+    whether PIRS score discriminates constitutive genes and whether TauMean
+    discriminates circadian genes — on the same axes.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``.
+    true_classes : pd.DataFrame
+        Binary ground-truth table with columns like ``Const``, ``Circadian``,
+        ``Linear``.
+    tasks : list of (str, str, bool) or None
+        Each entry is ``(score_col, truth_col, invert)``.  ``invert=True``
+        means lower score = positive (used for PIRS score and p-values).
+        Defaults to sensible combinations based on available columns.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+
+    if tasks is None:
+        tasks = []
+        if 'pirs_score' in classifications.columns and 'Const' in true_classes.columns:
+            tasks.append(('pirs_score', 'Const', True))
+        if 'tau_mean' in classifications.columns and 'Circadian' in true_classes.columns:
+            tasks.append(('tau_mean', 'Circadian', False))
+        if 'emp_p' in classifications.columns and 'Circadian' in true_classes.columns:
+            tasks.append(('emp_p', 'Circadian', True))
+        if 'pval' in classifications.columns and 'Const' in true_classes.columns:
+            tasks.append(('pval', 'Const', True))
+        if 'slope_pval' in classifications.columns and 'Linear' in true_classes.columns:
+            tasks.append(('slope_pval', 'Linear', True))
+
+    palette = sns.color_palette('muted', n_colors=max(len(tasks), 1))
+    for (score_col, truth_col, invert), color in zip(tasks, palette):
+        merged = classifications[[score_col]].join(
+            true_classes[[truth_col]], how='inner'
+        ).dropna()
+        if merged.empty:
+            continue
+        scores = -merged[score_col].values if invert else merged[score_col].values
+        fpr, tpr, _ = roc_curve(merged[truth_col].values, scores, pos_label=1)
+        auc_val = auc(fpr, tpr)
+        ax.plot(fpr, tpr, color=color, lw=1.2,
+                label=f'{score_col}→{truth_col}  AUC={auc_val:.3f}')
+
+    ax.plot([0, 1], [0, 1], color='#999999', ls='--', lw=0.8, label='random')
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.05)
+    ax.set_xlabel('False positive rate')
+    ax.set_ylabel('True positive rate')
+    ax.set_title(title)
+    ax.legend(loc='lower right', frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    return ax

--- a/circ/visualization/classify.py
+++ b/circ/visualization/classify.py
@@ -1,0 +1,645 @@
+"""Visualizations for expression classification results from Classifier.classify()."""
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import seaborn as sns
+
+# Consistent label colors used across every plot in this module
+LABEL_COLORS = {
+    'constitutive':  '#4878CF',
+    'rhythmic':      '#6ACC65',
+    'linear':        '#D65F5F',
+    'variable':      '#B47CC7',
+    'noisy_rhythmic': '#C4AD66',
+    'unclassified':  '#8C8C8C',
+}
+
+_LABEL_ORDER = [
+    'constitutive', 'rhythmic', 'linear',
+    'variable', 'noisy_rhythmic', 'unclassified',
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _ax(ax):
+    return ax if ax is not None else plt.subplots()[1]
+
+
+def _safe_neglog10(series, floor=1e-300):
+    return -np.log10(np.maximum(series.clip(lower=floor), floor))
+
+
+def _has(df, col):
+    return col in df.columns and df[col].notna().any()
+
+
+def _scatter_by_label(df, xcol, ycol, ax, size=18, alpha=0.65):
+    for lbl in _LABEL_ORDER:
+        sub = df[df['label'] == lbl] if 'label' in df.columns else df
+        if not sub.empty:
+            ax.scatter(
+                sub[xcol], sub[ycol],
+                color=LABEL_COLORS.get(lbl, '#8C8C8C'),
+                s=size, alpha=alpha, label=lbl,
+                rasterized=len(df) > 1000,
+            )
+
+
+def _label_legend(present, ax):
+    patches = [
+        mpatches.Patch(color=LABEL_COLORS[l], label=l)
+        for l in _LABEL_ORDER if l in present
+    ]
+    if patches:
+        ax.legend(handles=patches, loc='best', frameon=False, fontsize=8)
+
+
+# ---------------------------------------------------------------------------
+# Public plot functions
+# ---------------------------------------------------------------------------
+
+def label_distribution(classifications, ax=None, title='Expression label counts'):
+    """Horizontal bar chart of gene counts per expression label.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    present = [l for l in _LABEL_ORDER if l in classifications['label'].values]
+    counts = (
+        classifications['label']
+        .value_counts()
+        .reindex(present)
+        .fillna(0)
+        .astype(int)
+    )
+    colors = [LABEL_COLORS[l] for l in counts.index]
+    bars = ax.barh(counts.index, counts.values, color=colors)
+    ax.bar_label(bars, fmt='%d', padding=3, fontsize=8)
+    ax.set_xlabel('Gene count')
+    ax.set_title(title)
+    ax.invert_yaxis()
+    sns.despine(ax=ax, left=True)
+    return ax
+
+
+def pirs_vs_tau(
+    classifications,
+    pirs_percentile=50,
+    tau_threshold=0.5,
+    ax=None,
+    title='PIRS score vs rhythmicity (TauMean)',
+):
+    """Scatter of PIRS constitutiveness score vs BooteJTK TauMean.
+
+    Decision boundaries are drawn at *pirs_percentile* (vertical dashed line)
+    and *tau_threshold* (horizontal dotted line), showing the four
+    classification quadrants.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    pirs_percentile : float
+        Percentile threshold used for the stable/unstable split (default 50).
+    tau_threshold : float
+        TauMean threshold for rhythmicity calls (default 0.5).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    df = classifications.dropna(subset=['pirs_score', 'tau_mean'])
+    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+
+    _scatter_by_label(df, 'pirs_score', 'tau_mean', ax)
+
+    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'PIRS p{int(pirs_percentile)}')
+    ax.axhline(tau_threshold, color='#333333', ls=':', lw=0.9, alpha=0.7,
+               label=f'τ = {tau_threshold}')
+    ax.set_xlabel('PIRS score')
+    ax.set_ylabel('TauMean')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def volcano(
+    classifications,
+    emp_p_threshold=0.05,
+    pirs_percentile=50,
+    ax=None,
+    title='PIRS score vs rhythmicity significance',
+):
+    """Scatter of PIRS score vs −log₁₀(emp_p).
+
+    Combines the constitutiveness axis (PIRS score) with the rhythmicity
+    significance axis (GammaBH empirical p-value), revealing the four
+    quadrants that underlie the classification labels.
+
+    Requires ``emp_p`` column (present when ``run_bootjtk()`` has been called).
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    emp_p_threshold : float
+        FDR significance threshold drawn as a horizontal line (default 0.05).
+    pirs_percentile : float
+        PIRS percentile threshold drawn as a vertical dashed line (default 50).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if not _has(classifications, 'emp_p'):
+        raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
+    ax = _ax(ax)
+    df = classifications.dropna(subset=['pirs_score', 'emp_p'])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
+    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+
+    _scatter_by_label(df, 'pirs_score', 'neg_log_emp_p', ax)
+
+    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'FDR = {emp_p_threshold}')
+    ax.axvline(pirs_cut, color='#333333', ls=':', lw=0.9, alpha=0.7,
+               label=f'PIRS p{int(pirs_percentile)}')
+    ax.set_xlabel('PIRS score')
+    ax.set_ylabel('−log₁₀(GammaBH)')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def pirs_score_distribution(
+    classifications,
+    pirs_percentile=50,
+    ax=None,
+    title='PIRS score distribution by label',
+):
+    """KDE of PIRS scores overlaid per expression label.
+
+    A vertical dashed line marks the constitutiveness cutoff at
+    *pirs_percentile*.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    pirs_percentile : float
+        Percentile cutoff shown as a reference line (default 50).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    pirs_cut = np.percentile(classifications['pirs_score'].dropna(), pirs_percentile)
+    for lbl in _LABEL_ORDER:
+        sub = classifications[classifications['label'] == lbl]['pirs_score'].dropna()
+        if len(sub) >= 3:
+            sns.kdeplot(sub, ax=ax, color=LABEL_COLORS[lbl], label=lbl, fill=True,
+                        alpha=0.3, linewidth=1.2)
+    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.8,
+               label=f'p{int(pirs_percentile)} cut')
+    ax.set_xlabel('PIRS score')
+    ax.set_ylabel('Density')
+    ax.set_title(title)
+    ax.legend(frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    return ax
+
+
+def tau_pval_scatter(
+    classifications,
+    tau_threshold=0.5,
+    emp_p_threshold=0.05,
+    ax=None,
+    title='Rhythmicity: TauMean vs GammaBH significance',
+):
+    """Scatter of TauMean vs −log₁₀(emp_p), showing the BooteJTK decision space.
+
+    Threshold lines illustrate where the rhythmicity call is made.
+
+    Requires ``emp_p`` column.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    tau_threshold : float
+        TauMean threshold (default 0.5).
+    emp_p_threshold : float
+        Significance threshold (default 0.05).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if not _has(classifications, 'emp_p'):
+        raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
+    ax = _ax(ax)
+    df = classifications.dropna(subset=['tau_mean', 'emp_p'])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
+
+    _scatter_by_label(df, 'tau_mean', 'neg_log_emp_p', ax)
+
+    ax.axvline(tau_threshold, color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'τ = {tau_threshold}')
+    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls=':', lw=0.9, alpha=0.7,
+               label=f'FDR = {emp_p_threshold}')
+    ax.set_xlabel('TauMean')
+    ax.set_ylabel('−log₁₀(GammaBH)')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def pirs_pval_scatter(
+    classifications,
+    pval_threshold=0.05,
+    ax=None,
+    title='PIRS score vs temporal structure significance',
+):
+    """Scatter of PIRS score vs −log₁₀(pval_bh).
+
+    Combines the raw PIRS score with its permutation p-value.  Genes with both
+    a high PIRS score **and** a significant pval have statistically confirmed
+    temporal structure, distinguishing them from genes with high score due to
+    noise alone.
+
+    Requires ``pval`` column (from ``run_pirs(pvals=True)``).
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    pval_threshold : float
+        BH-corrected p-value threshold drawn as a horizontal line (default 0.05).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    p_col = 'pval_bh' if _has(classifications, 'pval_bh') else 'pval'
+    if not _has(classifications, p_col):
+        raise ValueError(
+            "'pval' column is required. Call run_pirs(pvals=True) first."
+        )
+    ax = _ax(ax)
+    df = classifications.dropna(subset=['pirs_score', p_col])
+    df = df.assign(neg_log_p=_safe_neglog10(df[p_col]))
+
+    _scatter_by_label(df, 'pirs_score', 'neg_log_p', ax)
+
+    ax.axhline(-np.log10(pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'α = {pval_threshold}')
+    lbl_used = 'pval_bh' if p_col == 'pval_bh' else 'pval'
+    ax.set_xlabel('PIRS score')
+    ax.set_ylabel(f'−log₁₀({lbl_used})')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def slope_pval_scatter(
+    classifications,
+    slope_pval_threshold=0.05,
+    pirs_percentile=50,
+    ax=None,
+    title='PIRS score vs linear slope significance',
+):
+    """Scatter of PIRS score vs −log₁₀(slope_pval_bh).
+
+    Reveals which genes have a statistically significant linear trend in
+    expression.  Linear genes should cluster at top-left (low PIRS score but
+    significant slope), while constitutive genes sit at the bottom-left.
+
+    Requires ``slope_pval`` column (from ``run_pirs(slope_pvals=True)``).
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    slope_pval_threshold : float
+        BH-corrected p-value threshold drawn as a horizontal line (default 0.05).
+    pirs_percentile : float
+        PIRS percentile cutoff drawn as a vertical reference line (default 50).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    p_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    if not _has(classifications, p_col):
+        raise ValueError(
+            "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
+        )
+    ax = _ax(ax)
+    df = classifications.dropna(subset=['pirs_score', p_col])
+    df = df.assign(neg_log_slope=_safe_neglog10(df[p_col]))
+    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+
+    _scatter_by_label(df, 'pirs_score', 'neg_log_slope', ax)
+
+    ax.axhline(-np.log10(slope_pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'α = {slope_pval_threshold}')
+    ax.axvline(pirs_cut, color='#333333', ls=':', lw=0.9, alpha=0.7,
+               label=f'PIRS p{int(pirs_percentile)}')
+    lbl_used = 'slope_pval_bh' if p_col == 'slope_pval_bh' else 'slope_pval'
+    ax.set_xlabel('PIRS score')
+    ax.set_ylabel(f'−log₁₀({lbl_used})')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def slope_vs_rhythm(
+    classifications,
+    slope_pval_threshold=0.05,
+    emp_p_threshold=0.05,
+    ax=None,
+    title='Slope significance vs rhythmicity significance',
+):
+    """Scatter of −log₁₀(slope_pval_bh) vs −log₁₀(emp_p).
+
+    Contrasts the two independent significance axes: linear drift (slope test)
+    and circadian rhythmicity (BooteJTK empirical p-value).  The four quadrants
+    correspond to the major label classes:
+
+    * Top-right: significant slope **and** rhythmic — ``noisy_rhythmic`` or
+      ``rhythmic`` depending on PIRS score.
+    * Top-left: significant slope, not rhythmic — ``linear``.
+    * Bottom-right: not sloped, rhythmic — ``rhythmic``.
+    * Bottom-left: neither — ``constitutive`` or ``variable``.
+
+    Requires ``slope_pval`` and ``emp_p`` columns.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    slope_pval_threshold : float
+        Slope significance threshold (default 0.05).
+    emp_p_threshold : float
+        Rhythm significance threshold (default 0.05).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    sp_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    if not _has(classifications, sp_col):
+        raise ValueError(
+            "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
+        )
+    if not _has(classifications, 'emp_p'):
+        raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
+
+    ax = _ax(ax)
+    df = classifications.dropna(subset=[sp_col, 'emp_p'])
+    df = df.assign(
+        neg_log_slope=_safe_neglog10(df[sp_col]),
+        neg_log_emp_p=_safe_neglog10(df['emp_p']),
+    )
+
+    _scatter_by_label(df, 'neg_log_slope', 'neg_log_emp_p', ax)
+
+    ax.axvline(-np.log10(slope_pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'slope α = {slope_pval_threshold}')
+    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls=':', lw=0.9, alpha=0.7,
+               label=f'rhythm α = {emp_p_threshold}')
+    lbl_used = 'slope_pval_bh' if sp_col == 'slope_pval_bh' else 'slope_pval'
+    ax.set_xlabel(f'−log₁₀({lbl_used})')
+    ax.set_ylabel('−log₁₀(GammaBH)')
+    ax.set_title(title)
+    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    sns.despine(ax=ax)
+    return ax
+
+
+def phase_wheel(
+    classifications,
+    labels=('rhythmic', 'noisy_rhythmic'),
+    ax=None,
+    title='Phase distribution (rhythmic genes)',
+):
+    """Polar histogram of estimated phase angles for rhythmic genes.
+
+    ``PhaseMean`` is in hours (0–24) and is converted to radians for the
+    polar plot.  Only genes whose ``label`` is in *labels* are included.
+
+    Requires ``phase_mean`` column (always present when ``run_bootjtk()`` has
+    been called).
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    labels : tuple of str
+        Labels to include (default: rhythmic and noisy_rhythmic).
+    ax : matplotlib.axes.Axes, optional
+        Must be a polar axes.  Created automatically if not provided.
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if not _has(classifications, 'phase_mean'):
+        raise ValueError("'phase_mean' column is required. Call run_bootjtk() first.")
+
+    if ax is None:
+        _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+
+    df = classifications[classifications['label'].isin(labels)].dropna(subset=['phase_mean'])
+    if df.empty:
+        ax.set_title(title + ' (no data)')
+        return ax
+
+    phases_rad = df['phase_mean'] * (2 * np.pi / 24)
+    nbins = 12
+    bins = np.linspace(0, 2 * np.pi, nbins + 1)
+    counts, _ = np.histogram(phases_rad, bins=bins)
+    widths = np.diff(bins)
+    bars = ax.bar(bins[:-1], counts, width=widths, align='edge', alpha=0.7,
+                  color='#6ACC65', edgecolor='white')
+
+    ax.set_theta_zero_location('N')
+    ax.set_theta_direction(-1)
+    ax.set_xticks(np.linspace(0, 2 * np.pi, 8, endpoint=False))
+    hour_labels = [f'ZT{int(h):02d}' for h in np.linspace(0, 24, 8, endpoint=False)]
+    ax.set_xticklabels(hour_labels, fontsize=8)
+    ax.set_title(title, pad=15)
+    return ax
+
+
+def period_distribution(
+    classifications,
+    labels=('rhythmic', 'noisy_rhythmic'),
+    reference_period=24.0,
+    ax=None,
+    title='Period distribution (rhythmic genes)',
+):
+    """Histogram of estimated period lengths for rhythmic genes.
+
+    A vertical dashed line marks *reference_period* (default 24 h).  Only
+    genes whose ``label`` is in *labels* are included.
+
+    Requires ``period_mean`` column (always present when ``run_bootjtk()`` has
+    been called).
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+    labels : tuple of str
+    reference_period : float
+        Reference period drawn as a dashed line (default 24.0).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if not _has(classifications, 'period_mean'):
+        raise ValueError("'period_mean' column is required. Call run_bootjtk() first.")
+
+    ax = _ax(ax)
+    for lbl in labels:
+        sub = classifications[classifications['label'] == lbl]['period_mean'].dropna()
+        if not sub.empty:
+            ax.hist(sub, bins=20, color=LABEL_COLORS.get(lbl, '#8C8C8C'),
+                    alpha=0.6, label=lbl, edgecolor='white')
+    ax.axvline(reference_period, color='#333333', ls='--', lw=0.9, alpha=0.8,
+               label=f'{reference_period:.0f} h')
+    ax.set_xlabel('Period (h)')
+    ax.set_ylabel('Gene count')
+    ax.set_title(title)
+    ax.legend(frameon=False, fontsize=8)
+    sns.despine(ax=ax)
+    return ax
+
+
+def classification_summary(
+    classifications,
+    pirs_percentile=50,
+    tau_threshold=0.5,
+    emp_p_threshold=0.05,
+    slope_pval_threshold=0.05,
+    outpath=None,
+):
+    """Multi-panel summary figure for a classification result DataFrame.
+
+    Panels are selected adaptively based on which optional columns are present:
+
+    * **Always shown** (3 panels): label distribution, PIRS vs TauMean,
+      PIRS score distribution.
+    * **Requires ``emp_p``** (2 panels): volcano, TauMean vs GammaBH.
+    * **Requires ``phase_mean``** (1 panel): phase wheel.
+    * **Requires ``period_mean``** (1 panel): period distribution.
+    * **Requires ``pval``** (1 panel): PIRS score vs temporal structure
+      significance.
+    * **Requires ``slope_pval`` and ``emp_p``** (1 panel): slope significance
+      vs rhythm significance.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``.
+    pirs_percentile : float
+        Passed to relevant individual plot functions (default 50).
+    tau_threshold : float
+        Passed to ``pirs_vs_tau`` and ``tau_pval_scatter`` (default 0.5).
+    emp_p_threshold : float
+        Passed to ``volcano`` and ``tau_pval_scatter`` (default 0.05).
+    slope_pval_threshold : float
+        Passed to ``slope_vs_rhythm`` and ``slope_pval_scatter`` (default 0.05).
+    outpath : str or None
+        If provided, save the figure to this path.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    has_emp_p     = _has(classifications, 'emp_p')
+    has_phase     = _has(classifications, 'phase_mean')
+    has_period    = _has(classifications, 'period_mean')
+    has_pval      = _has(classifications, 'pval') or _has(classifications, 'pval_bh')
+    has_slope_emp = (_has(classifications, 'slope_pval') or _has(classifications, 'slope_pval_bh')) and has_emp_p
+
+    # Build ordered list of (title, callable) for each panel
+    panels = [
+        ('label_distribution', lambda ax: label_distribution(classifications, ax=ax)),
+        ('pirs_vs_tau', lambda ax: pirs_vs_tau(
+            classifications, pirs_percentile=pirs_percentile,
+            tau_threshold=tau_threshold, ax=ax)),
+        ('pirs_score_distribution', lambda ax: pirs_score_distribution(
+            classifications, pirs_percentile=pirs_percentile, ax=ax)),
+    ]
+    if has_emp_p:
+        panels += [
+            ('volcano', lambda ax: volcano(
+                classifications, emp_p_threshold=emp_p_threshold,
+                pirs_percentile=pirs_percentile, ax=ax)),
+            ('tau_pval_scatter', lambda ax: tau_pval_scatter(
+                classifications, tau_threshold=tau_threshold,
+                emp_p_threshold=emp_p_threshold, ax=ax)),
+        ]
+    if has_pval:
+        panels.append(('pirs_pval_scatter', lambda ax: pirs_pval_scatter(
+            classifications, ax=ax)))
+    if has_slope_emp:
+        panels.append(('slope_vs_rhythm', lambda ax: slope_vs_rhythm(
+            classifications, slope_pval_threshold=slope_pval_threshold,
+            emp_p_threshold=emp_p_threshold, ax=ax)))
+    if has_phase:
+        panels.append(('phase_wheel', None))  # handled separately — polar axes
+    if has_period:
+        panels.append(('period_distribution', lambda ax: period_distribution(
+            classifications, ax=ax)))
+
+    n = len(panels)
+    ncols = min(3, n)
+    nrows = (n + ncols - 1) // ncols
+
+    fig = plt.figure(figsize=(5 * ncols, 4 * nrows))
+
+    for i, (name, fn) in enumerate(panels, 1):
+        if name == 'phase_wheel':
+            ax = fig.add_subplot(nrows, ncols, i, projection='polar')
+            phase_wheel(classifications, ax=ax)
+        else:
+            ax = fig.add_subplot(nrows, ncols, i)
+            fn(ax)
+
+    fig.tight_layout()
+    if outpath:
+        fig.savefig(outpath, dpi=150, bbox_inches='tight')
+    return fig

--- a/tests/visualization/test_benchmarks.py
+++ b/tests/visualization/test_benchmarks.py
@@ -1,0 +1,196 @@
+"""Tests for circ.visualization.benchmarks."""
+import numpy as np
+import pandas as pd
+import pytest
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.axes
+
+from circ.visualization.benchmarks import (
+    pr_curve,
+    roc_curve_plot,
+    roc_auc,
+    classification_pr,
+    classification_roc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+@pytest.fixture
+def curves_df():
+    """Synthetic PR curves DataFrame."""
+    rng = np.random.default_rng(0)
+    rows = []
+    for method in ['PIRS', 'RSD']:
+        for rep in range(3):
+            n = 20
+            recall = np.linspace(0, 1, n)
+            precision = np.clip(rng.uniform(0.3, 1.0, n) - recall * 0.3, 0, 1)
+            for r, p in zip(recall, precision):
+                rows.append({'recall': r, 'precision': p, 'method': method, 'rep': rep})
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def merged_dict():
+    """Synthetic merged dict for ROC curves."""
+    rng = np.random.default_rng(1)
+    n = 100
+    truth = rng.integers(0, 2, n)
+    return {
+        'method_a': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
+        'method_b': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
+    }
+
+
+@pytest.fixture
+def classification_df():
+    """Synthetic classification output."""
+    rng = np.random.default_rng(2)
+    n = 80
+    labels = ['constitutive'] * 20 + ['rhythmic'] * 20 + ['variable'] * 20 + ['noisy_rhythmic'] * 20
+    return pd.DataFrame({
+        'pirs_score': np.abs(rng.normal(0, 1, n)),
+        'tau_mean':   rng.uniform(0, 1, n),
+        'emp_p':      rng.uniform(0, 1, n),
+        'pval':       rng.uniform(0, 1, n),
+        'slope_pval': rng.uniform(0, 1, n),
+        'label':      labels,
+    }, index=[f'g{i}' for i in range(n)])
+
+
+@pytest.fixture
+def true_classes(classification_df):
+    """Simulated ground-truth binary labels aligned with classification_df."""
+    rng = np.random.default_rng(3)
+    n = len(classification_df)
+    return pd.DataFrame({
+        'Const':     rng.integers(0, 2, n),
+        'Circadian': rng.integers(0, 2, n),
+        'Linear':    rng.integers(0, 2, n),
+    }, index=classification_df.index)
+
+
+# ---------------------------------------------------------------------------
+# pr_curve
+# ---------------------------------------------------------------------------
+
+class TestPrCurve:
+    def test_returns_axes(self, curves_df):
+        ax = pr_curve(curves_df)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_accepts_explicit_ax(self, curves_df):
+        _, ax = plt.subplots()
+        returned = pr_curve(curves_df, ax=ax)
+        assert returned is ax
+
+    def test_baseline_drawn(self, curves_df):
+        ax = pr_curve(curves_df, baseline=0.4)
+        _, labels = ax.get_legend_handles_labels()
+        assert 'random classifier' in labels
+
+    def test_saves_to_file(self, curves_df, tmp_path):
+        import os
+        out = str(tmp_path / 'pr.png')
+        pr_curve(curves_df, outpath=out)
+        assert os.path.exists(out)
+
+
+# ---------------------------------------------------------------------------
+# roc_curve_plot
+# ---------------------------------------------------------------------------
+
+class TestRocCurvePlot:
+    def test_returns_axes(self, merged_dict):
+        ax = roc_curve_plot(merged_dict)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_one_line_per_method(self, merged_dict):
+        ax = roc_curve_plot(merged_dict)
+        n_methods = len(merged_dict)
+        # each method + diagonal = n_methods + 1 lines
+        assert len(ax.lines) == n_methods + 1
+
+    def test_accepts_truth_score_columns(self):
+        rng = np.random.default_rng(4)
+        n = 50
+        d = {'m1': pd.DataFrame({'truth': rng.integers(0, 2, n), 'score': rng.uniform(0, 1, n)})}
+        ax = roc_curve_plot(d)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+
+# ---------------------------------------------------------------------------
+# roc_auc
+# ---------------------------------------------------------------------------
+
+class TestRocAuc:
+    def test_returns_dict(self, merged_dict):
+        result = roc_auc(merged_dict)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == set(merged_dict.keys())
+
+    def test_auc_in_unit_interval(self, merged_dict):
+        result = roc_auc(merged_dict)
+        for v in result.values():
+            assert 0.0 <= v <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# classification_pr
+# ---------------------------------------------------------------------------
+
+class TestClassificationPr:
+    def test_returns_axes(self, classification_df, true_classes):
+        ax = classification_pr(classification_df, true_classes)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_no_crash_on_unmatched_index(self, classification_df, true_classes):
+        subset = true_classes.iloc[:10].copy()
+        ax = classification_pr(classification_df, subset)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_circadian_truth_col(self, classification_df, true_classes):
+        ax = classification_pr(
+            classification_df, true_classes,
+            ground_truth_col='Circadian', score_col='tau_mean', invert_score=False,
+        )
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_empty_intersection_no_crash(self, classification_df, true_classes):
+        tc = true_classes.copy()
+        tc.index = [f'other_{i}' for i in range(len(tc))]
+        ax = classification_pr(classification_df, tc)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+
+# ---------------------------------------------------------------------------
+# classification_roc
+# ---------------------------------------------------------------------------
+
+class TestClassificationRoc:
+    def test_returns_axes(self, classification_df, true_classes):
+        ax = classification_roc(classification_df, true_classes)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_auto_task_detection(self, classification_df, true_classes):
+        ax = classification_roc(classification_df, true_classes)
+        # pirs_score→Const, tau_mean→Circadian, emp_p→Circadian,
+        # pval→Const, slope_pval→Linear, + diagonal = at least 6 lines
+        assert len(ax.lines) >= 3
+
+    def test_explicit_tasks(self, classification_df, true_classes):
+        tasks = [('pirs_score', 'Const', True)]
+        ax = classification_roc(classification_df, true_classes, tasks=tasks)
+        # 1 method line + diagonal
+        assert len(ax.lines) == 2

--- a/tests/visualization/test_classify_plots.py
+++ b/tests/visualization/test_classify_plots.py
@@ -1,0 +1,302 @@
+"""Tests for circ.visualization.classify — expression classification plots."""
+import numpy as np
+import pandas as pd
+import pytest
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.axes
+
+from circ.visualization.classify import (
+    LABEL_COLORS,
+    label_distribution,
+    pirs_vs_tau,
+    volcano,
+    pirs_score_distribution,
+    tau_pval_scatter,
+    pirs_pval_scatter,
+    slope_pval_scatter,
+    slope_vs_rhythm,
+    phase_wheel,
+    period_distribution,
+    classification_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def minimal_clf():
+    """Minimal classification DataFrame: only the columns always present."""
+    rng = np.random.default_rng(0)
+    n = 60
+    labels = (
+        ['constitutive'] * 15 + ['rhythmic'] * 15 +
+        ['variable'] * 15 + ['noisy_rhythmic'] * 15
+    )
+    return pd.DataFrame({
+        'pirs_score': np.abs(rng.normal(0, 1, n)),
+        'tau_mean':   rng.uniform(0, 1, n),
+        'label':      labels,
+    }, index=[f'g{i}' for i in range(n)])
+
+
+@pytest.fixture
+def full_clf(minimal_clf):
+    """Classification DataFrame with all optional columns present."""
+    rng = np.random.default_rng(1)
+    n = len(minimal_clf)
+    df = minimal_clf.copy()
+    df['emp_p']           = rng.uniform(0, 1, n)
+    df['pval']            = rng.uniform(0, 1, n)
+    df['pval_bh']         = rng.uniform(0, 1, n)
+    df['slope_pval']      = rng.uniform(0, 1, n)
+    df['slope_pval_bh']   = rng.uniform(0, 1, n)
+    df['phase_mean']      = rng.uniform(0, 24, n)
+    df['period_mean']     = rng.normal(24, 1, n)
+    return df
+
+
+@pytest.fixture
+def with_linear(full_clf):
+    """Adds linear genes so all five labels are present."""
+    extra = full_clf.iloc[:10].copy()
+    extra.index = [f'lin{i}' for i in range(10)]
+    extra['label'] = 'linear'
+    return pd.concat([full_clf, extra])
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+# ---------------------------------------------------------------------------
+# LABEL_COLORS
+# ---------------------------------------------------------------------------
+
+def test_label_colors_has_all_labels():
+    for lbl in ('constitutive', 'rhythmic', 'linear', 'variable',
+                'noisy_rhythmic', 'unclassified'):
+        assert lbl in LABEL_COLORS
+        assert LABEL_COLORS[lbl].startswith('#')
+
+
+# ---------------------------------------------------------------------------
+# label_distribution
+# ---------------------------------------------------------------------------
+
+class TestLabelDistribution:
+    def test_returns_axes(self, minimal_clf):
+        ax = label_distribution(minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_bar_count_matches_labels(self, minimal_clf):
+        ax = label_distribution(minimal_clf)
+        assert len(ax.patches) == minimal_clf['label'].nunique()
+
+    def test_accepts_explicit_ax(self, minimal_clf):
+        _, ax = plt.subplots()
+        returned = label_distribution(minimal_clf, ax=ax)
+        assert returned is ax
+
+    def test_all_five_labels_shown(self, with_linear):
+        ax = label_distribution(with_linear)
+        assert len(ax.patches) == 5
+
+
+# ---------------------------------------------------------------------------
+# pirs_vs_tau
+# ---------------------------------------------------------------------------
+
+class TestPirsVsTau:
+    def test_returns_axes(self, minimal_clf):
+        ax = pirs_vs_tau(minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_decision_lines_drawn(self, minimal_clf):
+        ax = pirs_vs_tau(minimal_clf)
+        lines = [l for l in ax.lines if l.get_xdata() is not None]
+        assert len(lines) >= 2
+
+    def test_accepts_explicit_ax(self, minimal_clf):
+        _, ax = plt.subplots()
+        returned = pirs_vs_tau(minimal_clf, ax=ax)
+        assert returned is ax
+
+
+# ---------------------------------------------------------------------------
+# volcano
+# ---------------------------------------------------------------------------
+
+class TestVolcano:
+    def test_returns_axes(self, full_clf):
+        ax = volcano(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_emp_p(self, minimal_clf):
+        with pytest.raises(ValueError, match='emp_p'):
+            volcano(minimal_clf)
+
+    def test_accepts_explicit_ax(self, full_clf):
+        _, ax = plt.subplots()
+        returned = volcano(full_clf, ax=ax)
+        assert returned is ax
+
+
+# ---------------------------------------------------------------------------
+# pirs_score_distribution
+# ---------------------------------------------------------------------------
+
+class TestPirsScoreDistribution:
+    def test_returns_axes(self, minimal_clf):
+        ax = pirs_score_distribution(minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_vertical_line_present(self, minimal_clf):
+        ax = pirs_score_distribution(minimal_clf)
+        vlines = [l for l in ax.lines]
+        assert len(vlines) >= 1
+
+
+# ---------------------------------------------------------------------------
+# tau_pval_scatter
+# ---------------------------------------------------------------------------
+
+class TestTauPvalScatter:
+    def test_returns_axes(self, full_clf):
+        ax = tau_pval_scatter(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_emp_p(self, minimal_clf):
+        with pytest.raises(ValueError, match='emp_p'):
+            tau_pval_scatter(minimal_clf)
+
+
+# ---------------------------------------------------------------------------
+# pirs_pval_scatter
+# ---------------------------------------------------------------------------
+
+class TestPirsPvalScatter:
+    def test_returns_axes(self, full_clf):
+        ax = pirs_pval_scatter(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_pval(self, minimal_clf):
+        with pytest.raises(ValueError, match='pval'):
+            pirs_pval_scatter(minimal_clf)
+
+    def test_prefers_bh_corrected(self, full_clf):
+        ax = pirs_pval_scatter(full_clf)
+        assert 'pval_bh' in ax.get_ylabel()
+
+
+# ---------------------------------------------------------------------------
+# slope_pval_scatter
+# ---------------------------------------------------------------------------
+
+class TestSlopePvalScatter:
+    def test_returns_axes(self, full_clf):
+        ax = slope_pval_scatter(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_slope_pval(self, minimal_clf):
+        with pytest.raises(ValueError, match='slope_pval'):
+            slope_pval_scatter(minimal_clf)
+
+
+# ---------------------------------------------------------------------------
+# slope_vs_rhythm
+# ---------------------------------------------------------------------------
+
+class TestSlopeVsRhythm:
+    def test_returns_axes(self, full_clf):
+        ax = slope_vs_rhythm(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_slope_pval(self, full_clf):
+        df = full_clf.drop(columns=['slope_pval', 'slope_pval_bh'])
+        with pytest.raises(ValueError, match='slope_pval'):
+            slope_vs_rhythm(df)
+
+    def test_raises_without_emp_p(self, full_clf):
+        df = full_clf.drop(columns=['emp_p'])
+        with pytest.raises(ValueError, match='emp_p'):
+            slope_vs_rhythm(df)
+
+
+# ---------------------------------------------------------------------------
+# phase_wheel
+# ---------------------------------------------------------------------------
+
+class TestPhaseWheel:
+    def test_returns_polar_axes(self, full_clf):
+        ax = phase_wheel(full_clf)
+        assert ax.name == 'polar'
+
+    def test_raises_without_phase_mean(self, minimal_clf):
+        with pytest.raises(ValueError, match='phase_mean'):
+            phase_wheel(minimal_clf)
+
+    def test_accepts_explicit_polar_ax(self, full_clf):
+        _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+        returned = phase_wheel(full_clf, ax=ax)
+        assert returned is ax
+
+
+# ---------------------------------------------------------------------------
+# period_distribution
+# ---------------------------------------------------------------------------
+
+class TestPeriodDistribution:
+    def test_returns_axes(self, full_clf):
+        ax = period_distribution(full_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_raises_without_period_mean(self, minimal_clf):
+        with pytest.raises(ValueError, match='period_mean'):
+            period_distribution(minimal_clf)
+
+    def test_reference_line_present(self, full_clf):
+        ax = period_distribution(full_clf)
+        vlines = [l for l in ax.lines]
+        assert len(vlines) >= 1
+
+
+# ---------------------------------------------------------------------------
+# classification_summary
+# ---------------------------------------------------------------------------
+
+class TestClassificationSummary:
+    def test_returns_figure_minimal(self, minimal_clf):
+        fig = classification_summary(minimal_clf)
+        assert isinstance(fig, plt.Figure)
+        # minimal: always 3 panels
+        assert len(fig.axes) == 3
+
+    def test_returns_figure_full(self, full_clf):
+        fig = classification_summary(full_clf)
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) > 3
+
+    def test_saves_to_file(self, full_clf, tmp_path):
+        out = str(tmp_path / 'summary.png')
+        classification_summary(full_clf, outpath=out)
+        import os
+        assert os.path.exists(out)
+
+    def test_minimal_has_correct_panel_count(self, minimal_clf):
+        fig = classification_summary(minimal_clf)
+        # label_distribution + pirs_vs_tau + pirs_score_distribution = 3
+        assert len(fig.axes) == 3
+
+    def test_with_emp_p_adds_two_panels(self, minimal_clf):
+        df = minimal_clf.copy()
+        rng = np.random.default_rng(2)
+        df['emp_p'] = rng.uniform(0, 1, len(df))
+        fig = classification_summary(df)
+        # 3 base + 2 (volcano + tau_pval_scatter) = 5
+        assert len(fig.axes) == 5


### PR DESCRIPTION
## Summary

- New `circ/visualization/` package with two submodules extracted from the simulation analysis classes and extended with classification-specific plots
- Refactors `pirs.simulations.analyze` and `limbr.simulations.analyze` to delegate all matplotlib/seaborn calls to the new module (public APIs unchanged)
- Adds `slope_vs_rhythm` plot that directly contrasts the PIRS slope p-value against BooteJTK empirical p-value — the first visualization combining both new statistics from PR #5 with the existing rhythmicity scores

## `circ.visualization.classify` — 11 plot functions

| Function | Axes | Optional columns required |
|---|---|---|
| `label_distribution` | bar | — |
| `pirs_vs_tau` | scatter + decision lines | — |
| `pirs_score_distribution` | KDE overlay | — |
| `volcano` | scatter | `emp_p` |
| `tau_pval_scatter` | scatter + decision lines | `emp_p` |
| `pirs_pval_scatter` | scatter | `pval` / `pval_bh` |
| `slope_pval_scatter` | scatter | `slope_pval` / `slope_pval_bh` |
| `slope_vs_rhythm` | scatter | `slope_pval` **and** `emp_p` |
| `phase_wheel` | polar histogram | `phase_mean` |
| `period_distribution` | histogram | `period_mean` |
| `classification_summary` | adaptive multi-panel | auto-detects |

`classification_summary` assembles whatever panels the DataFrame supports and lays them in a 3-column grid — 3 panels minimum, up to 9 with all optional columns.

## `circ.visualization.benchmarks` — 5 plot/analysis functions

| Function | Description |
|---|---|
| `pr_curve` | Plot pre-computed PR curves (extracted from `pirs.simulations`) |
| `roc_curve_plot` | Plot ROC curves (extracted from `limbr.simulations`) |
| `roc_auc` | Compute AUC per method (extracted from `limbr.simulations`) |
| `classification_pr` | PR curve: Classifier output vs simulation ground truth |
| `classification_roc` | ROC curves: multiple score/truth pairings on one axes |

## Quick start

```python
from circ.expression_classification.classify import Classifier
import circ.visualization as viz

clf = Classifier("normalized.parquet", reps=2)
result = clf.run_all(slope_pvals=True, n_permutations=1000, n_jobs=4)

# Single-call summary figure
fig = viz.classification_summary(result, outpath="summary.png")

# Individual plots
ax = viz.pirs_vs_tau(result)
ax = viz.slope_vs_rhythm(result)   # new stats vs old stats
ax = viz.phase_wheel(result)
```

## Test plan

- [x] `poetry run pytest tests/visualization/` — 50 new tests, all passing
- [x] `poetry run pytest tests/` — 564 total tests, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)