### PR TITLE
Add cross-omics proteomics vs expression comparison

### DIFF
--- a/circ/compare.py
+++ b/circ/compare.py
@@ -6,6 +6,14 @@ runs and returns a per-gene summary of effect sizes and, when BooteJTK
 uncertainty columns (``tau_std``, ``phase_std``, ``n_boots``) are present,
 FDR-corrected significance tests.
 
+Cross-omic comparisons (proteomics vs. gene expression)
+-------------------------------------------------------
+Proteomics data is classified at peptide level and carries a
+``(Peptide, Protein)`` MultiIndex.  Before passing such results to
+:func:`compare_conditions`, collapse them to protein level with
+:func:`aggregate_to_protein`.  The Protein identifiers must then overlap
+with the gene IDs in the expression result.
+
 Statistical methods
 -------------------
 **Rhythmicity change (TauMean)**
@@ -30,6 +38,62 @@ from scipy import stats
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def aggregate_to_protein(result):
+    """Aggregate peptide-level classifier results to the protein level.
+
+    When proteomics data is classified at peptide level the result carries a
+    ``(Peptide, Protein)`` MultiIndex.  This function collapses it to a
+    single-level index on ``Protein`` so the result can be compared with gene
+    expression results via :func:`compare_conditions`.
+
+    Aggregation rules:
+
+    * **numeric columns** — mean across all peptides for the same protein
+    * **phase_mean** — circular mean (period 24 h) to handle wrap-around
+    * **label** — majority vote; ties broken by the first label alphabetically
+
+    Parameters
+    ----------
+    result : pd.DataFrame
+        Classifier output with a ``(Peptide, Protein)`` MultiIndex, as
+        produced when the expression data uses a proteomics-style multi-index.
+        If *result* already has a flat index it is returned unchanged.
+
+    Returns
+    -------
+    pd.DataFrame
+        Same columns as *result*, indexed by ``Protein``.
+    """
+    if not isinstance(result.index, pd.MultiIndex):
+        return result.copy()
+
+    protein = result.index.get_level_values('Protein')
+    df = result.copy()
+    df.index = pd.Index(protein, name='Protein')
+
+    numeric_cols = set(df.select_dtypes(include='number').columns)
+    agg = {}
+    for col in df.columns:
+        if col == 'phase_mean':
+            continue
+        elif col == 'label':
+            agg[col] = _majority_label
+        elif col in numeric_cols:
+            agg[col] = 'mean'
+
+    out = df.groupby(df.index, sort=False).agg(agg) if agg else pd.DataFrame(index=df.index.unique())
+
+    if 'phase_mean' in df.columns:
+        angles = 2 * np.pi * df['phase_mean'].values / 24.0
+        sin_s = pd.Series(np.sin(angles), index=df.index)
+        cos_s = pd.Series(np.cos(angles), index=df.index)
+        sin_mean = sin_s.groupby(df.index, sort=False).mean()
+        cos_mean = cos_s.groupby(df.index, sort=False).mean()
+        out['phase_mean'] = (np.arctan2(sin_mean, cos_mean) * 24 / (2 * np.pi)) % 24
+
+    return out.reindex(columns=[c for c in result.columns if c in out.columns])
+
 
 def compare_conditions(
     result_A,
@@ -76,11 +140,21 @@ def compare_conditions(
         * ``phase_pval``, ``phase_padj`` — z-test on phase shift
           (only for genes rhythmic in both conditions)
     """
+    for _name, _res in (('result_A', result_A), ('result_B', result_B)):
+        if isinstance(_res.index, pd.MultiIndex):
+            raise ValueError(
+                f"{_name} has a MultiIndex (peptide-level proteomics data). "
+                "Call aggregate_to_protein(result) first to collapse to protein "
+                "level before comparing."
+            )
+
     shared = result_A.index.intersection(result_B.index)
     if len(shared) == 0:
         raise ValueError(
             "result_A and result_B share no gene IDs. "
-            "Check that both DataFrames are indexed by the same gene identifiers."
+            "Check that both DataFrames are indexed by the same identifiers. "
+            "For proteomics vs. gene expression comparisons, call "
+            "aggregate_to_protein() first and ensure Protein IDs match gene IDs."
         )
 
     A = result_A.loc[shared]
@@ -157,6 +231,11 @@ def label_change_table(comparison):
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+def _majority_label(series):
+    """Return the most common label; ties broken alphabetically."""
+    return series.mode().iloc[0]
+
 
 def _circular_diff(a, b, period=24.0):
     """Signed circular difference b − a, wrapped to (−period/2, +period/2]."""

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -79,8 +79,8 @@ COND_COLORS = ("#4878CF", "#D65F5F")
 # the rhythmic gene sets rarely overlap at typical detection thresholds.
 # ---------------------------------------------------------------------------
 print("Simulating shared rhythmic core …")
-sim_core_A = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=10)
-sim_core_B = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=11)
+sim_core_A = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=10, amp_noise=0.35)
+sim_core_B = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=11, amp_noise=0.35)
 
 print("Simulating condition-specific backgrounds …")
 sim_bg_A = simulate(tpoints=8, nrows=240, nreps=2, pcirc=0.20, plin=0.10, rseed=1)

--- a/examples/07_compare_proteomics_vs_expression.py
+++ b/examples/07_compare_proteomics_vs_expression.py
@@ -1,0 +1,245 @@
+"""Compare circadian classifications from proteomics and gene-expression experiments.
+
+Use case:
+    You have circadian profiling data from the same biological system measured
+    at two molecular layers — mass-spectrometry proteomics and RNA-seq — and
+    want to identify which proteins/genes are rhythmic at each level, whether
+    oscillation phase is conserved across layers, and where the layers diverge
+    (e.g. post-transcriptionally regulated rhythms).
+
+How it works:
+    Both datasets are classified independently with ``Classifier``.  Because
+    the proteomics Protein identifiers match the RNA-seq gene identifiers,
+    ``compare_conditions`` finds the shared features automatically and computes
+    per-feature effect sizes and significance tests.
+
+    If your proteomics result is at *peptide* level (a ``(Peptide, Protein)``
+    MultiIndex), call ``aggregate_to_protein`` first — this is demonstrated
+    in the final section.
+
+Run:
+    poetry run python examples/07_compare_proteomics_vs_expression.py
+
+Figures are saved to ./figures/.  Pass --show to display interactively.
+
+Swap the simulation block for real data:
+    from circ.io import read_expression
+    # Protein-level proteomics (e.g. after circ.limbr SVA normalization):
+    prot_expr = read_expression("proteomics_protein_level.parquet")
+    # RNA-seq:
+    rna_expr  = read_expression("rnaseq.parquet")
+    # Protein IDs in prot_expr.index must match gene IDs in rna_expr.index.
+"""
+
+import sys
+from pathlib import Path
+
+import matplotlib
+if "--show" not in sys.argv:
+    matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from circ.simulations import simulate
+from circ.expression_classification.classify import Classifier
+import circ.visualization as viz
+from circ.compare import aggregate_to_protein, compare_conditions, label_change_table
+
+FIGURES = Path("figures")
+FIGURES.mkdir(exist_ok=True)
+
+LAYER_LABELS = ("Proteomics", "RNA-seq")
+
+# ---------------------------------------------------------------------------
+# 1. Simulate paired multi-omic datasets
+#
+# 200 features share the same identifiers (protein ID = gene ID) across both
+# molecular layers.  Three tiers create realistic cross-layer divergence:
+#
+#   feat_0000–0039  Shared rhythmic (40):  oscillate at both protein and mRNA
+#     level — transcriptionally driven rhythms.
+#   feat_0040–0059  Proteomics-only rhythmic (20):  rhythmic at protein level
+#     but flat mRNA — e.g. post-translational regulation or slow turnover.
+#   feat_0060–0079  RNA-only rhythmic (20):  rhythmic mRNA but non-rhythmic
+#     protein — e.g. rapid protein degradation buffers the oscillation.
+#   feat_0080–0199  Non-rhythmic background (120).
+# ---------------------------------------------------------------------------
+print("Simulating multi-omic datasets …")
+
+sim_core_prot      = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=20)
+sim_core_rna       = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=21)
+sim_prot_only_rhy  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=22)
+sim_prot_only_flat = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=26)
+sim_rna_only_flat  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=27)
+sim_rna_only_rhy   = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=23)
+sim_bg_prot        = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=24)
+sim_bg_rna         = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=25)
+
+feature_ids = [f"feat_{i:04d}" for i in range(200)]
+cols = sim_core_prot.cols
+
+prot_expr = pd.DataFrame(
+    np.vstack([
+        sim_core_prot.sim,       # feat_0000–0039: rhythmic in both
+        sim_prot_only_rhy.sim,   # feat_0040–0059: prot-only rhythmic
+        sim_rna_only_flat.sim,   # feat_0060–0079: non-rhythmic at protein level
+        sim_bg_prot.sim,         # feat_0080–0199: background
+    ]),
+    index=feature_ids, columns=cols,
+)
+prot_expr.index.name = "#"
+
+rna_expr = pd.DataFrame(
+    np.vstack([
+        sim_core_rna.sim,        # feat_0000–0039: rhythmic in both
+        sim_prot_only_flat.sim,  # feat_0040–0059: non-rhythmic in RNA
+        sim_rna_only_rhy.sim,    # feat_0060–0079: rna-only rhythmic
+        sim_bg_rna.sim,          # feat_0080–0199: background
+    ]),
+    index=feature_ids, columns=cols,
+)
+rna_expr.index.name = "#"
+
+# ---------------------------------------------------------------------------
+# 2. Classify each molecular layer independently
+# ---------------------------------------------------------------------------
+print("Classifying proteomics layer …")
+clf_prot    = Classifier(prot_expr, reps=2)
+result_prot = clf_prot.run_all(pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1)
+
+print("Classifying RNA-seq layer …")
+clf_rna    = Classifier(rna_expr, reps=2)
+result_rna = clf_rna.run_all(pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1)
+
+print("\nProteomics labels:")
+print(result_prot["label"].value_counts().to_string())
+print("\nRNA-seq labels:")
+print(result_rna["label"].value_counts().to_string(), "\n")
+
+# ---------------------------------------------------------------------------
+# 3. Per-layer classification overview
+# ---------------------------------------------------------------------------
+print("Section 1: Per-layer label distributions …")
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
+viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0])
+viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1])
+xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
+for ax in axes:
+    ax.set_xlim(0, xmax)
+plt.tight_layout()
+out = FIGURES / "31_layer_label_distributions.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# ---------------------------------------------------------------------------
+# 4. Cross-layer statistical comparison
+#
+# compare_conditions joins on shared feature IDs.  Effect-size columns
+# (delta_tau, delta_pirs, delta_phase) and significance tests
+# (tau_padj, phase_padj) are computed for all 200 shared features.
+#
+# Column naming convention: _A = proteomics, _B = RNA-seq.
+#   rhythmicity_status "lost"   = rhythmic in proteomics, non-rhythmic in RNA
+#   rhythmicity_status "gained" = non-rhythmic in proteomics, rhythmic in RNA
+# ---------------------------------------------------------------------------
+print("Section 2: Cross-layer statistical comparison …")
+
+comparison = compare_conditions(result_prot, result_rna)
+
+print("\nRhythmicity status (proteomics → RNA-seq):")
+print(comparison["rhythmicity_status"].value_counts().to_string())
+print("\nLabel transition table (proteomics → RNA-seq):")
+print(label_change_table(comparison).to_string())
+
+sig_tau   = comparison["tau_padj"].lt(0.05).sum()
+sig_phase = comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+print(f"\nSignificant τ changes   (tau_padj  < 0.05): {sig_tau}")
+print(f"Significant phase shifts (phase_padj < 0.05): {sig_phase}\n")
+
+fig = viz.comparison_summary(
+    comparison,
+    outpath=str(FIGURES / "32_cross_layer_summary.png"),
+)
+plt.close(fig)
+print(f"  saved → {FIGURES / '32_cross_layer_summary.png'}")
+
+# ---------------------------------------------------------------------------
+# 5. Divergent features: prot-only vs. RNA-only rhythmic
+# ---------------------------------------------------------------------------
+print("Section 3: Divergent features …")
+
+prot_only = comparison[comparison["rhythmicity_status"] == "lost"]
+rna_only  = comparison[comparison["rhythmicity_status"] == "gained"]
+
+print(f"\n  Rhythmic at protein level only ({len(prot_only)} features):")
+if not prot_only.empty:
+    print(prot_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].head(5).to_string())
+
+print(f"\n  Rhythmic at mRNA level only ({len(rna_only)} features):")
+if not rna_only.empty:
+    print(rna_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].head(5).to_string())
+
+fig, ax = plt.subplots(figsize=(5, 5))
+viz.rhythmicity_shift_scatter(comparison, ax=ax)
+ax.set_xlabel(f"TauMean — {LAYER_LABELS[0]}")
+ax.set_ylabel(f"TauMean — {LAYER_LABELS[1]}")
+ax.set_title("Rhythmicity across molecular layers")
+plt.tight_layout()
+out = FIGURES / "33_cross_layer_rhythmicity_scatter.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# ---------------------------------------------------------------------------
+# 6. Peptide-level workflow: aggregate_to_protein
+#
+# If your proteomics classification result carries a (Peptide, Protein)
+# MultiIndex — for example from running PIRS directly on peptide-level data
+# before protein aggregation — call aggregate_to_protein() to collapse it
+# to one row per protein before comparing.
+#
+# Aggregation rules applied by aggregate_to_protein:
+#   - numeric columns : mean across peptides
+#   - phase_mean      : circular mean (handles wrap-around correctly)
+#   - label           : majority vote across peptides
+#
+# This section constructs a synthetic peptide-level result by expanding the
+# protein-level result and adding per-peptide noise.
+# ---------------------------------------------------------------------------
+print("\nSection 4: aggregate_to_protein workflow …")
+
+rng = np.random.default_rng(42)
+n_pep_per = rng.integers(2, 4, size=len(result_prot))
+
+peptide_result = result_prot.loc[result_prot.index.repeat(n_pep_per)].copy()
+for col in ("tau_mean", "pirs_score"):
+    noise = rng.normal(0, 0.02, size=len(peptide_result))
+    peptide_result[col] = (peptide_result[col].values + noise).clip(min=0)
+
+prot_ids = peptide_result.index
+pep_ids  = [f"pep_{i:04d}" for i in range(len(peptide_result))]
+peptide_result.index = pd.MultiIndex.from_arrays(
+    [pep_ids, prot_ids], names=["Peptide", "Protein"]
+)
+n_prot = peptide_result.index.get_level_values("Protein").nunique()
+print(f"  Peptide-level result: {len(peptide_result)} peptides → {n_prot} proteins")
+
+# Passing peptide-level data to compare_conditions raises a descriptive error:
+try:
+    compare_conditions(peptide_result, result_rna)
+except ValueError as e:
+    print(f"  Raised ValueError as expected:\n    {e}")
+
+# Aggregate to protein level, then compare:
+prot_agg = aggregate_to_protein(peptide_result)
+comparison_from_pep = compare_conditions(prot_agg, result_rna)
+print(f"  aggregate_to_protein + compare_conditions: "
+      f"{len(comparison_from_pep)} features compared successfully")
+
+if "--show" in sys.argv:
+    plt.show()
+
+print(f"\nDone. Figures written to {FIGURES}")

--- a/examples/07_compare_proteomics_vs_expression.py
+++ b/examples/07_compare_proteomics_vs_expression.py
@@ -67,12 +67,12 @@ LAYER_LABELS = ("Proteomics", "RNA-seq")
 # ---------------------------------------------------------------------------
 print("Simulating multi-omic datasets …")
 
-sim_core_prot      = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=20)
-sim_core_rna       = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=21)
-sim_prot_only_rhy  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=22)
+sim_core_prot      = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=20, amp_noise=0.35)
+sim_core_rna       = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=21, amp_noise=0.35)
+sim_prot_only_rhy  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=22, amp_noise=0.35)
 sim_prot_only_flat = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=26)
 sim_rna_only_flat  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=27)
-sim_rna_only_rhy   = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=23)
+sim_rna_only_rhy   = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=23, amp_noise=0.35)
 sim_bg_prot        = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=24)
 sim_bg_rna         = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=25)
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -3,12 +3,47 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from circ.compare import compare_conditions, label_change_table, _circular_diff, _bh_correct
+from circ.compare import (
+    aggregate_to_protein,
+    compare_conditions,
+    label_change_table,
+    _circular_diff,
+    _bh_correct,
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _make_prot_result(rseed=0, with_uncertainty=False, n_proteins=50, peptides_per_protein=3):
+    """Proteomics-style result with a (Peptide, Protein) MultiIndex."""
+    rng = np.random.default_rng(rseed)
+    n = n_proteins * peptides_per_protein
+    proteins = [f'PROT_{p:04d}' for p in range(n_proteins) for _ in range(peptides_per_protein)]
+    peptides = [f'PEP_{i:04d}' for i in range(n)]
+    idx = pd.MultiIndex.from_arrays([peptides, proteins], names=['Peptide', 'Protein'])
+    tau   = rng.uniform(0.0, 1.0, n)
+    emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
+    pirs  = rng.uniform(0.0, 2.0, n)
+    phase = rng.uniform(0.0, 24.0, n)
+    labels = np.where(
+        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
+        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+    )
+    df = pd.DataFrame({
+        'tau_mean':   tau,
+        'emp_p':      emp_p,
+        'pirs_score': pirs,
+        'phase_mean': phase,
+        'label':      labels,
+    }, index=idx)
+    if with_uncertainty:
+        df['tau_std']   = rng.uniform(0.05, 0.2, n)
+        df['phase_std'] = rng.uniform(0.5, 2.0, n)
+        df['n_boots']   = 50
+    return df
+
 
 def _make_result(rseed=0, with_uncertainty=False, n=100, index_prefix='gene'):
     rng = np.random.default_rng(rseed)
@@ -225,6 +260,86 @@ class TestCompareConditions:
         B = _make_result(rseed=1).drop(columns=['phase_mean'])
         result = compare_conditions(A, B)
         assert 'delta_phase' not in result.columns
+
+    def test_raises_for_multiindex_input(self):
+        prot = _make_prot_result(rseed=0)
+        rna  = _make_result(rseed=1)
+        with pytest.raises(ValueError, match='MultiIndex'):
+            compare_conditions(prot, rna)
+
+    def test_raises_for_multiindex_second_arg(self):
+        rna  = _make_result(rseed=0)
+        prot = _make_prot_result(rseed=1)
+        with pytest.raises(ValueError, match='MultiIndex'):
+            compare_conditions(rna, prot)
+
+
+# ---------------------------------------------------------------------------
+# aggregate_to_protein
+# ---------------------------------------------------------------------------
+
+class TestAggregateToProtein:
+    def test_passthrough_flat_index(self):
+        result = _make_result(rseed=0)
+        out = aggregate_to_protein(result)
+        pd.testing.assert_frame_equal(out, result)
+
+    def test_output_indexed_by_protein(self):
+        result = _make_prot_result(rseed=0)
+        out = aggregate_to_protein(result)
+        assert not isinstance(out.index, pd.MultiIndex)
+        assert out.index.name == 'Protein'
+
+    def test_n_rows_equals_n_proteins(self):
+        result = _make_prot_result(rseed=0, n_proteins=20, peptides_per_protein=3)
+        out = aggregate_to_protein(result)
+        assert len(out) == 20
+
+    def test_numeric_columns_averaged(self):
+        result = _make_prot_result(rseed=0, n_proteins=10, peptides_per_protein=2)
+        result = result.copy()
+        result['tau_mean'] = 0.7
+        out = aggregate_to_protein(result)
+        np.testing.assert_allclose(out['tau_mean'].values, 0.7)
+
+    def test_label_majority_vote(self):
+        result = _make_prot_result(rseed=0, n_proteins=1, peptides_per_protein=3)
+        result = result.copy()
+        result.iloc[0, result.columns.get_loc('label')] = 'rhythmic'
+        result.iloc[1, result.columns.get_loc('label')] = 'rhythmic'
+        result.iloc[2, result.columns.get_loc('label')] = 'constitutive'
+        out = aggregate_to_protein(result)
+        assert out.iloc[0]['label'] == 'rhythmic'
+
+    def test_phase_circular_mean(self):
+        """Circular mean of 23 h and 1 h must be near 0 h, not 12 h."""
+        result = _make_prot_result(rseed=0, n_proteins=1, peptides_per_protein=2)
+        result = result.copy()
+        result['phase_mean'] = [23.0, 1.0]
+        out = aggregate_to_protein(result)
+        phase = out['phase_mean'].iloc[0]
+        assert phase < 2.0 or phase > 22.0
+
+    def test_preserves_columns(self):
+        result = _make_prot_result(rseed=0, with_uncertainty=True)
+        out = aggregate_to_protein(result)
+        for col in result.columns:
+            assert col in out.columns
+
+    def test_preserves_column_order(self):
+        result = _make_prot_result(rseed=0, with_uncertainty=True)
+        out = aggregate_to_protein(result)
+        assert list(out.columns) == list(result.columns)
+
+    def test_aggregate_then_compare(self):
+        """Protein-level result after aggregation must work with compare_conditions."""
+        prot = aggregate_to_protein(_make_prot_result(rseed=0, n_proteins=50, peptides_per_protein=2))
+        # Build RNA result sharing some protein IDs
+        prot_ids = list(prot.index[:30])
+        rna = _make_result(rseed=1, n=30)
+        rna.index = pd.Index(prot_ids, name='#')
+        result = compare_conditions(prot, rna)
+        assert len(result) == 30
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `aggregate_to_protein()` to `circ/compare.py` to collapse peptide-level classifier results (with a `(Peptide, Protein)` MultiIndex) to protein level before cross-omics comparison; aggregates numeric columns by mean, `phase_mean` by circular mean, and `label` by majority vote
- Adds validation in `compare_conditions()` that raises a descriptive `ValueError` when a MultiIndex (peptide-level) result is passed directly, guiding users to call `aggregate_to_protein()` first
- Adds example 07 (`examples/07_compare_proteomics_vs_expression.py`) demonstrating the full proteomics-vs-RNA-seq workflow including the peptide-level aggregation path
- Adds tests for `aggregate_to_protein()` and the new MultiIndex guard in `tests/test_compare.py`
- Fixes simulation `amp_noise` in examples 06 and 07: the default `amp_noise=0.75` gave SNR ~1.3 with 8 time points / 2 reps, leaving only 3–8 of the expected 40–60 shared-core features detectable in both layers after FDR correction; lowered to `amp_noise=0.35` (SNR ~2.9) so all shared-core features are reliably detected

## Test plan

- [x] `poetry run pytest tests/test_compare.py -v` — all new `TestAggregateToProtein` tests and `test_raises_for_multiindex_*` pass
- [x] `poetry run python examples/06_compare_conditions.py` — `maintained_rhythmic` count is ~60 (was 8)
- [x] `poetry run python examples/07_compare_proteomics_vs_expression.py` — `maintained_rhythmic` count is ~40, `lost` ~20, `gained` ~20; peptide-level aggregation section completes without error
- [x] Figures written to `figures/` for both examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)