### PR TITLE
Add circ.evaluation module and circadian ROC/AUC coverage

### DIFF
--- a/circ/evaluation.py
+++ b/circ/evaluation.py
@@ -1,0 +1,140 @@
+"""Evaluation metrics for expression classification benchmarking.
+
+These functions compute performance metrics (ROC AUC, average precision)
+against simulation ground truth.  They are intentionally decoupled from
+matplotlib so they can be used in automated pipelines without a display.
+
+Plotting wrappers that visualise these metrics live in
+``circ.visualization.benchmarks``.
+"""
+import pandas as pd
+from sklearn.metrics import average_precision_score, roc_curve, auc
+
+
+# ---------------------------------------------------------------------------
+# Legacy-format ROC (merged_dict interface used by circ.limbr.simulations)
+# ---------------------------------------------------------------------------
+
+def roc_auc(merged_dict):
+    """Compute area under the ROC curve for each method.
+
+    Parameters
+    ----------
+    merged_dict : dict[str, pd.DataFrame]
+        ``{tag: df}`` where each ``df`` has a binary truth column and a score
+        column.  The truth column must be named ``truth`` or ``Circadian``, and
+        the score column ``score`` or ``GammaBH``.
+
+    Returns
+    -------
+    dict[str, float]
+        ``{tag: auc_value}``.
+    """
+    out = {}
+    for tag, df in merged_dict.items():
+        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
+        score_col = 'score' if 'score' in df.columns else 'GammaBH'
+        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
+        out[tag] = auc(fpr, tpr)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Classifier-output evaluation (Classifier + simulate ground-truth interface)
+# ---------------------------------------------------------------------------
+
+def _default_tasks(classifications, true_classes):
+    """Return the default (score_col, truth_col, invert) task list."""
+    tasks = []
+    if 'pirs_score' in classifications.columns and 'Const' in true_classes.columns:
+        tasks.append(('pirs_score', 'Const', True))
+    if 'tau_mean' in classifications.columns and 'Circadian' in true_classes.columns:
+        tasks.append(('tau_mean', 'Circadian', False))
+    if 'emp_p' in classifications.columns and 'Circadian' in true_classes.columns:
+        tasks.append(('emp_p', 'Circadian', True))
+    if 'pval' in classifications.columns and 'Const' in true_classes.columns:
+        tasks.append(('pval', 'Const', True))
+    if 'slope_pval' in classifications.columns and 'Linear' in true_classes.columns:
+        tasks.append(('slope_pval', 'Linear', True))
+    return tasks
+
+
+def classification_auc(classifications, true_classes, tasks=None):
+    """Compute ROC AUC for multiple binary classification tasks.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``, indexed by gene ID.
+    true_classes : pd.DataFrame
+        Simulation ground-truth table with binary columns such as ``Const``,
+        ``Circadian``, and ``Linear``.
+    tasks : list of (str, str, bool) or None
+        Each entry is ``(score_col, truth_col, invert)``.  ``invert=True``
+        means a lower score indicates the positive class (used for PIRS score
+        and p-values).  Defaults to sensible combinations based on available
+        columns.
+
+    Returns
+    -------
+    dict[(str, str), float]
+        Mapping from ``(score_col, truth_col)`` to AUC value.  Tasks where
+        the merged data is empty or has only one class are omitted.
+    """
+    if tasks is None:
+        tasks = _default_tasks(classifications, true_classes)
+
+    result = {}
+    for score_col, truth_col, invert in tasks:
+        merged = (
+            classifications[[score_col]]
+            .join(true_classes[[truth_col]], how='inner')
+            .dropna()
+        )
+        if merged.empty or merged[truth_col].nunique() < 2:
+            continue
+        scores = -merged[score_col].values if invert else merged[score_col].values
+        fpr, tpr, _ = roc_curve(merged[truth_col].values, scores, pos_label=1)
+        result[(score_col, truth_col)] = auc(fpr, tpr)
+    return result
+
+
+def classification_ap(
+    classifications,
+    true_classes,
+    ground_truth_col='Const',
+    score_col='pirs_score',
+    invert_score=True,
+):
+    """Compute average precision (PR AUC) for a single classification task.
+
+    Parameters
+    ----------
+    classifications : pd.DataFrame
+        Output of ``Classifier.classify()``, indexed by gene ID.
+    true_classes : pd.DataFrame
+        Simulation ground-truth table with binary columns.
+    ground_truth_col : str
+        Column in *true_classes* to treat as positive (default ``'Const'``).
+    score_col : str
+        Score column from *classifications* to rank by (default
+        ``'pirs_score'``).
+    invert_score : bool
+        If ``True`` (default), invert the score before computing the curve.
+
+    Returns
+    -------
+    float or None
+        Average precision, or ``None`` if the merged data is empty or
+        contains only one class.
+    """
+    merged = (
+        classifications[[score_col]]
+        .join(true_classes[[ground_truth_col]], how='inner')
+        .dropna()
+    )
+    if merged.empty or merged[ground_truth_col].nunique() < 2:
+        return None
+    scores = -merged[score_col].values if invert_score else merged[score_col].values
+    ap = average_precision_score(merged[ground_truth_col].values, scores)
+    return float(ap)

--- a/circ/limbr/simulations.py
+++ b/circ/limbr/simulations.py
@@ -119,6 +119,6 @@ class analyze:
 
     def calculate_auc(self):
         """Compute AUC for each dataset and store in ``self.roc_auc``."""
-        from circ.visualization.benchmarks import roc_auc
+        from circ.evaluation import roc_auc
         self.roc_auc = roc_auc(self._merged_dict())
         return self.roc_auc

--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -108,8 +108,8 @@ class simulate:
             p=[pcirc, plin, pconst],
         )
 
-        # Base waveform spanning two full periods
-        base = np.arange(0, 4 * np.pi, 4 * np.pi / self.tpoints)
+        # One 24-hour cycle across tpoints timepoints
+        base = np.arange(0, 2 * np.pi, 2 * np.pi / self.tpoints)
         ramp = np.linspace(0, 2, self.tpoints)
 
         # Build clean simulation matrix
@@ -130,7 +130,7 @@ class simulate:
                 ]
                 raw[idx] = [v for t in zip(*reps) for v in t]
             else:  # constitutive
-                raw[idx] = np.random.normal(0, amp_noise, n_cols)
+                raw[idx] = np.random.normal(1, amp_noise, n_cols)
 
         self._raw = raw
         # Row-scale to unit standard deviation for expression analysis

--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -41,10 +41,10 @@ from circ.visualization.classify import (
     period_distribution,
     classification_summary,
 )
+from circ.evaluation import roc_auc
 from circ.visualization.benchmarks import (
     pr_curve,
     roc_curve_plot,
-    roc_auc,
     classification_pr,
     classification_roc,
 )

--- a/circ/visualization/benchmarks.py
+++ b/circ/visualization/benchmarks.py
@@ -1,14 +1,16 @@
-"""Benchmark visualizations: PR curves, ROC curves, and AUC comparison.
+"""Benchmark visualizations: PR curves and ROC curves.
 
 The standalone functions here are used by the ``analyze`` classes in
 ``circ.pirs.simulations`` and ``circ.limbr.simulations``, and can also be
 called directly with pre-computed data.
+
+Metric-only functions (no matplotlib) live in ``circ.evaluation``.
 """
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
-from sklearn.metrics import precision_recall_curve, roc_curve, auc
+from sklearn.metrics import average_precision_score, precision_recall_curve, roc_curve, auc
 
 
 # ---------------------------------------------------------------------------
@@ -105,28 +107,6 @@ def roc_curve_plot(merged_dict, ax=None, outpath=None):
     return ax
 
 
-def roc_auc(merged_dict):
-    """Compute area under the ROC curve for each method.
-
-    Parameters
-    ----------
-    merged_dict : dict[str, pd.DataFrame]
-        Same format as :func:`roc_curve_plot`.
-
-    Returns
-    -------
-    dict[str, float]
-        ``{tag: auc_value}``.
-    """
-    out = {}
-    for tag, df in merged_dict.items():
-        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
-        score_col = 'score' if 'score' in df.columns else 'GammaBH'
-        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
-        out[tag] = auc(fpr, tpr)
-    return out
-
-
 # ---------------------------------------------------------------------------
 # Classification benchmarking (Classifier output + simulation ground truth)
 # ---------------------------------------------------------------------------
@@ -181,7 +161,7 @@ def classification_pr(
         merged[ground_truth_col].values, scores, pos_label=1
     )
     baseline = merged[ground_truth_col].mean()
-    ap = np.trapezoid(precision, recall) if hasattr(np, 'trapezoid') else np.trapz(precision, recall)
+    ap = average_precision_score(merged[ground_truth_col].values, scores)
     ax.plot(recall, precision, color='#4878CF', lw=1.2,
             label=f'{score_col} (AP={ap:.3f})')
     ax.axhline(baseline, color='#CC4444', ls=':', lw=0.9,

--- a/tests/expression_classification/test_metrics_quality.py
+++ b/tests/expression_classification/test_metrics_quality.py
@@ -1,0 +1,350 @@
+"""Metric quality tests: each pipeline score should discriminate its target class.
+
+Unlike the structural tests in test_classify.py, these tests run on a clean
+high-signal simulation (no batch effects, no missing data) and assert that
+continuous scores rank their target class above others.  The intent is to
+isolate metric behaviour from pipeline noise so that a failing test here
+points directly at the underlying algorithm rather than at imputation/SVA.
+
+Assertions use AUC > 0.5 (ranking) and AP > baseline (precision-recall) so
+that they remain valid regardless of classification threshold choices.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import roc_auc_score, average_precision_score
+
+from circ.simulations import simulate
+from circ.expression_classification.classify import Classifier
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def clean_pipeline(tmp_path_factory):
+    """Run Classifier on clean (no batch/missing) simulated data.
+
+    Uses reduced noise (amp_noise=0.4, phase_noise=0.1) and more genes (150)
+    than the CI fixture so that AUC estimates are stable and the metrics have
+    a fair chance to discriminate their target classes without pipeline noise.
+    """
+    tmp = tmp_path_factory.mktemp("quality")
+    out = str(tmp / "clean.txt")
+
+    sim = simulate(
+        tpoints=12, nrows=150, nreps=2, tpoint_space=2,
+        pcirc=0.35, plin=0.25,
+        phase_noise=0.1, amp_noise=0.4,
+        n_batch_effects=0, p_miss=0.0,
+        rseed=11,
+    )
+    sim.write_output(out_name=out)
+
+    true_classes = pd.read_csv(
+        out.replace(".txt", "_true_classes.txt"), sep="\t", index_col=0
+    )
+
+    clf = Classifier(out, reps=2, size=20)
+    result = clf.run_all(slope_pvals=True, n_permutations=99)
+
+    return {"result": result, "true_classes": true_classes}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _auc(result, true_classes, score_col, truth_col, invert=False):
+    """ROC AUC for score_col vs binary truth_col; None if data is insufficient."""
+    shared = result.index.intersection(true_classes.index)
+    df = (
+        result.loc[shared, [score_col]]
+        .join(true_classes.loc[shared, [truth_col]])
+        .dropna()
+    )
+    if len(df) < 10 or df[truth_col].nunique() < 2:
+        return None
+    scores = -df[score_col].values if invert else df[score_col].values
+    return roc_auc_score(df[truth_col].values, scores)
+
+
+def _ap(result, true_classes, score_col, truth_col, invert=False):
+    """Average precision (PR AUC) for score_col vs binary truth_col."""
+    shared = result.index.intersection(true_classes.index)
+    df = (
+        result.loc[shared, [score_col]]
+        .join(true_classes.loc[shared, [truth_col]])
+        .dropna()
+    )
+    if len(df) < 10 or df[truth_col].nunique() < 2:
+        return None
+    scores = -df[score_col].values if invert else df[score_col].values
+    return average_precision_score(df[truth_col].values, scores)
+
+
+def _class_means(result, true_classes, score_col, truth_col):
+    """Return (mean score for truth==1, mean score for truth==0)."""
+    shared = result.index.intersection(true_classes.index)
+    tc = true_classes.loc[shared]
+    pos_ids = tc[tc[truth_col] == 1].index
+    neg_ids = tc[tc[truth_col] == 0].index
+    pos_mean = result.loc[pos_ids, score_col].dropna().mean()
+    neg_mean = result.loc[neg_ids, score_col].dropna().mean()
+    return pos_mean, neg_mean
+
+
+# ---------------------------------------------------------------------------
+# ROC AUC: each metric should rank its target class above others
+# ---------------------------------------------------------------------------
+
+class TestMetricAUC:
+    """Each score must achieve AUC > 0.5 against its target class on clean data.
+
+    An AUC below 0.5 on clean (no batch effects, no missing data) data
+    indicates a fundamental failure of the underlying metric, not pipeline
+    noise.
+
+    PIRS is NOT expected to separate constitutive from circadian — both can be
+    PIRS-stable.  PIRS is designed to separate flat (constitutive) from
+    variable (linear / noisy) expression.  BooteJTK handles circadian vs
+    non-rhythmic discrimination.
+    """
+
+    def test_pirs_score_discriminates_linear_from_constitutive(self, clean_pipeline):
+        """High PIRS (temporal deviation) should rank linear genes above constitutive.
+
+        This is PIRS's core purpose: a linear ramp creates large prediction-interval
+        deviations from mean expression at the time extremes, while flat constitutive
+        noise does not.
+        """
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        shared = result.index.intersection(tc.index)
+        # Restrict to the two classes PIRS is designed to separate
+        lin_const_mask = (tc.loc[shared, "Linear"] + tc.loc[shared, "Const"]) == 1
+        subset = tc.loc[shared][lin_const_mask]
+        merged = result.loc[subset.index, ["pirs_score"]].join(subset[["Linear"]]).dropna()
+        if len(merged) < 10 or merged["Linear"].nunique() < 2:
+            pytest.skip("insufficient data for AUC test")
+        auc = roc_auc_score(merged["Linear"].values, merged["pirs_score"].values)
+        assert auc > 0.5, f"PIRS score → Linear (vs Const) AUC={auc:.3f}; expected > 0.5"
+
+    def test_tau_mean_discriminates_circadian(self, clean_pipeline):
+        """High TauMean (strong 24h autocorrelation) should rank circadian genes first."""
+        auc = _auc(clean_pipeline["result"], clean_pipeline["true_classes"],
+                   "tau_mean", "Circadian", invert=False)
+        if auc is None:
+            pytest.skip("insufficient data for AUC test")
+        assert auc > 0.5, f"tau_mean → Circadian AUC={auc:.3f}; expected > 0.5"
+
+    def test_emp_p_discriminates_circadian(self, clean_pipeline):
+        """Low GammaBH p-value should rank circadian genes first."""
+        auc = _auc(clean_pipeline["result"], clean_pipeline["true_classes"],
+                   "emp_p", "Circadian", invert=True)
+        if auc is None:
+            pytest.skip("insufficient data for AUC test")
+        assert auc > 0.5, f"emp_p → Circadian AUC={auc:.3f}; expected > 0.5"
+
+    def test_slope_pval_discriminates_linear(self, clean_pipeline):
+        """Low slope p-value should rank linear (ramp) genes first."""
+        auc = _auc(clean_pipeline["result"], clean_pipeline["true_classes"],
+                   "slope_pval", "Linear", invert=True)
+        if auc is None:
+            pytest.skip("insufficient data for AUC test")
+        assert auc > 0.5, f"slope_pval → Linear AUC={auc:.3f}; expected > 0.5"
+
+
+# ---------------------------------------------------------------------------
+# Average Precision: PR AUC should exceed random baseline
+# ---------------------------------------------------------------------------
+
+class TestMetricAP:
+    """Average precision must exceed the positive-class prevalence baseline.
+
+    AP == baseline means the score adds no information over random guessing.
+    """
+
+    def test_pirs_ap_for_linear_above_baseline(self, clean_pipeline):
+        """AP for PIRS discriminating linear from constitutive should exceed prevalence."""
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        shared = result.index.intersection(tc.index)
+        lin_const_mask = (tc.loc[shared, "Linear"] + tc.loc[shared, "Const"]) == 1
+        subset = tc.loc[shared][lin_const_mask]
+        merged = result.loc[subset.index, ["pirs_score"]].join(subset[["Linear"]]).dropna()
+        if len(merged) < 10 or merged["Linear"].nunique() < 2:
+            pytest.skip("insufficient data")
+        ap = average_precision_score(merged["Linear"].values, merged["pirs_score"].values)
+        baseline = subset["Linear"].mean()
+        assert ap > baseline, f"PIRS AP={ap:.3f} should exceed prevalence baseline ({baseline:.3f})"
+
+    def test_slope_pval_ap_above_baseline(self, clean_pipeline):
+        ap = _ap(clean_pipeline["result"], clean_pipeline["true_classes"],
+                 "slope_pval", "Linear", invert=True)
+        if ap is None:
+            pytest.skip("insufficient data")
+        baseline = clean_pipeline["true_classes"]["Linear"].mean()
+        assert ap > baseline, f"slope_pval AP={ap:.3f} should exceed prevalence baseline ({baseline:.3f})"
+
+    def test_tau_mean_ap_above_baseline(self, clean_pipeline):
+        ap = _ap(clean_pipeline["result"], clean_pipeline["true_classes"],
+                 "tau_mean", "Circadian", invert=False)
+        if ap is None:
+            pytest.skip("insufficient data")
+        baseline = clean_pipeline["true_classes"]["Circadian"].mean()
+        assert ap > baseline, f"tau_mean AP={ap:.3f} should exceed prevalence baseline ({baseline:.3f})"
+
+
+# ---------------------------------------------------------------------------
+# Directional ranking: class means must be in the correct direction
+# ---------------------------------------------------------------------------
+
+class TestDirectionalRanking:
+    """Mean score values must be directionally consistent with true class membership.
+
+    These are weaker than AUC tests but more interpretable: they tell you
+    *which* class is mis-ranked rather than just reporting a combined AUC.
+    """
+
+    def test_circadian_has_higher_tau_mean_than_constitutive(self, clean_pipeline):
+        pos_mean, neg_mean = _class_means(
+            clean_pipeline["result"], clean_pipeline["true_classes"],
+            "tau_mean", "Circadian",
+        )
+        assert pos_mean > neg_mean, (
+            f"Circadian tau_mean ({pos_mean:.3f}) should exceed "
+            f"non-circadian ({neg_mean:.3f})"
+        )
+
+    def test_linear_has_higher_pirs_than_constitutive(self, clean_pipeline):
+        """Linear (ramp) genes should have higher PIRS than constitutive (flat noise).
+
+        PIRS measures how far prediction-interval bounds deviate from mean
+        expression.  A linear trend pushes the prediction far from the mean at
+        time extremes; flat noise does not.
+        """
+        lin_pirs, _ = _class_means(
+            clean_pipeline["result"], clean_pipeline["true_classes"],
+            "pirs_score", "Linear",
+        )
+        const_pirs, _ = _class_means(
+            clean_pipeline["result"], clean_pipeline["true_classes"],
+            "pirs_score", "Const",
+        )
+        assert lin_pirs > const_pirs, (
+            f"Linear pirs_score ({lin_pirs:.3f}) should exceed "
+            f"constitutive ({const_pirs:.3f})"
+        )
+
+    def test_linear_has_lower_slope_pval_than_constitutive(self, clean_pipeline):
+        lin_pval, const_pval = _class_means(
+            clean_pipeline["result"], clean_pipeline["true_classes"],
+            "slope_pval", "Linear",
+        )
+        assert lin_pval < const_pval, (
+            f"Linear slope_pval ({lin_pval:.3f}) should be "
+            f"lower than constitutive ({const_pval:.3f})"
+        )
+
+    def test_circadian_has_lower_emp_p_than_constitutive(self, clean_pipeline):
+        circ_empp, const_empp = _class_means(
+            clean_pipeline["result"], clean_pipeline["true_classes"],
+            "emp_p", "Circadian",
+        )
+        assert circ_empp < const_empp, (
+            f"Circadian emp_p ({circ_empp:.3f}) should be "
+            f"lower than constitutive ({const_empp:.3f})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Label accuracy: precision of assigned labels vs ground truth
+# ---------------------------------------------------------------------------
+
+class TestLabelAccuracy:
+    """Predicted labels should agree with ground truth better than random chance.
+
+    Precision >= class prevalence means the label is informative.  Tests skip
+    when fewer than three genes receive a label (e.g. strict emp_p threshold
+    with small bootstrap size prevents any rhythmic assignments).
+    """
+
+    def _precision_recall(self, result, true_classes, label, truth_col):
+        shared = result.index.intersection(true_classes.index)
+        pred_pos = result.loc[shared, "label"] == label
+        act_pos = true_classes.loc[shared, truth_col] == 1
+        tp = (pred_pos & act_pos).sum()
+        fp = (pred_pos & ~act_pos).sum()
+        fn = (~pred_pos & act_pos).sum()
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        return precision, recall
+
+    def test_compound_rhythmic_precision_above_chance(self, clean_pipeline):
+        """Genes labeled rhythmic OR noisy_rhythmic should be enriched for true circadian genes.
+
+        PIRS determines whether a gene is stable or variable; BooteJTK determines
+        whether it is rhythmic.  Truly circadian genes can be either stable
+        (→ 'rhythmic') or variable (→ 'noisy_rhythmic') depending on their noise
+        level, so the compound label set is the correct thing to check.
+        """
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        shared = result.index.intersection(tc.index)
+        rhythmic_labels = {"rhythmic", "noisy_rhythmic"}
+        n_detected = result.loc[shared, "label"].isin(rhythmic_labels).sum()
+        if n_detected < 3:
+            pytest.skip("too few rhythmic/noisy_rhythmic labels for meaningful precision test")
+        pred_pos = result.loc[shared, "label"].isin(rhythmic_labels)
+        act_pos = tc.loc[shared, "Circadian"] == 1
+        tp = (pred_pos & act_pos).sum()
+        fp = (pred_pos & ~act_pos).sum()
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        baseline = tc["Circadian"].mean()
+        assert precision >= baseline, (
+            f"rhythmic+noisy_rhythmic precision ({precision:.3f}) should exceed "
+            f"prevalence ({baseline:.3f})"
+        )
+
+    def test_constitutive_label_precision_above_chance(self, clean_pipeline):
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        if (result["label"] == "constitutive").sum() < 3:
+            pytest.skip("too few 'constitutive' labels")
+        precision, _ = self._precision_recall(result, tc, "constitutive", "Const")
+        baseline = tc["Const"].mean()
+        assert precision >= baseline, (
+            f"'constitutive' precision ({precision:.3f}) should exceed "
+            f"prevalence ({baseline:.3f})"
+        )
+
+    def test_linear_label_precision_above_chance(self, clean_pipeline):
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        if (result["label"] == "linear").sum() < 3:
+            pytest.skip("too few 'linear' labels")
+        precision, _ = self._precision_recall(result, tc, "linear", "Linear")
+        baseline = tc["Linear"].mean()
+        assert precision >= baseline, (
+            f"'linear' precision ({precision:.3f}) should exceed "
+            f"prevalence ({baseline:.3f})"
+        )
+
+    def test_at_least_one_circadian_gene_labelled_rhythmic_or_noisy_rhythmic(
+        self, clean_pipeline
+    ):
+        """On clean data, at least one truly circadian gene should be detected as rhythmic."""
+        result = clean_pipeline["result"]
+        tc = clean_pipeline["true_classes"]
+        shared = result.index.intersection(tc.index)
+        circ_ids = tc.loc[shared][tc.loc[shared]["Circadian"] == 1].index
+        if len(circ_ids) < 5:
+            pytest.skip("too few circadian genes")
+        rhythmic_labels = {"rhythmic", "noisy_rhythmic"}
+        n_detected = result.loc[circ_ids, "label"].isin(rhythmic_labels).sum()
+        assert n_detected >= 1, (
+            f"Expected at least 1 truly circadian gene labelled rhythmic/noisy_rhythmic "
+            f"on clean data; got 0 out of {len(circ_ids)}"
+        )

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.metrics import roc_auc_score
 
 from circ.simulations import simulate
 from circ.limbr.imputation import imputable
@@ -248,6 +249,44 @@ class TestClassification:
         assert (result.loc[linear_ids, "slope_pval"].mean() <
                 result.loc[const_ids, "slope_pval"].mean())
 
+    def test_circadian_genes_have_higher_tau_mean(self, pipeline):
+        """Simulated circadian genes should rank higher on tau_mean than constitutive genes."""
+        result = pipeline["result"]
+        true_classes = pipeline["true_classes"]
+        shared = result.index.intersection(true_classes.index)
+        if len(shared) < 10:
+            pytest.skip("too few matched genes for directional test")
+        tc = true_classes.loc[shared]
+        circ_ids = tc[tc["Circadian"] == 1].index
+        const_ids = tc[tc["Const"] == 1].index
+        if len(circ_ids) < 3 or len(const_ids) < 3:
+            pytest.skip("insufficient class representation")
+        circ_tau = result.loc[circ_ids, "tau_mean"].mean()
+        const_tau = result.loc[const_ids, "tau_mean"].mean()
+        assert circ_tau > const_tau, (
+            f"circadian tau_mean ({circ_tau:.3f}) should exceed "
+            f"constitutive ({const_tau:.3f})"
+        )
+
+    def test_circadian_genes_have_lower_emp_p(self, pipeline):
+        """Simulated circadian genes should have lower GammaBH p-values than constitutive."""
+        result = pipeline["result"]
+        true_classes = pipeline["true_classes"]
+        shared = result.index.intersection(true_classes.index)
+        if len(shared) < 10:
+            pytest.skip("too few matched genes for directional test")
+        tc = true_classes.loc[shared]
+        circ_ids = tc[tc["Circadian"] == 1].index
+        const_ids = tc[tc["Const"] == 1].index
+        if len(circ_ids) < 3 or len(const_ids) < 3:
+            pytest.skip("insufficient class representation")
+        circ_emp_p = result.loc[circ_ids, "emp_p"].dropna().mean()
+        const_emp_p = result.loc[const_ids, "emp_p"].dropna().mean()
+        assert circ_emp_p < const_emp_p, (
+            f"circadian emp_p ({circ_emp_p:.3f}) should be lower than "
+            f"constitutive ({const_emp_p:.3f})"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Step 5: Visualization — classification plots
@@ -345,3 +384,54 @@ class TestBenchmarkPlots:
         outpath = str(pipeline["tmp"] / "benchmark.png")
         fig.savefig(outpath, dpi=72, bbox_inches="tight")
         assert os.path.exists(outpath)
+
+    def _matched(self, pipeline, score_col, truth_col):
+        """Return a clean DataFrame with score and truth aligned on shared index."""
+        result = pipeline["result"]
+        true_classes = pipeline["true_classes"]
+        shared = result.index.intersection(true_classes.index)
+        return (
+            result.loc[shared, [score_col]]
+            .join(true_classes.loc[shared, [truth_col]])
+            .dropna()
+        )
+
+    def test_tau_mean_circadian_auc_above_chance(self, pipeline):
+        """tau_mean should discriminate simulated circadian genes better than random."""
+        df = self._matched(pipeline, "tau_mean", "Circadian")
+        if len(df) < 10 or df["Circadian"].nunique() < 2:
+            pytest.skip("insufficient data for AUC test")
+        auc = roc_auc_score(df["Circadian"], df["tau_mean"])
+        assert auc > 0.5, (
+            f"tau_mean → Circadian AUC={auc:.3f}; expected > 0.5 (better than random)"
+        )
+
+    def test_emp_p_circadian_auc_above_chance(self, pipeline):
+        """emp_p (inverted) should discriminate simulated circadian genes better than random."""
+        df = self._matched(pipeline, "emp_p", "Circadian")
+        if len(df) < 10 or df["Circadian"].nunique() < 2:
+            pytest.skip("insufficient data for AUC test")
+        auc = roc_auc_score(df["Circadian"], -df["emp_p"])
+        assert auc > 0.5, (
+            f"emp_p → Circadian AUC={auc:.3f}; expected > 0.5 (better than random)"
+        )
+
+    def test_pirs_score_constitutive_auc_above_chance(self, pipeline):
+        """PIRS score (inverted) should discriminate constitutive genes better than random."""
+        df = self._matched(pipeline, "pirs_score", "Const")
+        if len(df) < 10 or df["Const"].nunique() < 2:
+            pytest.skip("insufficient data for AUC test")
+        auc = roc_auc_score(df["Const"], -df["pirs_score"])
+        assert auc > 0.5, (
+            f"pirs_score → Const AUC={auc:.3f}; expected > 0.5 (better than random)"
+        )
+
+    def test_slope_pval_linear_auc_above_chance(self, pipeline):
+        """slope_pval (inverted) should discriminate linear genes better than random."""
+        df = self._matched(pipeline, "slope_pval", "Linear")
+        if len(df) < 10 or df["Linear"].nunique() < 2:
+            pytest.skip("insufficient data for AUC test")
+        auc = roc_auc_score(df["Linear"], -df["slope_pval"])
+        assert auc > 0.5, (
+            f"slope_pval → Linear AUC={auc:.3f}; expected > 0.5 (better than random)"
+        )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,221 @@
+"""Tests for circ.evaluation — pure metric functions."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from circ.evaluation import roc_auc, classification_auc, classification_ap
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def merged_dict():
+    """Synthetic merged dict for roc_auc tests."""
+    rng = np.random.default_rng(1)
+    n = 100
+    truth = rng.integers(0, 2, n)
+    return {
+        'method_a': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
+        'method_b': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
+    }
+
+
+@pytest.fixture
+def classification_df():
+    """Synthetic classification output."""
+    rng = np.random.default_rng(2)
+    n = 80
+    labels = ['constitutive'] * 20 + ['rhythmic'] * 20 + ['variable'] * 20 + ['noisy_rhythmic'] * 20
+    return pd.DataFrame({
+        'pirs_score': np.abs(rng.normal(0, 1, n)),
+        'tau_mean':   rng.uniform(0, 1, n),
+        'emp_p':      rng.uniform(0, 1, n),
+        'pval':       rng.uniform(0, 1, n),
+        'slope_pval': rng.uniform(0, 1, n),
+        'label':      labels,
+    }, index=[f'g{i}' for i in range(n)])
+
+
+@pytest.fixture
+def true_classes(classification_df):
+    """Simulated ground-truth binary labels aligned with classification_df."""
+    rng = np.random.default_rng(3)
+    n = len(classification_df)
+    return pd.DataFrame({
+        'Const':     rng.integers(0, 2, n),
+        'Circadian': rng.integers(0, 2, n),
+        'Linear':    rng.integers(0, 2, n),
+    }, index=classification_df.index)
+
+
+# ---------------------------------------------------------------------------
+# roc_auc — structural
+# ---------------------------------------------------------------------------
+
+class TestRocAuc:
+    def test_returns_dict(self, merged_dict):
+        result = roc_auc(merged_dict)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == set(merged_dict.keys())
+
+    def test_auc_in_unit_interval(self, merged_dict):
+        result = roc_auc(merged_dict)
+        for v in result.values():
+            assert 0.0 <= v <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# roc_auc — metric correctness
+# ---------------------------------------------------------------------------
+
+class TestRocAucQuality:
+    """roc_auc() should return correct values for controllable inputs.
+
+    roc_auc() computes 1 - GammaBH before scoring, so a low GammaBH for
+    positive-class genes yields a high discriminating score (as expected for
+    a p-value).
+    """
+
+    def _make_dict(self, truth, gammabh, tag='m'):
+        return {tag: pd.DataFrame({'Circadian': truth, 'GammaBH': gammabh})}
+
+    def test_perfect_score_gives_auc_one(self):
+        """GammaBH == 0 for all positive genes → AUC should be 1.0."""
+        truth = np.array([1] * 30 + [0] * 30)
+        gammabh = np.array([0.0] * 30 + [1.0] * 30)
+        result = roc_auc(self._make_dict(truth, gammabh))
+        assert result['m'] == pytest.approx(1.0)
+
+    def test_inverted_score_gives_auc_zero(self):
+        """GammaBH == 1 for all positive genes → AUC should be 0.0."""
+        truth = np.array([1] * 30 + [0] * 30)
+        gammabh = np.array([1.0] * 30 + [0.0] * 30)
+        result = roc_auc(self._make_dict(truth, gammabh))
+        assert result['m'] == pytest.approx(0.0)
+
+    def test_random_score_gives_auc_near_half(self):
+        """A random score should give AUC close to 0.5."""
+        rng = np.random.default_rng(99)
+        n = 400
+        truth = rng.integers(0, 2, n)
+        gammabh = rng.uniform(0, 1, n)
+        result = roc_auc(self._make_dict(truth, gammabh))
+        assert abs(result['m'] - 0.5) < 0.1, (
+            f"Random-score AUC={result['m']:.3f} should be near 0.5"
+        )
+
+    def test_multiple_methods_ranked_correctly(self):
+        """Perfect score should outrank a random score."""
+        n = 100
+        truth = np.array([1] * 50 + [0] * 50)
+        rng = np.random.default_rng(7)
+        d = {
+            'perfect': pd.DataFrame({'Circadian': truth,
+                                     'GammaBH': np.array([0.0]*50 + [1.0]*50)}),
+            'random':  pd.DataFrame({'Circadian': truth,
+                                     'GammaBH': rng.uniform(0, 1, n)}),
+        }
+        result = roc_auc(d)
+        assert result['perfect'] > result['random'], (
+            f"perfect AUC={result['perfect']:.3f} should exceed "
+            f"random AUC={result['random']:.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# classification_auc
+# ---------------------------------------------------------------------------
+
+class TestClassificationAuc:
+    def test_returns_dict(self, classification_df, true_classes):
+        result = classification_auc(classification_df, true_classes)
+        assert isinstance(result, dict)
+
+    def test_keys_are_score_truth_tuples(self, classification_df, true_classes):
+        result = classification_auc(classification_df, true_classes)
+        for key in result:
+            assert isinstance(key, tuple) and len(key) == 2
+
+    def test_values_in_unit_interval(self, classification_df, true_classes):
+        result = classification_auc(classification_df, true_classes)
+        for v in result.values():
+            assert 0.0 <= v <= 1.0
+
+    def test_auto_detection_finds_expected_tasks(self, classification_df, true_classes):
+        result = classification_auc(classification_df, true_classes)
+        assert ('pirs_score', 'Const') in result
+        assert ('tau_mean', 'Circadian') in result
+        assert ('slope_pval', 'Linear') in result
+
+    def test_explicit_tasks_respected(self, classification_df, true_classes):
+        result = classification_auc(
+            classification_df, true_classes,
+            tasks=[('slope_pval', 'Linear', True)],
+        )
+        assert list(result.keys()) == [('slope_pval', 'Linear')]
+
+    def test_perfect_score_gives_auc_one(self):
+        """A score that perfectly separates classes should give AUC=1.0."""
+        n = 60
+        clf_df = pd.DataFrame(
+            {'pirs_score': np.array([0.0]*30 + [1.0]*30)},
+            index=[f'g{i}' for i in range(n)],
+        )
+        truth_df = pd.DataFrame(
+            {'Const': np.array([1]*30 + [0]*30)},
+            index=clf_df.index,
+        )
+        result = classification_auc(clf_df, truth_df, tasks=[('pirs_score', 'Const', True)])
+        assert result[('pirs_score', 'Const')] == pytest.approx(1.0)
+
+    def test_empty_intersection_omitted(self):
+        """Tasks with no overlapping index should be omitted from the result."""
+        clf_df = pd.DataFrame({'pirs_score': [0.1, 0.2]}, index=['a', 'b'])
+        truth_df = pd.DataFrame({'Const': [1, 0]}, index=['x', 'y'])
+        result = classification_auc(clf_df, truth_df, tasks=[('pirs_score', 'Const', True)])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# classification_ap
+# ---------------------------------------------------------------------------
+
+class TestClassificationAp:
+    def test_returns_float(self, classification_df, true_classes):
+        ap = classification_ap(classification_df, true_classes)
+        assert isinstance(ap, float)
+
+    def test_value_in_unit_interval(self, classification_df, true_classes):
+        ap = classification_ap(classification_df, true_classes)
+        assert 0.0 <= ap <= 1.0
+
+    def test_perfect_score_gives_ap_one(self):
+        """A score that perfectly separates classes should give AP=1.0."""
+        n = 60
+        clf_df = pd.DataFrame(
+            {'pirs_score': np.array([0.0]*30 + [1.0]*30)},
+            index=[f'g{i}' for i in range(n)],
+        )
+        truth_df = pd.DataFrame(
+            {'Const': np.array([1]*30 + [0]*30)},
+            index=clf_df.index,
+        )
+        ap = classification_ap(clf_df, truth_df, ground_truth_col='Const',
+                               score_col='pirs_score', invert_score=True)
+        assert ap == pytest.approx(1.0)
+
+    def test_empty_intersection_returns_none(self):
+        clf_df = pd.DataFrame({'pirs_score': [0.1, 0.2]}, index=['a', 'b'])
+        truth_df = pd.DataFrame({'Const': [1, 0]}, index=['x', 'y'])
+        ap = classification_ap(clf_df, truth_df)
+        assert ap is None
+
+    def test_non_default_score_col(self, classification_df, true_classes):
+        ap = classification_ap(
+            classification_df, true_classes,
+            ground_truth_col='Circadian', score_col='tau_mean', invert_score=False,
+        )
+        assert ap is not None
+        assert 0.0 <= ap <= 1.0

--- a/tests/visualization/test_benchmarks.py
+++ b/tests/visualization/test_benchmarks.py
@@ -1,4 +1,10 @@
-"""Tests for circ.visualization.benchmarks."""
+"""Tests for circ.visualization.benchmarks — plotting functions only.
+
+Metric correctness tests (roc_auc, classification_auc, classification_ap)
+live in tests/test_evaluation.py.
+"""
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,7 +16,6 @@ import matplotlib.axes
 from circ.visualization.benchmarks import (
     pr_curve,
     roc_curve_plot,
-    roc_auc,
     classification_pr,
     classification_roc,
 )
@@ -43,7 +48,7 @@ def curves_df():
 
 @pytest.fixture
 def merged_dict():
-    """Synthetic merged dict for ROC curves."""
+    """Synthetic merged dict for roc_curve_plot tests."""
     rng = np.random.default_rng(1)
     n = 100
     truth = rng.integers(0, 2, n)
@@ -131,22 +136,6 @@ class TestRocCurvePlot:
 
 
 # ---------------------------------------------------------------------------
-# roc_auc
-# ---------------------------------------------------------------------------
-
-class TestRocAuc:
-    def test_returns_dict(self, merged_dict):
-        result = roc_auc(merged_dict)
-        assert isinstance(result, dict)
-        assert set(result.keys()) == set(merged_dict.keys())
-
-    def test_auc_in_unit_interval(self, merged_dict):
-        result = roc_auc(merged_dict)
-        for v in result.values():
-            assert 0.0 <= v <= 1.0
-
-
-# ---------------------------------------------------------------------------
 # classification_pr
 # ---------------------------------------------------------------------------
 
@@ -175,7 +164,7 @@ class TestClassificationPr:
 
 
 # ---------------------------------------------------------------------------
-# classification_roc
+# classification_roc — rendering
 # ---------------------------------------------------------------------------
 
 class TestClassificationRoc:
@@ -194,3 +183,69 @@ class TestClassificationRoc:
         ax = classification_roc(classification_df, true_classes, tasks=tasks)
         # 1 method line + diagonal
         assert len(ax.lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# classification_roc — AUC values embedded in legend labels
+# ---------------------------------------------------------------------------
+
+class TestClassificationRocValues:
+    """AUC values written into classification_roc() legend labels should be correct."""
+
+    def _extract_auc(self, ax):
+        """Return the first AUC value found in any line label on the axes."""
+        for line in ax.lines:
+            m = re.search(r'AUC=([0-9.]+)', line.get_label())
+            if m:
+                return float(m.group(1))
+        return None
+
+    def test_perfect_slope_pval_gives_auc_near_one(self):
+        """A score that perfectly separates Linear genes should appear as AUC ≈ 1.0."""
+        n = 100
+        clf_df = pd.DataFrame(
+            {'slope_pval': np.array([0.001] * 25 + [0.99] * 75)},
+            index=[f'g{i}' for i in range(n)],
+        )
+        truth_df = pd.DataFrame(
+            {'Linear': np.array([1] * 25 + [0] * 75)},
+            index=clf_df.index,
+        )
+        ax = classification_roc(clf_df, truth_df, tasks=[('slope_pval', 'Linear', True)])
+        auc_val = self._extract_auc(ax)
+        assert auc_val is not None, "AUC value not found in classification_roc legend labels"
+        assert auc_val > 0.99, (
+            f"Perfect slope_pval should give AUC > 0.99; got {auc_val:.3f}"
+        )
+
+    def test_random_score_gives_near_chance_auc(self):
+        """A random score should appear as AUC ≈ 0.5 in the legend."""
+        rng = np.random.default_rng(55)
+        n = 300
+        clf_df = pd.DataFrame(
+            {'pirs_score': rng.uniform(0, 1, n)},
+            index=[f'g{i}' for i in range(n)],
+        )
+        truth_df = pd.DataFrame(
+            {'Const': rng.integers(0, 2, n)},
+            index=clf_df.index,
+        )
+        ax = classification_roc(clf_df, truth_df, tasks=[('pirs_score', 'Const', True)])
+        auc_val = self._extract_auc(ax)
+        assert auc_val is not None, "AUC value not found in classification_roc legend labels"
+        assert abs(auc_val - 0.5) < 0.1, (
+            f"Random pirs_score AUC={auc_val:.3f} should be near 0.5"
+        )
+
+    def test_all_tasks_produce_auc_labels(self, classification_df, true_classes):
+        """All auto-detected tasks should embed an AUC value in their legend label."""
+        ax = classification_roc(classification_df, true_classes)
+        auc_labels = [
+            l for line in ax.lines
+            for l in [line.get_label()]
+            if re.search(r'AUC=([0-9.]+)', l)
+        ]
+        # Should have at least one labelled task line (random diagonal also has AUC=0.5)
+        assert len(auc_labels) >= 2, (
+            f"Expected ≥2 lines with AUC labels; found {len(auc_labels)}"
+        )


### PR DESCRIPTION
## Summary

- Extracts `roc_auc`, `classification_auc`, `classification_ap` into a new `circ.evaluation` module — metric logic is now decoupled from matplotlib; `circ.visualization.benchmarks` covers plotting only
- Fixes `circ.simulations` constitutive gene baseline (`N(1,σ)` instead of `N(0,σ)`) so PIRS mean-expression normalisation works on simulation data
- Fixes circadian sine wave to span exactly one 24h cycle (2π not 4π)
- Switches `classification_pr` AP calculation to `sklearn.average_precision_score`
- Adds `TestClassificationRocValues`: legend labels in `classification_roc()` now carry numerically verified AUC values
- Adds `tests/test_evaluation.py`: structural + metric-correctness tests for all three evaluation functions
- Adds `tests/expression_classification/test_metrics_quality.py`: each pipeline score must achieve AUC > 0.5 and AP > baseline against its intended target class on clean simulation data; PIRS is tested only against **Linear vs Const** (its intended task), not against Circadian

## Test plan

- [x] `poetry run pytest` — 670 passed, 1 skipped, 0 failures
- [x] Review that `test_metrics_quality.py` comment block correctly documents why PIRS is not tested against Circadian
- [x] Confirm `circ.evaluation` is importable standalone (no matplotlib dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)