### PR TITLE
Add end-to-end docs example, pipeline test, and fix threading warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ integrating four complementary tools:
 | `circ.pirs` | Prediction Interval Ranking Score for constitutive expression |
 | `circ.bootjtk` | Bootstrap empirical JTK circadian rhythm detection |
 | `circ.expression_classification` | Unified classifier combining PIRS and BooteJTK |
+| `circ.visualization` | Classification and benchmark plots |
 
 A single `circ` CLI entry point wraps all three core tools, and all modules share
 the same `ZT{HH}_{rep}` column format so outputs chain directly between steps.
@@ -76,39 +77,76 @@ r = ranker(df, anova=False)       # DataFrame passed directly
 ranked = r.pirs_sort()
 ```
 
-## Full pipeline
+## End-to-end example
 
-A typical proteomics circadian experiment using Parquet throughout:
+A complete walkthrough from simulation through visualization, using a
+proteomics-style dataset with batch effects and missing values:
 
 ```python
 from circ.limbr import simulations, imputation, batch_fx
 from circ.expression_classification.classify import Classifier
+import circ.visualization as viz
+import matplotlib.pyplot as plt
 
 # 1. Simulate (or start from real data)
-sim = simulations.simulate(tpoints=12, nrows=500, nreps=2, rseed=42)
+#    n_batch_effects and p_miss add realistic noise for benchmarking.
+sim = simulations.simulate(
+    tpoints=12, nrows=500, nreps=2,
+    pcirc=0.3, plin=0.2,
+    n_batch_effects=2, p_miss=0.3,
+    rseed=42,
+)
 sim.generate_pool_map(out_name="pool_map")
-sim.write_output(out_name="sim")
+# write_proteomics creates sim_with_noise.txt (batch effects + missing as NULL),
+# sim_baseline.txt (clean), and sim_true_classes.txt.
+sim.write_proteomics(out_name="sim")
 
 # 2. Impute missing values — write Parquet for fast downstream reading
 imp = imputation.imputable("sim_with_noise.txt", missingness=0.3, neighbors=10)
 imp.impute_data("imputed.parquet")
 
 # 3. Remove batch effects — reads Parquet, writes Parquet
-#    Diagnostic sidecars (imputed_trends.parquet, _perms.parquet, etc.) are
-#    written alongside the main output with a matching extension.
+#    Diagnostic sidecars (_trends, _perms, _tks, _pep_bias) are written
+#    alongside the main output with a matching extension.
 sva_obj = batch_fx.sva("imputed.parquet", design="c", data_type="p",
                         pool="pool_map.parquet")
 sva_obj.preprocess_default()
 sva_obj.perm_test(nperm=200)
 sva_obj.output_default("normalized.parquet")
 
-# 4. Classify expression patterns — accepts the Parquet path directly
+# 4. Classify expression patterns
 clf = Classifier("normalized.parquet", reps=2)
 result = clf.run_all(slope_pvals=True, n_permutations=1000, n_jobs=4)
 # result.label: constitutive | rhythmic | linear | variable | noisy_rhythmic
 
-# Constitutive genes make good normalization references
+print(result["label"].value_counts())
 constitutive = result[result["label"] == "constitutive"].index
+
+# 5. Visualize results
+#    classification_summary produces an adaptive multi-panel figure.
+fig = viz.classification_summary(result, outpath="summary.png")
+
+#    Individual plots can be composed into custom figures:
+fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+viz.label_distribution(result, ax=axes[0])
+viz.pirs_vs_tau(result, ax=axes[1])
+viz.phase_wheel(result, ax=axes[2])
+plt.tight_layout()
+plt.savefig("classification_panels.png", dpi=150, bbox_inches="tight")
+plt.show()
+
+# 6. Benchmark against simulation ground truth
+#    (Only possible when true labels are known, e.g. from a simulation.)
+import pandas as pd
+true_classes = pd.read_csv("sim_true_classes.txt", sep="\t", index_col=0)
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+viz.classification_pr(result, true_classes, ground_truth_col="Const",
+                      ax=axes[0], title="Constitutive PR")
+viz.classification_roc(result, true_classes, ax=axes[1], title="Rhythmic ROC")
+plt.tight_layout()
+plt.savefig("benchmark.png", dpi=150, bbox_inches="tight")
+plt.show()
 ```
 
 Modules can also be composed **in-memory** by passing DataFrames directly —
@@ -404,6 +442,66 @@ When `slope_pvals=False` (default), `run_pirs` computes only the raw PIRS
 score and `classify` falls back to the four-label scheme.  This keeps the
 default path fast for exploratory use.
 
+### `circ.visualization`
+
+Classification plots and benchmark evaluation plots for `Classifier` output.
+All plot functions accept an optional `ax` keyword for composing multi-panel
+figures, and return the `Axes` object.
+
+```python
+import circ.visualization as viz
+import matplotlib.pyplot as plt
+
+# --- Classification plots ---
+# Bar chart of gene counts per label
+viz.label_distribution(result, ax=ax)
+
+# Scatter of PIRS score vs TauMean with decision boundaries
+viz.pirs_vs_tau(result, pirs_percentile=50, tau_threshold=0.5, ax=ax)
+
+# Volcano: PIRS score vs −log₁₀(empirical p-value)
+viz.volcano(result, emp_p_threshold=0.05, ax=ax)
+
+# KDE of PIRS scores split by label
+viz.pirs_score_distribution(result, ax=ax)
+
+# Scatter of TauMean vs −log₁₀(GammaBH)
+viz.tau_pval_scatter(result, ax=ax)
+
+# Polar histogram of estimated phase angles (rhythmic genes only)
+viz.phase_wheel(result, labels=("rhythmic", "noisy_rhythmic"), ax=ax)
+
+# Histogram of estimated periods
+viz.period_distribution(result, reference_period=24.0, ax=ax)
+
+# Adaptive multi-panel summary figure
+fig = viz.classification_summary(result, outpath="summary.png")
+
+# --- Benchmark plots (require simulation ground-truth labels) ---
+import pandas as pd
+true_classes = pd.read_csv("sim_true_classes.txt", sep="\t", index_col=0)
+# Columns: Circadian, Linear, Const (binary 0/1)
+
+# PR curve: how well PIRS score recovers constitutive genes
+viz.classification_pr(result, true_classes, ground_truth_col="Const",
+                      score_col="pirs_score", ax=ax)
+
+# ROC curves: auto-detects available score × truth pairings
+viz.classification_roc(result, true_classes, ax=ax)
+# or specify tasks explicitly: (score_col, truth_col, invert_score)
+viz.classification_roc(result, true_classes,
+                       tasks=[("tau_mean", "Circadian", False),
+                               ("slope_pval", "Linear", True)], ax=ax)
+```
+
+`LABEL_COLORS` maps each label to a consistent hex color for custom plots:
+
+```python
+from circ.visualization import LABEL_COLORS
+# {'constitutive': '#4878CF', 'rhythmic': '#6ACC65', 'linear': '#D65F5F',
+#  'variable': '#B47CC7', 'noisy_rhythmic': '#C4AD66', 'unclassified': '#8C8C8C'}
+```
+
 ### `circ.pirs.rank.rsd_ranker`
 
 ```python
@@ -418,21 +516,34 @@ ranked = r.rsd_sort(outname="rsd_scores.parquet")
 Alternative ranker using Relative Standard Deviation — faster but less
 discriminating than PIRS for large datasets.
 
-### `circ.limbr.simulations.simulate` and `circ.pirs.simulations.simulate`
+### `circ.simulations.simulate`
 
-Both modules expose a `simulate()` factory for generating synthetic datasets
-suitable for method benchmarking:
+Generates a three-class synthetic time-series (circadian / linear / constitutive)
+with optional batch effects and missing data:
 
 ```python
-from circ.limbr.simulations import simulate   # proteomics simulation (with missing data)
-from circ.pirs.simulations import simulate    # expression simulation (const vs rhythmic)
+from circ.simulations import simulate
+# circ.limbr.simulations and circ.pirs.simulations both re-export the same class.
 
-sim = simulate(tpoints=12, nrows=500, nreps=2, pcirc=0.3, rseed=42)
-sim.write_output(out_name="sim")
+# Minimal expression-style simulation (no noise, no missing data)
+sim = simulate(tpoints=12, nrows=500, nreps=2, pcirc=0.3, plin=0.2, rseed=42)
+sim.write_output(out_name="sim")          # sim.txt + sim_true_classes.txt
+
+# Proteomics-style simulation (batch effects + missing data)
+sim = simulate(
+    tpoints=12, nrows=500, nreps=2,
+    pcirc=0.3, plin=0.2,
+    n_batch_effects=2, pbatch=0.5, effect_size=2.0,
+    p_miss=0.3, lam_miss=5,
+    rseed=42,
+)
+sim.generate_pool_map(out_name="pool_map")   # pool_map.parquet
+sim.write_proteomics(out_name="sim")         # sim_with_noise.txt + sim_baseline.txt
+                                             # + sim_true_classes.txt
 ```
 
-The LIMBR simulation additionally supports `generate_pool_map()` for
-proteomics pool control files.
+Key attributes after construction: `sim.classes` (per-row string labels),
+`sim.sim` (clean scaled matrix), `sim.sim_miss` (with batch effects and NaN).
 
 ## License and attribution
 

--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -2,7 +2,8 @@ import itertools
 
 import numpy as np
 import pandas as pd
-from multiprocess import Pool
+import multiprocess as _mp
+_forkserver_pool = _mp.get_context('forkserver').Pool
 from sklearn import preprocessing
 from sklearn.decomposition import PCA
 from scipy.stats import linregress, f_oneway
@@ -429,7 +430,7 @@ class sva:
             block_design = getattr(self, 'block_design', None)
             chunksize = max(1, int(nperm) // (int(npr) * 4))
             init_args = (self.res, self.tks, self.designtype, tpoints, block_design)
-            with Pool(int(npr), initializer=_init_perm_worker, initargs=init_args) as pool:
+            with _forkserver_pool(int(npr), initializer=_init_perm_worker, initargs=init_args) as pool:
                 output = list(tqdm(
                     pool.imap_unordered(_perm_worker, seeds, chunksize=chunksize),
                     total=int(nperm), desc='permuting', smoothing=0,

--- a/circ/pirs/rank.py
+++ b/circ/pirs/rank.py
@@ -1,4 +1,5 @@
 import multiprocessing
+_mp_ctx = multiprocessing.get_context('forkserver')
 
 import pandas as pd
 import numpy as np
@@ -265,7 +266,7 @@ class ranker:
             pool_size = n_jobs if n_jobs > 0 else None
             actual    = pool_size or multiprocessing.cpu_count()
             chunksize = max(1, len(gene_args) // (actual * 4))
-            with multiprocessing.Pool(pool_size) as pool:
+            with _mp_ctx.Pool(pool_size) as pool:
                 results = list(tqdm(
                     pool.imap(_permutation_worker, gene_args, chunksize=chunksize),
                     total=len(gene_args),
@@ -335,7 +336,7 @@ class ranker:
             pool_size = n_jobs if n_jobs > 0 else None
             actual    = pool_size or multiprocessing.cpu_count()
             chunksize = max(1, len(gene_args) // (actual * 4))
-            with multiprocessing.Pool(pool_size) as pool:
+            with _mp_ctx.Pool(pool_size) as pool:
                 results = list(tqdm(
                     pool.imap(_slope_permutation_worker, gene_args, chunksize=chunksize),
                     total=len(gene_args),

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1,0 +1,344 @@
+"""End-to-end pipeline test: simulation → imputation → SVA → classification → visualization.
+
+Mirrors the README 'End-to-end example' using a small synthetic proteomics
+dataset with batch effects and missing values.  The full pipeline runs once via
+a module-scoped fixture; individual test classes check each stage.
+
+Assertions are structural (column presence, shape, label validity) and
+directional (known-class averages) rather than exact numeric values.
+"""
+import os
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from circ.simulations import simulate
+from circ.limbr.imputation import imputable
+from circ.limbr.batch_fx import sva
+from circ.expression_classification.classify import Classifier
+import circ.visualization as viz
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture: run the full pipeline once
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def pipeline(tmp_path_factory):
+    """Run the complete pipeline and return all intermediate artifacts."""
+    tmp = tmp_path_factory.mktemp("e2e_pipeline")
+
+    # 1. Simulate
+    # tpoints=12 is required: SVA's circ_cor() shifts by 12 and 6 in the
+    # per-timepoint means matrix, so fewer than 12 unique timepoints causes
+    # all correlations to alias to zero and data_reduced becomes empty.
+    sim = simulate(
+        tpoints=12, nrows=100, nreps=2, tpoint_space=2,
+        pcirc=0.3, plin=0.2,
+        n_batch_effects=1, pbatch=0.5, effect_size=2.0,
+        p_miss=0.2, lam_miss=3,
+        rseed=42,
+    )
+    pool_map_stem = str(tmp / "pool_map")
+    sim_stem = str(tmp / "sim")
+    sim.generate_pool_map(out_name=pool_map_stem)
+    sim.write_proteomics(out_name=sim_stem)
+
+    # 2. Impute
+    imputed_path = str(tmp / "imputed.parquet")
+    imp = imputable(sim_stem + "_with_noise.txt", missingness=0.3, neighbors=5)
+    imp.impute_data(imputed_path)
+
+    # 3. SVA batch correction
+    normalized_path = str(tmp / "normalized.parquet")
+    sva_obj = sva(
+        imputed_path,
+        design="c",
+        data_type="p",
+        pool=pool_map_stem + ".parquet",
+    )
+    sva_obj.preprocess_default()
+    sva_obj.perm_test(nperm=99)
+    sva_obj.output_default(normalized_path)
+
+    # 4. Classify
+    clf = Classifier(normalized_path, reps=2, size=10)
+    result = clf.run_all(slope_pvals=True, n_permutations=99)
+
+    true_classes = pd.read_csv(sim_stem + "_true_classes.txt", sep="\t", index_col=0)
+
+    return {
+        "tmp": tmp,
+        "sim": sim,
+        "sim_stem": sim_stem,
+        "pool_map_stem": pool_map_stem,
+        "imputed_path": imputed_path,
+        "normalized_path": normalized_path,
+        "sva_obj": sva_obj,
+        "clf": clf,
+        "result": result,
+        "true_classes": true_classes,
+    }
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Simulation
+# ---------------------------------------------------------------------------
+
+class TestSimulation:
+    def test_classes_array_length(self, pipeline):
+        assert len(pipeline["sim"].classes) == 100
+
+    def test_class_labels_valid(self, pipeline):
+        assert set(pipeline["sim"].classes).issubset({"circadian", "linear", "constitutive"})
+
+    def test_all_three_classes_present(self, pipeline):
+        assert set(pipeline["sim"].classes) == {"circadian", "linear", "constitutive"}
+
+    def test_sim_miss_has_nan(self, pipeline):
+        assert np.isnan(pipeline["sim"].sim_miss).any()
+
+    def test_with_noise_file_exists(self, pipeline):
+        assert os.path.exists(pipeline["sim_stem"] + "_with_noise.txt")
+
+    def test_true_classes_file_exists(self, pipeline):
+        assert os.path.exists(pipeline["sim_stem"] + "_true_classes.txt")
+
+    def test_pool_map_file_exists(self, pipeline):
+        assert os.path.exists(pipeline["pool_map_stem"] + ".parquet")
+
+    def test_true_classes_columns(self, pipeline):
+        assert {"Circadian", "Linear", "Const"}.issubset(pipeline["true_classes"].columns)
+
+    def test_true_classes_binary(self, pipeline):
+        for col in ("Circadian", "Linear", "Const"):
+            assert set(pipeline["true_classes"][col].unique()).issubset({0, 1})
+
+    def test_class_fractions_roughly_correct(self, pipeline):
+        classes = pipeline["sim"].classes
+        circ_frac = (classes == "circadian").mean()
+        lin_frac = (classes == "linear").mean()
+        assert 0.1 < circ_frac < 0.6
+        assert 0.0 < lin_frac < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Imputation
+# ---------------------------------------------------------------------------
+
+class TestImputation:
+    def test_output_file_exists(self, pipeline):
+        assert os.path.exists(pipeline["imputed_path"])
+
+    def test_no_missing_after_imputation(self, pipeline):
+        df = pd.read_parquet(pipeline["imputed_path"])
+        zt_cols = [c for c in df.columns if str(c).startswith("ZT")]
+        assert not df[zt_cols].isnull().any().any()
+
+    def test_row_count_at_most_input(self, pipeline):
+        df = pd.read_parquet(pipeline["imputed_path"])
+        assert len(df) <= 100
+
+    def test_zt_columns_present(self, pipeline):
+        df = pd.read_parquet(pipeline["imputed_path"])
+        zt_cols = [c for c in df.columns if str(c).startswith("ZT")]
+        assert len(zt_cols) == 24  # 12 tpoints * 2 reps
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Normalization (SVA)
+# ---------------------------------------------------------------------------
+
+class TestNormalization:
+    def test_output_file_exists(self, pipeline):
+        assert os.path.exists(pipeline["normalized_path"])
+
+    def test_svd_norm_attribute_set(self, pipeline):
+        assert pipeline["sva_obj"].svd_norm is not None
+
+    def test_svd_norm_is_dataframe(self, pipeline):
+        assert isinstance(pipeline["sva_obj"].svd_norm, pd.DataFrame)
+
+    def test_normalized_has_no_missing(self, pipeline):
+        assert not pipeline["sva_obj"].svd_norm.isnull().any().any()
+
+    def test_diagnostic_sidecars_exist(self, pipeline):
+        stem = pipeline["normalized_path"].replace(".parquet", "")
+        for suffix in ("_trends", "_perms", "_tks"):
+            path = stem + suffix + ".parquet"
+            assert os.path.exists(path), f"missing sidecar: {path}"
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Classification
+# ---------------------------------------------------------------------------
+
+class TestClassification:
+    def test_result_is_dataframe(self, pipeline):
+        assert isinstance(pipeline["result"], pd.DataFrame)
+
+    def test_result_is_non_empty(self, pipeline):
+        assert len(pipeline["result"]) > 0
+
+    def test_required_columns_present(self, pipeline):
+        for col in ("pirs_score", "tau_mean", "label"):
+            assert col in pipeline["result"].columns, f"missing column: {col}"
+
+    def test_slope_pval_columns_present(self, pipeline):
+        for col in ("slope_pval", "slope_pval_bh"):
+            assert col in pipeline["result"].columns
+
+    def test_all_rows_labelled(self, pipeline):
+        assert pipeline["result"]["label"].notna().all()
+
+    def test_valid_label_set(self, pipeline):
+        valid = {"constitutive", "rhythmic", "linear", "variable", "noisy_rhythmic", "unclassified"}
+        assert set(pipeline["result"]["label"].unique()).issubset(valid)
+
+    def test_pirs_scores_non_negative(self, pipeline):
+        assert (pipeline["result"]["pirs_score"] >= 0).all()
+
+    def test_slope_pvals_in_unit_interval(self, pipeline):
+        for col in ("slope_pval", "slope_pval_bh"):
+            vals = pipeline["result"][col]
+            assert (vals >= 0).all() and (vals <= 1).all()
+
+    def test_classifier_attributes_populated(self, pipeline):
+        clf = pipeline["clf"]
+        assert clf.pirs_scores is not None
+        assert clf.rhythm_results is not None
+        assert clf.classifications is not None
+
+    def test_constitutive_label_has_lower_pirs_than_variable(self, pipeline):
+        """Classifier consistency: 'constitutive' genes must have lower PIRS than 'variable'.
+
+        This is guaranteed by the PIRS percentile cutoff in classify(), so it
+        tests that the classifier logic applied correctly end-to-end.
+        """
+        result = pipeline["result"]
+        const_ids = result[result["label"] == "constitutive"].index
+        variable_ids = result[result["label"] == "variable"].index
+        if len(const_ids) < 3 or len(variable_ids) < 3:
+            pytest.skip("insufficient label representation for comparison")
+        assert (result.loc[const_ids, "pirs_score"].mean() <
+                result.loc[variable_ids, "pirs_score"].mean())
+
+    def test_linear_genes_have_lower_slope_pval_on_average(self, pipeline):
+        """Genes simulated as linear should have lower slope_pval on average."""
+        result = pipeline["result"]
+        true_classes = pipeline["true_classes"]
+        shared = result.index.intersection(true_classes.index)
+        if len(shared) < 10:
+            pytest.skip("too few matched genes for directional test")
+        tc = true_classes.loc[shared]
+        linear_ids = tc[tc["Linear"] == 1].index
+        const_ids = tc[tc["Const"] == 1].index
+        if len(linear_ids) < 3 or len(const_ids) < 3:
+            pytest.skip("insufficient class representation")
+        assert (result.loc[linear_ids, "slope_pval"].mean() <
+                result.loc[const_ids, "slope_pval"].mean())
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Visualization — classification plots
+# ---------------------------------------------------------------------------
+
+class TestClassificationPlots:
+    def test_label_distribution(self, pipeline):
+        assert isinstance(viz.label_distribution(pipeline["result"]), plt.Axes)
+
+    def test_pirs_vs_tau(self, pipeline):
+        assert isinstance(viz.pirs_vs_tau(pipeline["result"]), plt.Axes)
+
+    def test_volcano(self, pipeline):
+        assert isinstance(viz.volcano(pipeline["result"]), plt.Axes)
+
+    def test_pirs_score_distribution(self, pipeline):
+        assert isinstance(viz.pirs_score_distribution(pipeline["result"]), plt.Axes)
+
+    def test_tau_pval_scatter(self, pipeline):
+        assert isinstance(viz.tau_pval_scatter(pipeline["result"]), plt.Axes)
+
+    def test_slope_pval_scatter(self, pipeline):
+        assert isinstance(viz.slope_pval_scatter(pipeline["result"]), plt.Axes)
+
+    def test_slope_vs_rhythm(self, pipeline):
+        assert isinstance(viz.slope_vs_rhythm(pipeline["result"]), plt.Axes)
+
+    def test_phase_wheel(self, pipeline):
+        assert isinstance(viz.phase_wheel(pipeline["result"]), plt.Axes)
+
+    def test_period_distribution(self, pipeline):
+        assert isinstance(viz.period_distribution(pipeline["result"]), plt.Axes)
+
+    def test_classification_summary_returns_figure(self, pipeline):
+        fig = viz.classification_summary(pipeline["result"])
+        assert isinstance(fig, plt.Figure)
+
+    def test_classification_summary_saves_file(self, pipeline):
+        outpath = str(pipeline["tmp"] / "summary.png")
+        viz.classification_summary(pipeline["result"], outpath=outpath)
+        assert os.path.exists(outpath)
+
+    def test_custom_panel_composition(self, pipeline):
+        fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+        viz.label_distribution(pipeline["result"], ax=axes[0])
+        viz.pirs_vs_tau(pipeline["result"], ax=axes[1])
+        viz.phase_wheel(pipeline["result"], ax=axes[2])
+        assert len(fig.axes) == 3
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Visualization — benchmark plots against ground truth
+# ---------------------------------------------------------------------------
+
+class TestBenchmarkPlots:
+    def test_classification_pr_returns_axes(self, pipeline):
+        ax = viz.classification_pr(
+            pipeline["result"],
+            pipeline["true_classes"],
+            ground_truth_col="Const",
+        )
+        assert isinstance(ax, plt.Axes)
+
+    def test_classification_roc_returns_axes(self, pipeline):
+        ax = viz.classification_roc(
+            pipeline["result"],
+            pipeline["true_classes"],
+        )
+        assert isinstance(ax, plt.Axes)
+
+    def test_classification_roc_explicit_tasks(self, pipeline):
+        ax = viz.classification_roc(
+            pipeline["result"],
+            pipeline["true_classes"],
+            tasks=[
+                ("tau_mean", "Circadian", False),
+                ("slope_pval", "Linear", True),
+            ],
+        )
+        assert isinstance(ax, plt.Axes)
+
+    def test_benchmark_figure_saves(self, pipeline):
+        fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+        viz.classification_pr(
+            pipeline["result"], pipeline["true_classes"],
+            ground_truth_col="Const", ax=axes[0],
+        )
+        viz.classification_roc(
+            pipeline["result"], pipeline["true_classes"],
+            ax=axes[1],
+        )
+        outpath = str(pipeline["tmp"] / "benchmark.png")
+        fig.savefig(outpath, dpi=72, bbox_inches="tight")
+        assert os.path.exists(outpath)


### PR DESCRIPTION
## Summary

- Rewrites the README **Full pipeline** section into a complete end-to-end walkthrough (simulation → imputation → SVA → classification → visualization → benchmark), including the new `circ.visualization` module in the table and API reference
- Adds `tests/test_e2e_pipeline.py`: 46 tests across 6 classes that mirror the README example step by step, running the full proteomics pipeline in a single module-scoped fixture (~8 s total)
- Fixes `fork()`-in-multithreaded-process `DeprecationWarning`s from Python 3.13 by switching both parallel pool sites to the `forkserver` start method

## Bug fixes included

- `README.md` full pipeline called `write_output` instead of `write_proteomics`, so `sim_with_noise.txt` was never created
- `README.md` `classification_roc` was called with `ground_truth_col=`/`score_col=` kwargs that don't exist on that function (it takes `tasks=`)
- `circ/limbr/batch_fx.py` and `circ/pirs/rank.py` used `fork` start method, producing 4 `DeprecationWarning`s per run under pytest on Python 3.13

## Test plan

- [x] `poetry run pytest` — 625 passed, 0 warnings
- [x] `poetry run pytest tests/test_e2e_pipeline.py -v` — 46 passed
- [x] README end-to-end code block is copy-pasteable and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)