### PR TITLE
Add between-condition statistical comparison module

### DIFF
--- a/circ/__init__.py
+++ b/circ/__init__.py
@@ -7,6 +7,7 @@ circ.limbr      KNN imputation and SVA-based batch-effect removal
 circ.pirs       Prediction Interval Ranking Score (constitutive expression)
 circ.bootjtk               Bootstrap empirical JTK circadian rhythm detection
 circ.expression_classification  Unified PIRS + BooteJTK expression classifier
+circ.compare    Statistical comparison of results between two conditions
 """
 from importlib.metadata import version, PackageNotFoundError
 

--- a/circ/compare.py
+++ b/circ/compare.py
@@ -1,0 +1,247 @@
+"""Statistical comparison of classification results between two experimental conditions.
+
+The main entry point is :func:`compare_conditions`, which takes the result
+DataFrames from two :class:`~circ.expression_classification.classify.Classifier`
+runs and returns a per-gene summary of effect sizes and, when BooteJTK
+uncertainty columns (``tau_std``, ``phase_std``, ``n_boots``) are present,
+FDR-corrected significance tests.
+
+Statistical methods
+-------------------
+**Rhythmicity change (TauMean)**
+    Welch's t-test on the bootstrap tau distributions.  BooteJTK reports
+    ``tau_std`` (SD of best-match tau values across ``n_boots`` bootstrap
+    resamples) and ``n_boots``, giving enough information to construct a
+    two-sample t-statistic with Welch–Satterthwaite degrees of freedom.
+
+**Phase shift**
+    A z-test on the signed circular phase difference B − A (wrapped to
+    ±12 h).  Standard errors are approximated as ``phase_std / √n_boots``
+    for each condition.  Only genes called rhythmic in *both* conditions
+    are tested; phase estimates for non-rhythmic genes are unreliable.
+
+Both tests apply Benjamini–Hochberg FDR correction across all tested genes.
+"""
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compare_conditions(
+    result_A,
+    result_B,
+    emp_p_threshold=0.05,
+    tau_threshold=0.5,
+):
+    """Compare classification results for shared genes between two conditions.
+
+    For each gene present in both result DataFrames, computes effect sizes
+    (``delta_tau``, ``delta_pirs``, ``delta_phase``) and, when BooteJTK
+    uncertainty columns are present (``tau_std``, ``phase_std``,
+    ``n_boots``), significance tests with Benjamini–Hochberg correction.
+
+    Parameters
+    ----------
+    result_A, result_B : pd.DataFrame
+        Output of ``Classifier.classify()`` for each condition.  Both must
+        share at least some gene IDs in their index.
+    emp_p_threshold : float
+        GammaBH threshold for calling a gene rhythmic (default 0.05).
+    tau_threshold : float
+        TauMean threshold for calling a gene rhythmic (default 0.5).
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per shared gene.  Always-present columns:
+
+        * ``label_A``, ``label_B`` — expression label in each condition
+        * ``rhythmicity_status`` — ``"gained"``, ``"lost"``,
+          ``"maintained_rhythmic"``, or ``"maintained_nonrhythmic"``
+        * ``tau_mean_A``, ``tau_mean_B``, ``delta_tau``
+        * ``pirs_score_A``, ``pirs_score_B``, ``delta_pirs``
+        * ``emp_p_A``, ``emp_p_B`` — per-condition GammaBH (if in input)
+        * ``phase_A``, ``phase_B``, ``delta_phase`` — circular phase
+          difference in hours (±12 h); ``NaN`` for genes not rhythmic
+          in both conditions (if phase columns present)
+
+        Significance columns (added when ``tau_std`` and ``n_boots`` are
+        present in both DataFrames):
+
+        * ``tau_pval``, ``tau_padj`` — Welch t-test on TauMean difference
+        * ``phase_pval``, ``phase_padj`` — z-test on phase shift
+          (only for genes rhythmic in both conditions)
+    """
+    shared = result_A.index.intersection(result_B.index)
+    if len(shared) == 0:
+        raise ValueError(
+            "result_A and result_B share no gene IDs. "
+            "Check that both DataFrames are indexed by the same gene identifiers."
+        )
+
+    A = result_A.loc[shared]
+    B = result_B.loc[shared]
+
+    out = pd.DataFrame(index=shared)
+    out.index.name = A.index.name
+    out['label_A'] = A['label']
+    out['label_B'] = B['label']
+
+    rhythmic_A = _is_rhythmic(A, emp_p_threshold, tau_threshold)
+    rhythmic_B = _is_rhythmic(B, emp_p_threshold, tau_threshold)
+    out['rhythmicity_status'] = _rhythmicity_status(rhythmic_A, rhythmic_B)
+
+    # TauMean effect size
+    out['tau_mean_A'] = A['tau_mean']
+    out['tau_mean_B'] = B['tau_mean']
+    out['delta_tau'] = B['tau_mean'].values - A['tau_mean'].values
+
+    # PIRS effect size
+    out['pirs_score_A'] = A['pirs_score']
+    out['pirs_score_B'] = B['pirs_score']
+    out['delta_pirs'] = B['pirs_score'].values - A['pirs_score'].values
+
+    # Empirical p-values (pass through for reference)
+    for suffix, df in [('_A', A), ('_B', B)]:
+        if 'emp_p' in df.columns:
+            out[f'emp_p{suffix}'] = df['emp_p']
+
+    # Phase effect size (circular)
+    if 'phase_mean' in A.columns and 'phase_mean' in B.columns:
+        out['phase_A'] = A['phase_mean']
+        out['phase_B'] = B['phase_mean']
+        raw_diff = _circular_diff(A['phase_mean'].values, B['phase_mean'].values)
+        out['delta_phase'] = raw_diff
+        # Phase difference is only meaningful when rhythmic in both conditions
+        out.loc[~(rhythmic_A & rhythmic_B), 'delta_phase'] = np.nan
+
+    # Significance tests (requires uncertainty columns from BooteJTK)
+    has_uncertainty = (
+        all(c in A.columns for c in ('tau_std', 'n_boots')) and
+        all(c in B.columns for c in ('tau_std', 'n_boots'))
+    )
+    if has_uncertainty:
+        _tau_test(out, A, B)
+        if 'delta_phase' in out.columns and 'phase_std' in A.columns and 'phase_std' in B.columns:
+            _phase_test(out, A, B)
+
+    return out
+
+
+def label_change_table(comparison):
+    """Pivot table of label transitions between conditions (A → B).
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`compare_conditions`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Rows = label in condition A, columns = label in condition B,
+        values = gene count.  Labels are ordered by ``_LABEL_ORDER``.
+    """
+    from circ.visualization.classify import _LABEL_ORDER
+    all_labels = list(dict.fromkeys(
+        [l for l in _LABEL_ORDER if l in comparison['label_A'].values or l in comparison['label_B'].values]
+    ))
+    ct = pd.crosstab(comparison['label_A'], comparison['label_B'])
+    return ct.reindex(index=all_labels, columns=all_labels, fill_value=0)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _circular_diff(a, b, period=24.0):
+    """Signed circular difference b − a, wrapped to (−period/2, +period/2]."""
+    diff = (np.asarray(b, dtype=float) - np.asarray(a, dtype=float)) % period
+    diff = np.where(diff > period / 2, diff - period, diff)
+    return diff
+
+
+def _bh_correct(pvals):
+    """Benjamini–Hochberg FDR correction; NaNs are preserved."""
+    pvals = np.asarray(pvals, dtype=float)
+    result = np.full(len(pvals), np.nan)
+    valid = ~np.isnan(pvals)
+    if not valid.any():
+        return result
+    p = pvals[valid]
+    m = len(p)
+    order = np.argsort(p)
+    rank = np.empty(m, dtype=float)
+    rank[order] = np.arange(1, m + 1)
+    adj = p * m / rank
+    # Enforce monotone decrease from right so smaller ranks stay ≤ larger
+    adj_sorted = adj[order]
+    adj_sorted = np.minimum.accumulate(adj_sorted[::-1])[::-1]
+    adj[order] = np.minimum(adj_sorted, 1.0)
+    result[valid] = adj
+    return result
+
+
+def _is_rhythmic(result, emp_p_threshold, tau_threshold):
+    """Boolean Series: True if the gene passes rhythmicity thresholds."""
+    has_emp_p = 'emp_p' in result.columns and result['emp_p'].notna().any()
+    has_tau   = 'tau_mean' in result.columns and result['tau_mean'].notna().any()
+    if has_emp_p and has_tau:
+        return (result['emp_p'] < emp_p_threshold) & (result['tau_mean'] >= tau_threshold)
+    elif has_tau:
+        return result['tau_mean'] >= tau_threshold
+    return result['label'].isin(['rhythmic', 'noisy_rhythmic'])
+
+
+def _rhythmicity_status(rhythmic_A, rhythmic_B):
+    status = pd.Series('maintained_nonrhythmic', index=rhythmic_A.index, dtype=object)
+    status[rhythmic_A  & rhythmic_B]  = 'maintained_rhythmic'
+    status[~rhythmic_A & rhythmic_B]  = 'gained'
+    status[rhythmic_A  & ~rhythmic_B] = 'lost'
+    return status
+
+
+def _tau_test(out, A, B):
+    """Vectorised Welch's t-test on bootstrap TauMean distributions."""
+    ta = A['tau_mean'].values.astype(float)
+    sa = A['tau_std'].values.astype(float)
+    na = A['n_boots'].values.astype(float)
+    tb = B['tau_mean'].values.astype(float)
+    sb = B['tau_std'].values.astype(float)
+    nb = B['n_boots'].values.astype(float)
+
+    se_a_sq = np.where(na > 1, sa**2 / na, np.nan)
+    se_b_sq = np.where(nb > 1, sb**2 / nb, np.nan)
+    se = np.sqrt(se_a_sq + se_b_sq)
+    t = (tb - ta) / se
+
+    # Welch–Satterthwaite degrees of freedom
+    df_ws = (se_a_sq + se_b_sq)**2 / (
+        se_a_sq**2 / np.maximum(na - 1, 1) + se_b_sq**2 / np.maximum(nb - 1, 1)
+    )
+    pvals = 2 * stats.t.sf(np.abs(t), df_ws)
+    pvals[~np.isfinite(t)] = np.nan
+
+    out['tau_pval'] = pvals
+    out['tau_padj'] = _bh_correct(pvals)
+
+
+def _phase_test(out, A, B):
+    """Vectorised z-test on circular phase shift (genes rhythmic in both)."""
+    delta = out['delta_phase'].values.astype(float)   # NaN where not both rhythmic
+    sa = A['phase_std'].values.astype(float)
+    na = A['n_boots'].values.astype(float)
+    sb = B['phase_std'].values.astype(float)
+    nb = B['n_boots'].values.astype(float)
+
+    se = np.sqrt(sa**2 / np.maximum(na, 1) + sb**2 / np.maximum(nb, 1))
+    z = delta / se                                     # NaN propagates from delta
+    pvals = 2 * stats.norm.sf(np.abs(z))
+    pvals[~np.isfinite(z)] = np.nan
+
+    out['phase_pval'] = pvals
+    out['phase_padj'] = _bh_correct(pvals)

--- a/circ/expression_classification/classify.py
+++ b/circ/expression_classification/classify.py
@@ -233,6 +233,9 @@ class Classifier:
             * ``emp_p`` – FDR-corrected p-value (``GammaBH``), if available
             * ``period_mean`` – estimated period, if available
             * ``phase_mean`` – estimated phase, if available
+            * ``tau_std`` – bootstrap standard deviation of TauMean
+            * ``phase_std`` – circular SD of phase estimate (hours)
+            * ``n_boots`` – number of BooteJTK bootstrap iterations
             * ``label`` – one of ``constitutive``, ``rhythmic``, ``linear``,
               ``variable``, ``noisy_rhythmic``
         """
@@ -256,9 +259,12 @@ class Classifier:
         result['tau_mean'] = self.rhythm_results[tau_col]
 
         for src_col, dst_col in [
-            ('GammaBH', 'emp_p'),
-            ('PeriodMean', 'period_mean'),
-            ('PhaseMean', 'phase_mean'),
+            ('GammaBH',     'emp_p'),
+            ('PeriodMean',  'period_mean'),
+            ('PhaseMean',   'phase_mean'),
+            ('TauStdDev',   'tau_std'),
+            ('PhaseStdDev', 'phase_std'),
+            ('NumBoots',    'n_boots'),
         ]:
             if src_col in self.rhythm_results.columns:
                 result[dst_col] = self.rhythm_results[src_col]

--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -15,6 +15,15 @@ Classification plots
    period_distribution
    classification_summary
 
+Condition comparison plots
+--------------------------
+.. autosummary::
+   rhythmicity_shift_scatter
+   phase_shift_histogram
+   label_transition_heatmap
+   delta_tau_volcano
+   comparison_summary
+
 Benchmark / evaluation plots
 -----------------------------
 .. autosummary::
@@ -45,6 +54,13 @@ from circ.visualization.classify import (
     threshold_sensitivity,
     classification_summary,
 )
+from circ.visualization.compare import (
+    rhythmicity_shift_scatter,
+    phase_shift_histogram,
+    label_transition_heatmap,
+    delta_tau_volcano,
+    comparison_summary,
+)
 from circ.evaluation import roc_auc
 from circ.visualization.benchmarks import (
     pr_curve,
@@ -71,6 +87,12 @@ __all__ = [
     'mean_expression_profiles',
     'threshold_sensitivity',
     'classification_summary',
+    # compare
+    'rhythmicity_shift_scatter',
+    'phase_shift_histogram',
+    'label_transition_heatmap',
+    'delta_tau_volcano',
+    'comparison_summary',
     # benchmarks
     'pr_curve',
     'roc_curve_plot',

--- a/circ/visualization/compare.py
+++ b/circ/visualization/compare.py
@@ -1,0 +1,289 @@
+"""Visualizations for between-condition comparison results from circ.compare."""
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import seaborn as sns
+
+from circ.visualization.classify import LABEL_COLORS, _LABEL_ORDER, _ax
+
+# Colors and draw order for rhythmicity change categories
+_STATUS_COLORS = {
+    'maintained_rhythmic':    '#6ACC65',
+    'gained':                 '#D65F5F',
+    'lost':                   '#4878CF',
+    'maintained_nonrhythmic': '#CCCCCC',
+}
+_STATUS_ORDER = ['maintained_rhythmic', 'gained', 'lost', 'maintained_nonrhythmic']
+
+
+def rhythmicity_shift_scatter(
+    comparison,
+    alpha=0.05,
+    ax=None,
+    title='Rhythmicity shift: TauMean per condition',
+):
+    """Scatter of tau_mean_A vs tau_mean_B, colored by rhythmicity status.
+
+    Each point is a shared gene.  Points above the diagonal increased
+    rhythmicity in condition B; below the diagonal lost it.  When
+    ``tau_padj`` is present, genes with a significant adjusted p-value
+    are drawn with larger, opaque markers; the rest are small and faint.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold for highlighting significant tau changes (default 0.05).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    has_padj = 'tau_padj' in comparison.columns
+
+    for status in _STATUS_ORDER:
+        sub = comparison[comparison['rhythmicity_status'] == status]
+        if sub.empty:
+            continue
+        color = _STATUS_COLORS[status]
+        if has_padj:
+            sig = sub['tau_padj'] < alpha
+            if sig.any():
+                ax.scatter(
+                    sub.loc[sig, 'tau_mean_A'], sub.loc[sig, 'tau_mean_B'],
+                    color=color, s=28, alpha=0.85, zorder=4,
+                    edgecolors='white', linewidths=0.5,
+                    label=f'{status} (FDR<{alpha})',
+                )
+            if (~sig).any():
+                ax.scatter(
+                    sub.loc[~sig, 'tau_mean_A'], sub.loc[~sig, 'tau_mean_B'],
+                    color=color, s=10, alpha=0.35, zorder=3,
+                    label=status,
+                )
+        else:
+            ax.scatter(
+                sub['tau_mean_A'], sub['tau_mean_B'],
+                color=color, s=10, alpha=0.55, zorder=3,
+                label=status,
+            )
+
+    lim = max(comparison['tau_mean_A'].max(), comparison['tau_mean_B'].max()) * 1.05
+    ax.plot([0, lim], [0, lim], color='#999999', ls='--', lw=0.9, alpha=0.6)
+    ax.set_xlim(0, lim)
+    ax.set_ylim(0, lim)
+    ax.set_xlabel('TauMean — condition A')
+    ax.set_ylabel('TauMean — condition B')
+    ax.set_title(title)
+    patches = [mpatches.Patch(color=_STATUS_COLORS[s], label=s)
+               for s in _STATUS_ORDER if s in comparison['rhythmicity_status'].values]
+    ax.legend(handles=patches, frameon=False, fontsize=9)
+    sns.despine(ax=ax)
+    return ax
+
+
+def phase_shift_histogram(
+    comparison,
+    ax=None,
+    title='Phase shift distribution (rhythmic in both conditions)',
+):
+    """Histogram of circular phase differences for genes rhythmic in both conditions.
+
+    ``delta_phase`` is the signed difference phase_B − phase_A, wrapped
+    to ±12 h.  A vertical dashed line at 0 marks no change.  Only genes
+    with a valid ``delta_phase`` (i.e. rhythmic in both conditions) are
+    shown.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+
+    if 'delta_phase' not in comparison.columns:
+        ax.text(0.5, 0.5, 'No phase data available',
+                transform=ax.transAxes, ha='center', va='center', color='#888888')
+        ax.set_title(title)
+        return ax
+
+    dp = comparison['delta_phase'].dropna()
+    if dp.empty:
+        ax.text(0.5, 0.5, 'No genes rhythmic\nin both conditions',
+                transform=ax.transAxes, ha='center', va='center', color='#888888')
+        ax.set_title(title)
+        sns.despine(ax=ax)
+        return ax
+
+    bins = np.arange(-12, 13, 2)
+    ax.hist(dp, bins=bins, color=LABEL_COLORS['rhythmic'], alpha=0.75, edgecolor='white')
+    ax.axvline(0, color='#333333', ls='--', lw=0.9, alpha=0.8, label='no shift')
+    ax.set_xlabel('Phase shift B − A (h)')
+    ax.set_ylabel('Gene count')
+    ax.set_xlim(-12, 12)
+    ax.set_xticks(range(-12, 13, 4))
+    ax.set_xticklabels([f'{h:+d}' if h != 0 else '0' for h in range(-12, 13, 4)])
+    ax.set_title(title)
+    ax.legend(frameon=False, fontsize=9)
+    sns.despine(ax=ax)
+    return ax
+
+
+def label_transition_heatmap(
+    comparison,
+    ax=None,
+    title='Label transitions A → B',
+):
+    """Heatmap of classification label changes between conditions.
+
+    Each cell shows the number of genes that moved from label A (row)
+    to label B (column).  Diagonal cells are genes whose label did not
+    change.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    from circ.compare import label_change_table
+    ax = _ax(ax)
+    ct = label_change_table(comparison)
+    if ct.empty:
+        ax.set_title(title)
+        return ax
+
+    sns.heatmap(
+        ct, ax=ax, annot=True, fmt='d', cmap='Blues',
+        linewidths=0.5, linecolor='white', cbar=False,
+        annot_kws={'size': 9},
+    )
+    ax.set_xlabel('Label in condition B')
+    ax.set_ylabel('Label in condition A')
+    ax.set_title(title)
+    return ax
+
+
+def delta_tau_volcano(
+    comparison,
+    alpha=0.05,
+    ax=None,
+    title='Rhythmicity change: Δ TauMean vs significance',
+):
+    """Volcano plot of Δ TauMean vs −log₁₀(tau_padj).
+
+    Each point is a shared gene.  The x-axis shows TauMean B − A
+    (positive = more rhythmic in B); the y-axis shows significance.
+    A horizontal dashed line marks the FDR threshold at *alpha*.
+
+    Requires ``tau_padj`` (produced when ``tau_std`` and ``n_boots`` are
+    present in both result DataFrames — i.e. when BooteJTK was run and
+    the Classifier added uncertainty columns to its output).
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold drawn as a horizontal line (default 0.05).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    if 'tau_padj' not in comparison.columns:
+        raise ValueError(
+            "'tau_padj' column missing — re-run compare_conditions() with "
+            "result DataFrames that include tau_std and n_boots (produced "
+            "automatically when Classifier.classify() is run after run_bootjtk())."
+        )
+    ax = _ax(ax)
+    df = comparison.dropna(subset=['delta_tau', 'tau_padj'])
+    df = df.assign(neg_log_p=-np.log10(df['tau_padj'].clip(lower=1e-300)))
+
+    for status in _STATUS_ORDER:
+        sub = df[df['rhythmicity_status'] == status]
+        if sub.empty:
+            continue
+        ax.scatter(
+            sub['delta_tau'], sub['neg_log_p'],
+            color=_STATUS_COLORS[status], s=14, alpha=0.65,
+            rasterized=len(df) > 500,
+        )
+
+    ax.axhline(-np.log10(alpha), color='#333333', ls='--', lw=0.9, alpha=0.7,
+               label=f'FDR = {alpha}')
+    ax.axvline(0, color='#999999', ls=':', lw=0.8, alpha=0.5)
+
+    ax.set_xlabel('Δ TauMean (B − A)')
+    ax.set_ylabel('−log₁₀(tau_padj)')
+    ax.set_title(title)
+    patches = [mpatches.Patch(color=_STATUS_COLORS[s], label=s)
+               for s in _STATUS_ORDER if s in df['rhythmicity_status'].values]
+    ax.legend(handles=patches, frameon=False, fontsize=9)
+    sns.despine(ax=ax)
+    return ax
+
+
+def comparison_summary(comparison, outpath=None):
+    """Multi-panel summary figure for a condition comparison.
+
+    Panels shown (based on available columns):
+
+    * Always: rhythmicity shift scatter, label transition heatmap
+    * Requires ``delta_phase``: phase shift histogram
+    * Requires ``tau_padj``: delta tau volcano
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    outpath : str or None
+        If provided, save to this path (dpi = 150).
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    panels = [
+        lambda ax: rhythmicity_shift_scatter(comparison, ax=ax),
+        lambda ax: label_transition_heatmap(comparison, ax=ax),
+    ]
+    if 'delta_phase' in comparison.columns:
+        panels.append(lambda ax: phase_shift_histogram(comparison, ax=ax))
+    if 'tau_padj' in comparison.columns:
+        panels.append(lambda ax: delta_tau_volcano(comparison, ax=ax))
+
+    n = len(panels)
+    ncols = min(2, n)
+    nrows = (n + ncols - 1) // ncols
+
+    fig, axes = plt.subplots(nrows, ncols, figsize=(7 * ncols, 5 * nrows), squeeze=False)
+    axes_flat = axes.flatten()
+
+    for ax, fn in zip(axes_flat, panels):
+        fn(ax)
+    for ax in axes_flat[n:]:
+        ax.set_visible(False)
+
+    fig.tight_layout(pad=1.5, h_pad=2.0, w_pad=1.5)
+    if outpath:
+        fig.savefig(outpath, dpi=150, bbox_inches='tight')
+    return fig

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -57,31 +57,49 @@ except ImportError:
 FIGURES = Path("figures")
 FIGURES.mkdir(exist_ok=True)
 
-COND_LABELS = ("Condition A (WT-like)", "Condition B (KO-like)")
+COND_LABELS = ("Condition A (reference)", "Condition B (phase-shifted)")
 COND_COLORS = ("#4878CF", "#D65F5F")
 
 # ---------------------------------------------------------------------------
 # 1. Setup — two simulations sharing the same gene IDs
 #
-# Condition A: higher circadian fraction (more rhythmic genes)
-# Condition B: lower circadian fraction, more linear (e.g., clock-disrupted)
+# The simulation is split into two parts so that the two conditions share a
+# realistic set of rhythmic genes:
 #
-# Both use the same gene_ids so downstream overlap analyses are meaningful.
+#   Shared core (gene_0000–gene_0059): 60 genes simulated as fully rhythmic
+#     in both conditions but with independent random phases, mimicking genes
+#     that oscillate in both conditions but peak at different times.
+#
+#   Condition-specific background (gene_0060–gene_0299):
+#     Condition A has additional rhythmic and linear genes; Condition B has
+#     fewer rhythmic genes and more linear ones (clock-disrupted background).
+#
+# This structure ensures that the phase shift histogram (genes rhythmic in
+# BOTH conditions) contains real data.  With purely independent simulations
+# the rhythmic gene sets rarely overlap at typical detection thresholds.
 # ---------------------------------------------------------------------------
-print("Simulating condition A …")
-sim_A = simulate(tpoints=8, nrows=300, nreps=2, pcirc=0.30, plin=0.10, rseed=1)
-print("Simulating condition B …")
-sim_B = simulate(tpoints=8, nrows=300, nreps=2, pcirc=0.10, plin=0.25, rseed=2)
+print("Simulating shared rhythmic core …")
+sim_core_A = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=10)
+sim_core_B = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=11)
 
-gene_ids = [f"gene_{i:04d}" for i in range(sim_A.nrows)]
+print("Simulating condition-specific backgrounds …")
+sim_bg_A = simulate(tpoints=8, nrows=240, nreps=2, pcirc=0.20, plin=0.10, rseed=1)
+sim_bg_B = simulate(tpoints=8, nrows=240, nreps=2, pcirc=0.05, plin=0.25, rseed=2)
 
-def _make_expr(sim):
-    df = pd.DataFrame(sim.sim, index=gene_ids, columns=sim.cols)
-    df.index.name = "#"
-    return df
+gene_ids = [f"gene_{i:04d}" for i in range(300)]
+cols = sim_core_A.cols
 
-expr_A = _make_expr(sim_A)
-expr_B = _make_expr(sim_B)
+expr_A = pd.DataFrame(
+    np.vstack([sim_core_A.sim, sim_bg_A.sim]),
+    index=gene_ids, columns=cols,
+)
+expr_A.index.name = "#"
+
+expr_B = pd.DataFrame(
+    np.vstack([sim_core_B.sim, sim_bg_B.sim]),
+    index=gene_ids, columns=cols,
+)
+expr_B.index.name = "#"
 
 # run_all() includes tau_std, phase_std, and n_boots — the bootstrap uncertainty
 # estimates from BooteJTK that compare_conditions() needs for statistical tests.

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -4,8 +4,19 @@ Use case:
     You have run the classifier on two datasets — for example, wild-type vs
     knockout, or two tissue types — and want to understand what changed:
     which label categories shifted, which rhythmic genes gained or lost
-    rhythmicity, and whether the same genes serve as stable housekeepers
-    in both conditions.
+    rhythmicity, whether the same genes serve as stable housekeepers in both
+    conditions, and which changes are statistically significant.
+
+How it works:
+    ``circ.compare.compare_conditions`` joins the two result DataFrames on
+    shared gene IDs and computes:
+
+    * Effect sizes: Δ TauMean, Δ PIRS score, circular Δ phase (±12 h)
+    * Rhythmicity status per gene: gained / lost / maintained / never rhythmic
+    * Statistical tests (when BooteJTK uncertainty columns are present):
+        - Welch's t-test on TauMean using the bootstrap SD from each condition
+        - z-test on the circular phase shift for genes rhythmic in both
+      Both tests apply Benjamini–Hochberg FDR correction across all genes.
 
 Run:
     poetry run python examples/06_compare_conditions.py
@@ -35,6 +46,7 @@ from circ.simulations import simulate
 from circ.expression_classification.classify import Classifier
 from circ.visualization import LABEL_COLORS
 import circ.visualization as viz
+from circ.compare import compare_conditions, label_change_table
 
 try:
     import circ.visualization.interactive as iviz
@@ -46,7 +58,7 @@ FIGURES = Path("figures")
 FIGURES.mkdir(exist_ok=True)
 
 COND_LABELS = ("Condition A (WT-like)", "Condition B (KO-like)")
-COND_COLORS = ("#4878CF", "#D65F5F")   # blue / red
+COND_COLORS = ("#4878CF", "#D65F5F")
 
 # ---------------------------------------------------------------------------
 # 1. Setup — two simulations sharing the same gene IDs
@@ -71,6 +83,8 @@ def _make_expr(sim):
 expr_A = _make_expr(sim_A)
 expr_B = _make_expr(sim_B)
 
+# run_all() includes tau_std, phase_std, and n_boots — the bootstrap uncertainty
+# estimates from BooteJTK that compare_conditions() needs for statistical tests.
 print("Classifying condition A …")
 clf_A = Classifier(expr_A, reps=2)
 result_A = clf_A.run_all(pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1)
@@ -87,9 +101,8 @@ print(result_B["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 # 2. Label distribution comparison
 #
-# Side-by-side bar charts reveal which label categories expanded or shrank
-# between conditions.  In a clock-disrupted condition you expect fewer
-# rhythmic genes and potentially more variable or linear ones.
+# Side-by-side bar charts reveal which label categories expanded or shrank.
+# A shared x-axis makes gene counts visually comparable between conditions.
 # ---------------------------------------------------------------------------
 print("Section 1: Label distribution comparison …")
 
@@ -97,7 +110,6 @@ fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
 viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0])
 viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1])
 
-# Shared x-axis range so gene counts are visually comparable across conditions
 xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
 axes[0].set_xlim(0, xmax)
 axes[1].set_xlim(0, xmax)
@@ -111,9 +123,9 @@ print(f"  saved → {out}")
 # ---------------------------------------------------------------------------
 # 3. Phase distribution comparison
 #
-# Overlaying the phase wheels from both conditions shows whether the timing
-# of peak expression shifted.  If the KO delays or advances the phase of
-# rhythmic genes, you will see the angular distribution rotate.
+# Overlaying the phase wheels shows whether the timing of peak expression
+# shifted.  If the KO delays or advances rhythmic gene phases, the angular
+# distribution will rotate.
 # ---------------------------------------------------------------------------
 print("Section 2: Phase wheel comparison …")
 
@@ -133,10 +145,8 @@ print(f"  saved → {out}")
 # ---------------------------------------------------------------------------
 # 4. Constitutive gene overlap
 #
-# Genes that are constitutively expressed in BOTH conditions are the most
-# reliable internal reference gene candidates — their stability is not
-# condition-specific.  Genes constitutive in only one condition should be
-# used with caution.
+# Genes constitutive in BOTH conditions are the most reliable reference
+# gene candidates — their stability is not condition-specific.
 # ---------------------------------------------------------------------------
 print("Section 3: Constitutive gene overlap …")
 
@@ -150,24 +160,21 @@ print(f"  Constitutive in A only : {len(only_A)}")
 print(f"  Constitutive in both   : {len(both)}")
 print(f"  Constitutive in B only : {len(only_B)}\n")
 
-# Side-by-side top_constitutive_candidates; highlight shared genes
 fig, axes = plt.subplots(1, 2, figsize=(14, 6))
 viz.top_constitutive_candidates(result_A, n_top=15, ax=axes[0],
                                 title=f"Top candidates — {COND_LABELS[0]}")
 viz.top_constitutive_candidates(result_B, n_top=15, ax=axes[1],
                                 title=f"Top candidates — {COND_LABELS[1]}")
 
-# Mark genes that appear in both conditions' top-15 lists
 top15_A = set(result_A.dropna(subset=["pirs_score"]).nsmallest(15, "pirs_score").index)
 top15_B = set(result_B.dropna(subset=["pirs_score"]).nsmallest(15, "pirs_score").index)
 shared_top = top15_A & top15_B
 if shared_top:
     for ax in axes:
-        ytick_labels = [t.get_text() for t in ax.get_yticklabels()]
-        for i, lbl in enumerate(ytick_labels):
-            if lbl in shared_top:
-                ax.get_yticklabels()[i].set_fontweight("bold")
-                ax.get_yticklabels()[i].set_color("#2E8B57")
+        for tick in ax.get_yticklabels():
+            if tick.get_text() in shared_top:
+                tick.set_fontweight("bold")
+                tick.set_color("#2E8B57")
 
 shared_patch = mpatches.Patch(color="#2E8B57",
                               label=f"In both top-15 ({len(shared_top)} genes)")
@@ -180,92 +187,101 @@ plt.close(fig)
 print(f"  saved → {out}")
 
 # ---------------------------------------------------------------------------
-# 5. Rhythmicity scatter — TauMean A vs TauMean B
+# 5. Statistical comparison — compare_conditions()
 #
-# Each point is one gene.  Points above the diagonal gained rhythmicity in
-# condition B; points below lost it.  Color encodes whether the gene was
-# called rhythmic in both, one, or neither condition.
+# Joins the two result DataFrames on shared gene IDs and returns:
+#   - Effect sizes: delta_tau, delta_pirs, delta_phase
+#   - Rhythmicity status per gene (gained / lost / maintained / never)
+#   - tau_pval / tau_padj: Welch t-test on bootstrap TauMean distributions
+#   - phase_pval / phase_padj: z-test on circular phase shift
 # ---------------------------------------------------------------------------
-print("Section 4: Rhythmicity shift scatter …")
+print("Section 4: Statistical comparison …")
 
-# Rhythmic = in (rhythmic | noisy_rhythmic) label
-rhythmic_A = set(result_A[result_A["label"].isin(["rhythmic", "noisy_rhythmic"])].index)
-rhythmic_B = set(result_B[result_B["label"].isin(["rhythmic", "noisy_rhythmic"])].index)
+comparison = compare_conditions(result_A, result_B)
 
-tau = result_A[["tau_mean"]].join(result_B[["tau_mean"]], lsuffix="_A", rsuffix="_B",
-                                  how="inner").dropna()
+print("\nRhythmicity status breakdown:")
+print(comparison["rhythmicity_status"].value_counts().to_string())
 
-def _rhythm_category(gene_id):
-    in_A = gene_id in rhythmic_A
-    in_B = gene_id in rhythmic_B
-    if in_A and in_B:   return "rhythmic in both",  "#6ACC65"
-    if in_A:            return "only in A",          COND_COLORS[0]
-    if in_B:            return "only in B",          COND_COLORS[1]
-    return                     "not rhythmic",       "#CCCCCC"
+sig_tau   = comparison["tau_padj"].lt(0.05).sum()
+sig_phase = comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+print(f"\nSignificant tau changes  (tau_padj < 0.05) : {sig_tau}")
+print(f"Significant phase shifts (phase_padj < 0.05): {sig_phase}")
 
-tau["category"], tau["color"] = zip(*[_rhythm_category(g) for g in tau.index])
+print("\nLabel transition table (A → B):")
+print(label_change_table(comparison).to_string(), "\n")
 
-fig, ax = plt.subplots(figsize=(6, 6))
-for cat, color in [
-    ("not rhythmic",   "#CCCCCC"),
-    ("only in A",      COND_COLORS[0]),
-    ("only in B",      COND_COLORS[1]),
-    ("rhythmic in both", "#6ACC65"),
-]:
-    sub = tau[tau["category"] == cat]
-    if sub.empty:
-        continue
-    ax.scatter(sub["tau_mean_A"], sub["tau_mean_B"],
-               color=color, s=10, alpha=0.6, label=f"{cat} (n={len(sub)})",
-               rasterized=len(tau) > 500)
-
-lim = max(tau["tau_mean_A"].max(), tau["tau_mean_B"].max()) * 1.05
-ax.plot([0, lim], [0, lim], color="#999999", ls="--", lw=0.8, alpha=0.7)
-ax.set_xlim(0, lim)
-ax.set_ylim(0, lim)
-ax.set_xlabel(f"TauMean — {COND_LABELS[0]}")
-ax.set_ylabel(f"TauMean — {COND_LABELS[1]}")
-ax.set_title("Rhythmicity shift: TauMean per condition")
-ax.legend(loc="upper left", frameon=False, fontsize=8, markerscale=1.5)
-sns.despine(ax=ax)
-
-plt.tight_layout()
-out = FIGURES / "23_rhythmicity_shift.png"
-fig.savefig(out, dpi=150, bbox_inches="tight")
+# comparison_summary auto-selects panels from: rhythmicity shift scatter,
+# label transition heatmap, phase shift histogram, and delta tau volcano.
+fig = viz.comparison_summary(
+    comparison,
+    outpath=str(FIGURES / "23_comparison_summary.png"),
+)
 plt.close(fig)
-print(f"  saved → {out}")
+print(f"  saved → {FIGURES / '23_comparison_summary.png'}")
 
 # ---------------------------------------------------------------------------
-# 6. Interactive condition comparison
+# 6. Top genes with significant rhythmicity or phase changes
+# ---------------------------------------------------------------------------
+print("Section 5: Top significant genes …")
+
+sig = comparison[comparison["tau_padj"] < 0.05]
+lost = sig[sig["rhythmicity_status"] == "lost"].nsmallest(5, "delta_tau")
+gained = sig[sig["rhythmicity_status"] == "gained"].nlargest(5, "delta_tau")
+
+if not lost.empty:
+    print("\nTop genes losing rhythmicity (tau_padj < 0.05):")
+    print(lost[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].to_string())
+
+if not gained.empty:
+    print("\nTop genes gaining rhythmicity (tau_padj < 0.05):")
+    print(gained[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].to_string())
+
+if "phase_padj" in comparison.columns:
+    sig_phase_df = comparison[
+        comparison["phase_padj"].lt(0.05) &
+        comparison["rhythmicity_status"].eq("maintained_rhythmic")
+    ].copy()
+    if not sig_phase_df.empty:
+        sig_phase_df["abs_shift"] = sig_phase_df["delta_phase"].abs()
+        print("\nTop genes with significant phase shifts (phase_padj < 0.05):")
+        print(sig_phase_df.nlargest(5, "abs_shift")[
+            ["phase_A", "phase_B", "delta_phase", "phase_padj"]
+        ].to_string())
+
+# ---------------------------------------------------------------------------
+# 7. Interactive condition comparison
 # ---------------------------------------------------------------------------
 if _HAS_PLOTLY:
-    print("Section 5: Interactive figures …")
+    print("\nSection 6: Interactive figure …")
 
-    # Hover to identify which genes changed rhythmicity
-    hover_texts = []
-    for gene_id, row in tau.iterrows():
-        txt = (f"<b>{gene_id}</b><br>"
-               f"TauMean A: {row['tau_mean_A']:.3f}<br>"
-               f"TauMean B: {row['tau_mean_B']:.3f}<br>"
-               f"{row['category']}")
-        hover_texts.append(txt)
+    hover_texts = [
+        f"<b>{g}</b><br>"
+        f"TauMean A: {row['tau_mean_A']:.3f}<br>"
+        f"TauMean B: {row['tau_mean_B']:.3f}<br>"
+        f"Δ tau: {row['delta_tau']:+.3f}<br>"
+        f"{row['rhythmicity_status']}"
+        for g, row in comparison.iterrows()
+    ]
 
     import plotly.graph_objects as go
+
+    _STATUS_COLORS = {
+        'maintained_rhythmic':    '#6ACC65',
+        'gained':                 '#D65F5F',
+        'lost':                   '#4878CF',
+        'maintained_nonrhythmic': '#CCCCCC',
+    }
     traces = []
-    for cat, color in [
-        ("not rhythmic",    "#CCCCCC"),
-        ("only in A",       COND_COLORS[0]),
-        ("only in B",       COND_COLORS[1]),
-        ("rhythmic in both","#6ACC65"),
-    ]:
-        sub  = tau[tau["category"] == cat]
-        htxt = [hover_texts[tau.index.get_loc(g)] for g in sub.index]
+    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
+    for status, color in _STATUS_COLORS.items():
+        sub  = comparison[comparison["rhythmicity_status"] == status]
+        htxt = [hover_texts[comparison.index.get_loc(g)] for g in sub.index]
         if sub.empty:
             continue
         traces.append(go.Scatter(
             x=sub["tau_mean_A"], y=sub["tau_mean_B"],
             mode="markers",
-            name=f"{cat} (n={len(sub)})",
+            name=f"{status} (n={len(sub)})",
             marker=dict(color=color, size=5, opacity=0.7),
             hovertext=htxt,
             hovertemplate="%{hovertext}<extra></extra>",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,258 @@
+"""Tests for circ.compare — condition comparison statistics."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from circ.compare import compare_conditions, label_change_table, _circular_diff, _bh_correct
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(rseed=0, with_uncertainty=False, n=100, index_prefix='gene'):
+    rng = np.random.default_rng(rseed)
+    idx = pd.Index([f'{index_prefix}_{i:04d}' for i in range(n)], name='#')
+    tau   = rng.uniform(0.0, 1.0, n)
+    emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
+    pirs  = rng.uniform(0.0, 2.0, n)
+    phase = rng.uniform(0.0, 24.0, n)
+    labels = np.where(
+        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
+        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+    )
+    df = pd.DataFrame({
+        'tau_mean':   tau,
+        'emp_p':      emp_p,
+        'pirs_score': pirs,
+        'phase_mean': phase,
+        'label':      labels,
+    }, index=idx)
+    if with_uncertainty:
+        df['tau_std']   = rng.uniform(0.05, 0.2, n)
+        df['phase_std'] = rng.uniform(0.5, 2.0, n)
+        df['n_boots']   = 50
+    return df
+
+
+# ---------------------------------------------------------------------------
+# _circular_diff
+# ---------------------------------------------------------------------------
+
+class TestCircularDiff:
+    def test_zero_diff(self):
+        assert _circular_diff(6.0, 6.0) == pytest.approx(0.0)
+
+    def test_positive_diff(self):
+        assert _circular_diff(2.0, 6.0) == pytest.approx(4.0)
+
+    def test_negative_diff(self):
+        assert _circular_diff(6.0, 2.0) == pytest.approx(-4.0)
+
+    def test_wrap_forward(self):
+        # 22 → 2 should give +4 h (not −20 h)
+        assert _circular_diff(22.0, 2.0) == pytest.approx(4.0)
+
+    def test_wrap_backward(self):
+        # 2 → 22 should give −4 h (not +20 h)
+        assert _circular_diff(2.0, 22.0) == pytest.approx(-4.0)
+
+    def test_exactly_half_period(self):
+        # ±12 h boundary: difference of exactly 12 wraps to +12
+        diff = _circular_diff(0.0, 12.0)
+        assert abs(diff) == pytest.approx(12.0)
+
+    def test_vectorised(self):
+        a = np.array([0.0, 22.0, 12.0])
+        b = np.array([6.0,  2.0, 18.0])
+        result = _circular_diff(a, b)
+        assert result == pytest.approx([6.0, 4.0, 6.0])
+
+
+# ---------------------------------------------------------------------------
+# _bh_correct
+# ---------------------------------------------------------------------------
+
+class TestBHCorrect:
+    def test_all_nan(self):
+        result = _bh_correct([np.nan, np.nan])
+        assert np.all(np.isnan(result))
+
+    def test_single_value(self):
+        result = _bh_correct([0.03])
+        assert result[0] == pytest.approx(0.03)
+
+    def test_bounded_zero_to_one(self):
+        pvals = [0.001, 0.01, 0.05, 0.1, 0.5]
+        result = _bh_correct(pvals)
+        assert np.all(result >= 0) and np.all(result <= 1)
+
+    def test_monotone_in_rank(self):
+        # After BH correction the adjusted p-values should be non-decreasing
+        # when sorted by original p-value.
+        pvals = np.array([0.001, 0.01, 0.02, 0.04, 0.05, 0.2])
+        result = _bh_correct(pvals)
+        assert np.all(np.diff(result) >= -1e-12)
+
+    def test_nan_passthrough(self):
+        result = _bh_correct([0.01, np.nan, 0.05])
+        assert np.isnan(result[1])
+        assert not np.isnan(result[0])
+        assert not np.isnan(result[2])
+
+
+# ---------------------------------------------------------------------------
+# compare_conditions
+# ---------------------------------------------------------------------------
+
+class TestCompareConditions:
+    def test_returns_only_shared_genes(self):
+        A = _make_result(rseed=0, n=80)
+        # B has 80 genes but only 60 overlap with A
+        B = _make_result(rseed=1, n=80)
+        result = compare_conditions(A, B)
+        shared = A.index.intersection(B.index)
+        assert list(result.index) == list(shared)
+
+    def test_partial_overlap(self):
+        A = _make_result(rseed=0, n=100, index_prefix='gene')
+        B_idx = pd.Index([f'gene_{i:04d}' for i in range(50, 150)], name='#')
+        B = _make_result(rseed=1, n=100)
+        B.index = B_idx
+        result = compare_conditions(A, B)
+        assert len(result) == 50
+
+    def test_required_columns(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        for col in (
+            'label_A', 'label_B', 'rhythmicity_status',
+            'tau_mean_A', 'tau_mean_B', 'delta_tau',
+            'pirs_score_A', 'pirs_score_B', 'delta_pirs',
+            'phase_A', 'phase_B', 'delta_phase',
+            'emp_p_A', 'emp_p_B',
+        ):
+            assert col in result.columns, f"Missing column: {col}"
+
+    def test_delta_tau_correct(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        shared = A.index.intersection(B.index)
+        expected = B.loc[shared, 'tau_mean'].values - A.loc[shared, 'tau_mean'].values
+        np.testing.assert_allclose(result['delta_tau'].values, expected)
+
+    def test_delta_pirs_correct(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        shared = A.index.intersection(B.index)
+        expected = B.loc[shared, 'pirs_score'].values - A.loc[shared, 'pirs_score'].values
+        np.testing.assert_allclose(result['delta_pirs'].values, expected)
+
+    def test_delta_phase_wrapped(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        valid = result['delta_phase'].dropna()
+        assert (valid >= -12).all() and (valid <= 12).all()
+
+    def test_delta_phase_nan_for_nonrhythmic(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        non_both = result['rhythmicity_status'] != 'maintained_rhythmic'
+        assert result.loc[non_both, 'delta_phase'].isna().all()
+
+    def test_no_shared_genes_raises(self):
+        A = _make_result(rseed=0, index_prefix='gene')
+        B = _make_result(rseed=1, index_prefix='prot')
+        with pytest.raises(ValueError, match='share no gene IDs'):
+            compare_conditions(A, B)
+
+    def test_rhythmicity_status_values(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        valid = {'gained', 'lost', 'maintained_rhythmic', 'maintained_nonrhythmic'}
+        assert set(result['rhythmicity_status'].unique()).issubset(valid)
+
+    def test_gained_lost_consistency(self):
+        """Genes rhythmic only in B → gained; rhythmic only in A → lost."""
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        gained = result[result['rhythmicity_status'] == 'gained']
+        lost   = result[result['rhythmicity_status'] == 'lost']
+        # Gained genes should have low emp_p in B and higher in A
+        if not gained.empty and 'emp_p_A' in gained.columns:
+            assert (gained['emp_p_B'] < 0.05).all()
+        if not lost.empty and 'emp_p_A' in lost.columns:
+            assert (lost['emp_p_A'] < 0.05).all()
+
+    def test_significance_columns_with_uncertainty(self):
+        A = _make_result(rseed=0, with_uncertainty=True)
+        B = _make_result(rseed=1, with_uncertainty=True)
+        result = compare_conditions(A, B)
+        for col in ('tau_pval', 'tau_padj', 'phase_pval', 'phase_padj'):
+            assert col in result.columns, f"Missing significance column: {col}"
+
+    def test_no_significance_without_uncertainty(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        for col in ('tau_pval', 'tau_padj'):
+            assert col not in result.columns
+
+    def test_tau_padj_bounded(self):
+        A = _make_result(rseed=0, with_uncertainty=True)
+        B = _make_result(rseed=1, with_uncertainty=True)
+        result = compare_conditions(A, B)
+        padj = result['tau_padj'].dropna()
+        assert (padj >= 0).all() and (padj <= 1).all()
+
+    def test_phase_pval_only_for_rhythmic_both(self):
+        A = _make_result(rseed=0, with_uncertainty=True)
+        B = _make_result(rseed=1, with_uncertainty=True)
+        result = compare_conditions(A, B)
+        if 'phase_pval' in result.columns:
+            non_both = result['rhythmicity_status'] != 'maintained_rhythmic'
+            assert result.loc[non_both, 'phase_pval'].isna().all()
+
+    def test_no_phase_columns_without_phase_data(self):
+        A = _make_result(rseed=0).drop(columns=['phase_mean'])
+        B = _make_result(rseed=1).drop(columns=['phase_mean'])
+        result = compare_conditions(A, B)
+        assert 'delta_phase' not in result.columns
+
+
+# ---------------------------------------------------------------------------
+# label_change_table
+# ---------------------------------------------------------------------------
+
+class TestLabelChangeTable:
+    def test_square(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        ct = label_change_table(result)
+        assert ct.shape[0] == ct.shape[1]
+
+    def test_sum_matches_gene_count(self):
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        ct = label_change_table(result)
+        assert ct.values.sum() == len(result)
+
+    def test_labels_are_valid(self):
+        from circ.visualization.classify import _LABEL_ORDER
+        A = _make_result(rseed=0)
+        B = _make_result(rseed=1)
+        result = compare_conditions(A, B)
+        ct = label_change_table(result)
+        for lbl in ct.index:
+            assert lbl in _LABEL_ORDER
+        for lbl in ct.columns:
+            assert lbl in _LABEL_ORDER

--- a/tests/visualization/test_compare_plots.py
+++ b/tests/visualization/test_compare_plots.py
@@ -1,0 +1,167 @@
+"""Tests for circ.visualization.compare — condition comparison plots."""
+import numpy as np
+import pandas as pd
+import pytest
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.axes
+
+from circ.compare import compare_conditions
+from circ.visualization.compare import (
+    rhythmicity_shift_scatter,
+    phase_shift_histogram,
+    label_transition_heatmap,
+    delta_tau_volcano,
+    comparison_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_result(rseed=0, with_uncertainty=False, n=80):
+    rng = np.random.default_rng(rseed)
+    idx = pd.Index([f'gene_{i:04d}' for i in range(n)], name='#')
+    tau   = rng.uniform(0.0, 1.0, n)
+    emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
+    pirs  = rng.uniform(0.0, 2.0, n)
+    phase = rng.uniform(0.0, 24.0, n)
+    labels = np.where(
+        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
+        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+    )
+    df = pd.DataFrame({
+        'tau_mean': tau, 'emp_p': emp_p, 'pirs_score': pirs,
+        'phase_mean': phase, 'label': labels,
+    }, index=idx)
+    if with_uncertainty:
+        df['tau_std']   = rng.uniform(0.05, 0.2, n)
+        df['phase_std'] = rng.uniform(0.5, 2.0, n)
+        df['n_boots']   = 50
+    return df
+
+
+@pytest.fixture
+def comp_basic():
+    A = _make_result(rseed=0)
+    B = _make_result(rseed=1)
+    return compare_conditions(A, B)
+
+
+@pytest.fixture
+def comp_with_uncertainty():
+    A = _make_result(rseed=0, with_uncertainty=True)
+    B = _make_result(rseed=1, with_uncertainty=True)
+    return compare_conditions(A, B)
+
+
+# ---------------------------------------------------------------------------
+# rhythmicity_shift_scatter
+# ---------------------------------------------------------------------------
+
+class TestRhythmicityShiftScatter:
+    def test_returns_axes(self, comp_basic):
+        _, ax = plt.subplots()
+        result = rhythmicity_shift_scatter(comp_basic, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+    def test_creates_axes_if_none(self, comp_basic):
+        result = rhythmicity_shift_scatter(comp_basic)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+    def test_with_padj(self, comp_with_uncertainty):
+        _, ax = plt.subplots()
+        result = rhythmicity_shift_scatter(comp_with_uncertainty, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+
+# ---------------------------------------------------------------------------
+# phase_shift_histogram
+# ---------------------------------------------------------------------------
+
+class TestPhaseShiftHistogram:
+    def test_returns_axes(self, comp_basic):
+        _, ax = plt.subplots()
+        result = phase_shift_histogram(comp_basic, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+    def test_no_phase_data(self):
+        A = _make_result(rseed=0).drop(columns=['phase_mean'])
+        B = _make_result(rseed=1).drop(columns=['phase_mean'])
+        comp = compare_conditions(A, B)
+        _, ax = plt.subplots()
+        result = phase_shift_histogram(comp, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+    def test_no_rhythmic_genes(self):
+        # Force all genes to be non-rhythmic so delta_phase is all NaN
+        A = _make_result(rseed=0)
+        A['emp_p'] = 1.0   # nothing passes emp_p < 0.05
+        B = _make_result(rseed=1)
+        B['emp_p'] = 1.0
+        comp = compare_conditions(A, B)
+        _, ax = plt.subplots()
+        result = phase_shift_histogram(comp, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+
+# ---------------------------------------------------------------------------
+# label_transition_heatmap
+# ---------------------------------------------------------------------------
+
+class TestLabelTransitionHeatmap:
+    def test_returns_axes(self, comp_basic):
+        _, ax = plt.subplots()
+        result = label_transition_heatmap(comp_basic, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+
+# ---------------------------------------------------------------------------
+# delta_tau_volcano
+# ---------------------------------------------------------------------------
+
+class TestDeltaTauVolcano:
+    def test_raises_without_padj(self, comp_basic):
+        _, ax = plt.subplots()
+        with pytest.raises(ValueError, match='tau_padj'):
+            delta_tau_volcano(comp_basic, ax=ax)
+        plt.close()
+
+    def test_returns_axes_with_padj(self, comp_with_uncertainty):
+        _, ax = plt.subplots()
+        result = delta_tau_volcano(comp_with_uncertainty, ax=ax)
+        assert isinstance(result, matplotlib.axes.Axes)
+        plt.close()
+
+
+# ---------------------------------------------------------------------------
+# comparison_summary
+# ---------------------------------------------------------------------------
+
+class TestComparisonSummary:
+    def test_returns_figure(self, comp_basic):
+        fig = comparison_summary(comp_basic)
+        assert fig is not None
+        plt.close('all')
+
+    def test_returns_figure_with_uncertainty(self, comp_with_uncertainty):
+        fig = comparison_summary(comp_with_uncertainty)
+        assert fig is not None
+        plt.close('all')
+
+    def test_saves_to_file(self, comp_basic, tmp_path):
+        out = str(tmp_path / 'test_summary.png')
+        fig = comparison_summary(comp_basic, outpath=out)
+        assert fig is not None
+        import os
+        assert os.path.exists(out)
+        plt.close('all')


### PR DESCRIPTION
## Summary

- New `circ.compare` module with statistical tests for comparing classification results between two experimental conditions (WT vs KO, tissue A vs B, etc.)
- New `circ.visualization.compare` module with four plot types for visualizing condition differences
- `Classifier.classify()` now surfaces BooteJTK bootstrap uncertainty columns (`tau_std`, `phase_std`, `n_boots`) that the statistical tests depend on
- `examples/06_compare_conditions.py` consolidated and extended to cover both descriptive and statistical comparison in one workflow

## Statistical methods

**Rhythmicity change (`tau_pval` / `tau_padj`)**
BooteJTK's bootstrap gives TauMean ± TauStdDev over N bootstrap resamples per gene per condition. `compare_conditions()` runs a vectorised Welch's t-test on these bootstrap distributions (Welch–Satterthwaite degrees of freedom), then applies BH FDR correction across all genes.

**Phase shift (`phase_pval` / `phase_padj`)**
For genes called rhythmic in both conditions, a z-test on the signed circular phase difference (wrapped to ±12 h) using `phase_std / √n_boots` as the SE for each condition, with BH correction. Genes not rhythmic in both conditions receive `NaN` (their phase estimates are unreliable).

Both tests are fully vectorised and degrade gracefully: if uncertainty columns are absent (older result DataFrames), only effect sizes are returned with no p-value columns.

## New public API

```python
from circ.compare import compare_conditions, label_change_table
import circ.visualization as viz

comparison = compare_conditions(result_A, result_B)
# → delta_tau, delta_pirs, delta_phase, rhythmicity_status,
#   tau_pval, tau_padj, phase_pval, phase_padj (when uncertainty cols present)

label_change_table(comparison)          # A→B transition pivot table

viz.rhythmicity_shift_scatter(comparison)   # tau_A vs tau_B, colored by status
viz.phase_shift_histogram(comparison)       # ±12 h phase shift histogram
viz.label_transition_heatmap(comparison)    # seaborn heatmap of label changes
viz.delta_tau_volcano(comparison)           # Δ TauMean vs −log₁₀(tau_padj)
viz.comparison_summary(comparison)          # adaptive 2×2 multi-panel figure
```

## Test plan

- [x] `poetry run pytest tests/test_compare.py tests/visualization/test_compare_plots.py -v` — 42 new tests, all pass
- [x] `poetry run pytest` — 764 total tests, 0 failures
- [x] `poetry run python examples/06_compare_conditions.py` — end-to-end run, all figures saved to `figures/`
- [x] Verify `figures/23_comparison_summary.png` contains all four panels (shift scatter, heatmap, phase histogram, volcano)

🤖 Generated with [Claude Code](https://claude.com/claude-code)