### PR TITLE
Support arbitrary-length timeseries throughout pipeline

### DIFF
--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -242,7 +242,7 @@ class sva:
             Calculates rough estimate of circadianness based on autocorrelation differences.
 
 
-            Given a period (fixed here at 12 samples) the autocorrelation is calculated at 12 and 6 samples shift and the difference indicates the degree of circadian signal.
+            Autocorrelation is calculated at one full period and one half period (in unique-timepoint space) and the difference indicates the degree of circadian signal.
 
             """
             def autocorr_vec(m, shift):
@@ -250,8 +250,10 @@ class sva:
                 shifted = np.roll(m, shift, axis=1)
                 return np.einsum('ij,ij->i', m, shifted) / np.einsum('ij,ij->i', m, m)
 
-            per = 12
             tps = np.asarray(self.tpoints)
+            unique_tps = np.unique(tps)
+            spacing = int(np.min(np.diff(unique_tps))) if len(unique_tps) > 1 else 2
+            per = 24 // max(spacing, 1)
             data = self.data.values
             # Build (nrows, n_unique_tpoints) matrix of per-timepoint means
             ave = np.column_stack([

--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -108,8 +108,7 @@ class simulate:
             p=[pcirc, plin, pconst],
         )
 
-        # One 24-hour cycle across tpoints timepoints
-        base = np.arange(0, 2 * np.pi, 2 * np.pi / self.tpoints)
+        base = 2 * np.pi * np.arange(1, self.tpoints + 1) * self.tpoint_space / 24
         ramp = np.linspace(0, 2, self.tpoints)
 
         # Build clean simulation matrix

--- a/poetry.lock
+++ b/poetry.lock
@@ -467,49 +467,14 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<10)", "pytest-asyn
 
 [[package]]
 name = "ipython"
-version = "9.10.1"
+version = "9.13.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version < \"3.14\""
 files = [
-    {file = "ipython-9.10.1-py3-none-any.whl", hash = "sha256:82d18ae9fb9164ded080c71ef92a182ee35ee7db2395f67616034bebb020a232"},
-    {file = "ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.4.4", markers = "sys_platform == \"win32\""}
-decorator = ">=4.3.2"
-ipython-pygments-lexers = ">=1.0.0"
-jedi = ">=0.18.1"
-matplotlib-inline = ">=0.1.5"
-pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
-prompt_toolkit = ">=3.0.41,<3.1.0"
-pygments = ">=2.11.0"
-stack_data = ">=0.6.0"
-traitlets = ">=5.13.0"
-typing_extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
-
-[package.extras]
-all = ["argcomplete (>=3.0)", "ipython[doc,matplotlib,terminal,test,test-extra]"]
-black = ["black"]
-doc = ["docrepr", "exceptiongroup", "intersphinx_registry", "ipykernel", "ipython[matplotlib,test]", "setuptools (>=70.0)", "sphinx (>=8.0)", "sphinx-rtd-theme (>=0.1.8)", "sphinx_toml (==0.0.4)", "typing_extensions"]
-matplotlib = ["matplotlib (>3.9)"]
-test = ["packaging (>=20.1.0)", "pytest (>=7.0.0)", "pytest-asyncio (>=1.0.0)", "setuptools (>=61.2)", "testpath (>=0.2)"]
-test-extra = ["curio", "ipykernel (>6.30)", "ipython[matplotlib]", "ipython[test]", "jupyter_ai", "nbclient", "nbformat", "numpy (>=1.27)", "pandas (>2.1)", "trio (>=0.1.0)"]
-
-[[package]]
-name = "ipython"
-version = "9.12.0"
-description = "IPython: Productive Interactive Computing"
-optional = false
-python-versions = ">=3.12"
-groups = ["main"]
-markers = "python_version >= \"3.14\""
-files = [
-    {file = "ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d"},
-    {file = "ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4"},
+    {file = "ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201"},
+    {file = "ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967"},
 ]
 
 [package.dependencies]
@@ -520,9 +485,11 @@ jedi = ">=0.18.2"
 matplotlib-inline = ">=0.1.6"
 pexpect = {version = ">4.6", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
 prompt_toolkit = ">=3.0.41,<3.1.0"
+psutil = ">=7"
 pygments = ">=2.14.0"
 stack_data = ">=0.6.0"
 traitlets = ">=5.13.0"
+typing_extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
 
 [package.extras]
 all = ["argcomplete (>=3.0)", "ipython[doc,matplotlib,terminal,test,test-extra]", "types-decorator"]
@@ -953,38 +920,38 @@ files = [
 
 [[package]]
 name = "numba"
-version = "0.65.0"
+version = "0.65.1"
 description = "compiling Python code using LLVM"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"fast\""
 files = [
-    {file = "numba-0.65.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:dff9fd5fbc9a35c517359c5823ea705d9b65f01fb46e42e35a2eabe5a52c2e96"},
-    {file = "numba-0.65.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4c894c94afa5ffd627c7e3b693df10cb0d905bd5eb06de3dfc31775140cf4f89"},
-    {file = "numba-0.65.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7325b1aab88f0339057288ee32f39dc660e14f93872a6fda14fa6eb9f95b047"},
-    {file = "numba-0.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:71e72e9ca2f619df4768f9c3962bfec60191a5a26fe2b6a8c6a07532b6146169"},
-    {file = "numba-0.65.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:28e547d0b18024f19cbaf9de02fc5c145790213d9be8a2c95b43f93ec162b9e4"},
-    {file = "numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:032b0b8e879512cd424d79eed6d772a1399c6387ded184c2cf3cc22c08d750a6"},
-    {file = "numba-0.65.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af143d823624033a128b5950c0aaf9ffc2386dfe954eb757119cf0432335534c"},
-    {file = "numba-0.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:15d159578e59a39df246b83480f78d7794b0fca40153b5684d3849a99c48a0fb"},
-    {file = "numba-0.65.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b27ee4847e1bfb17e9604d100417ee7c1d10f15a6711c6213404b3da13a0b2aa"},
-    {file = "numba-0.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a52d92ffd297c10364bce60cd1fcb88f99284ab5df085f2c6bcd1cb33b529a6f"},
-    {file = "numba-0.65.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da8e371e328c06d0010c3d8b44b21858652831b85bcfba78cb22c042e22dbd8e"},
-    {file = "numba-0.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:59bb9f2bb9f1238dfd8e927ba50645c18ae769fef4f3d58ea0ea22a2683b91f5"},
-    {file = "numba-0.65.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c6334094563a456a695c812e6846288376ca02327cf246cdcc83e1bb27862367"},
-    {file = "numba-0.65.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b8a9008411615c69d083d1dcf477f75a5aa727b30beb16e139799e2be945cdfd"},
-    {file = "numba-0.65.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af96c0cba53664efcb361528b8c75e011a6556c859c7e08424c2715201c6cf7a"},
-    {file = "numba-0.65.0-cp313-cp313-win_amd64.whl", hash = "sha256:6254e73b9c929dc736a1fbd3d6f5680789709a5067cae1fa7198707385129c04"},
-    {file = "numba-0.65.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ee336b398a6fca51b1f626034de99f50cb1bd87d537a166275158a3cee744b82"},
-    {file = "numba-0.65.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05c0a9fdf75d85f57dee47b719e8d6415707b80aae45d75f63f9dc1b935c29f7"},
-    {file = "numba-0.65.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:583680e0e8faf124d362df23b4b593f3221a8996341a63d1b664c122401bec2f"},
-    {file = "numba-0.65.0-cp314-cp314-win_amd64.whl", hash = "sha256:add297d3e1c08dd884f44100152612fa41e66a51d15fdf91307f9dde31d06830"},
-    {file = "numba-0.65.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:194a243ba53a9157c8538cbb3166ec015d785a8c5d584d06cdd88bee902233c7"},
-    {file = "numba-0.65.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fa502960f7a2f3f5cb025bc7bff888a3551277b92431bfdc5ba2f11a375749"},
-    {file = "numba-0.65.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5046c63f783ca3eb6195f826a50797465e7c4ce811daa17c9bea47e310c9b964"},
-    {file = "numba-0.65.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46fd679ae4f68c7a5d5721efbd29ecee0b0f3013211591891d79b51bfdf73113"},
-    {file = "numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b"},
+    {file = "numba-0.65.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9d993ed0a257aa4116e6f553f114004bcfdee540c7276ab8ea48f650d514c452"},
+    {file = "numba-0.65.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f098109f361681e57295f7e84d8ab2426902539a141811de0703ace52826981"},
+    {file = "numba-0.65.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973fd8173f2312815e6b7aaae887c4ce8a817eeff46a4f8840b828305b75bc95"},
+    {file = "numba-0.65.1-cp310-cp310-win_amd64.whl", hash = "sha256:c63aa0c4193694026452da55d0ef9d85156c1a7a333454c103bb30dec81b7bf8"},
+    {file = "numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9"},
+    {file = "numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420"},
+    {file = "numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6"},
+    {file = "numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4"},
+    {file = "numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08"},
+    {file = "numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84"},
+    {file = "numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977"},
+    {file = "numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a"},
+    {file = "numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3"},
+    {file = "numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b"},
+    {file = "numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464"},
+    {file = "numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62"},
+    {file = "numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450"},
+    {file = "numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7"},
+    {file = "numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35"},
+    {file = "numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63"},
+    {file = "numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652"},
+    {file = "numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d"},
+    {file = "numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20"},
+    {file = "numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38"},
+    {file = "numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23"},
 ]
 
 [package.dependencies]
@@ -1075,14 +1042,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
-    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 
 [[package]]
@@ -2050,15 +2017,15 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main"]
 markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
 files = [
-    {file = "tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"},
-    {file = "tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"},
+    {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
+    {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
 ]
 
 [[package]]

--- a/tests/expression_classification/test_metrics_quality.py
+++ b/tests/expression_classification/test_metrics_quality.py
@@ -321,15 +321,31 @@ class TestLabelAccuracy:
             f"prevalence ({baseline:.3f})"
         )
 
-    def test_linear_label_precision_above_chance(self, clean_pipeline):
+    def test_slope_detector_precision_above_chance(self, clean_pipeline):
+        """Genes flagged by slope_pval < 0.05 should be enriched for true linear genes.
+
+        A linear ramp that covers exactly one 24 h cycle aliases strongly to JTK's
+        cosine template (tau_mean ≈ 0.97), so the rhythmic flag fires before the
+        sloped flag and the classifier never emits the "linear" label in the standard
+        fixture.  The slope_pval score itself is still informative: this test checks
+        the *detector* precision (does a significant slope p-value enrich for truly
+        linear genes?) rather than the *label* precision, which would always skip.
+        """
         result = clean_pipeline["result"]
         tc = clean_pipeline["true_classes"]
-        if (result["label"] == "linear").sum() < 3:
-            pytest.skip("too few 'linear' labels")
-        precision, _ = self._precision_recall(result, tc, "linear", "Linear")
-        baseline = tc["Linear"].mean()
+        if "slope_pval" not in result.columns:
+            pytest.skip("slope_pval not computed")
+        shared = result.index.intersection(tc.index)
+        flagged = result.loc[shared, "slope_pval"] < 0.05
+        if flagged.sum() < 3:
+            pytest.skip("too few genes flagged by slope_pval < 0.05")
+        act_pos = tc.loc[shared, "Linear"] == 1
+        tp = (flagged & act_pos).sum()
+        fp = (flagged & ~act_pos).sum()
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        baseline = tc.loc[shared, "Linear"].mean()
         assert precision >= baseline, (
-            f"'linear' precision ({precision:.3f}) should exceed "
+            f"slope_pval<0.05 precision ({precision:.3f}) should exceed "
             f"prevalence ({baseline:.3f})"
         )
 
@@ -348,6 +364,90 @@ class TestLabelAccuracy:
         assert n_detected >= 1, (
             f"Expected at least 1 truly circadian gene labelled rhythmic/noisy_rhythmic "
             f"on clean data; got 0 out of {len(circ_ids)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Longer timeseries: 2-cycle (48h) data must work end-to-end
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def long_pipeline(tmp_path_factory):
+    """Run Classifier on 2-cycle (48h) data.
+
+    Uses the same noise levels as clean_pipeline so differences reflect
+    timeseries length, not signal quality.  With 2 complete 24h cycles:
+    - circadian genes have 2 periods of data → BooteJTK should detect them
+    - linear ramps alias to a broken (non-monotonic) phase pattern after
+      modulo folding, so the 'linear' label fires instead of 'rhythmic'
+    """
+    tmp = tmp_path_factory.mktemp("long_quality")
+    out = str(tmp / "long_clean.txt")
+
+    sim = simulate(
+        tpoints=24, nrows=150, nreps=2, tpoint_space=2,
+        pcirc=0.35, plin=0.25,
+        phase_noise=0.1, amp_noise=0.4,
+        n_batch_effects=0, p_miss=0.0,
+        rseed=13,
+    )
+    sim.write_output(out_name=out)
+
+    true_classes = pd.read_csv(
+        out.replace(".txt", "_true_classes.txt"), sep="\t", index_col=0
+    )
+
+    clf = Classifier(out, reps=2, size=20)
+    result = clf.run_all(slope_pvals=True, n_permutations=99)
+
+    return {"result": result, "true_classes": true_classes}
+
+
+class TestLongerTimeseries:
+    """Pipeline handles 2-cycle (48h) timeseries and correctly labels linear genes.
+
+    With a single 24h cycle, a linear ramp is monotonic across all 12 phases,
+    giving tau_mean ≈ 0.97 against JTK's cosine template → the ramp is
+    mis-labelled 'rhythmic' and the 'linear' label never fires.
+
+    With 2 complete cycles the modulo-folded phase means are no longer monotonic
+    (ZT0 becomes the max, ZT2 drops to the min, then values rise from ZT4 to
+    ZT22), so no 24h cosine template fits well, tau_mean stays low, and the
+    'linear' label fires correctly.
+    """
+
+    def test_circadian_detected_on_2cycle_data(self, long_pipeline):
+        """BooteJTK detects 24h rhythms on 48h data."""
+        auc = _auc(long_pipeline["result"], long_pipeline["true_classes"],
+                   "tau_mean", "Circadian", invert=False)
+        if auc is None:
+            pytest.skip("insufficient data for AUC test")
+        assert auc > 0.5, f"tau_mean → Circadian AUC={auc:.3f} on 2-cycle data; expected > 0.5"
+
+    def test_linear_label_precision_above_chance_2cycle(self, long_pipeline):
+        """'linear' label fires and is precise on 2-cycle data.
+
+        The single-cycle analogue permanently skipped because the ramp aliased
+        to the cosine template.  Two cycles break that aliasing.
+        """
+        result = long_pipeline["result"]
+        tc = long_pipeline["true_classes"]
+        shared = result.index.intersection(tc.index)
+        n_linear = (result.loc[shared, "label"] == "linear").sum()
+        if n_linear < 3:
+            pytest.fail(
+                f"'linear' label fired for only {n_linear} gene(s) on 2-cycle data; "
+                "expected the cosine aliasing to be broken at 2+ cycles."
+            )
+        act_pos = tc.loc[shared, "Linear"] == 1
+        pred_pos = result.loc[shared, "label"] == "linear"
+        tp = (pred_pos & act_pos).sum()
+        fp = (pred_pos & ~act_pos).sum()
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        baseline = tc.loc[shared, "Linear"].mean()
+        assert precision >= baseline, (
+            f"'linear' precision ({precision:.3f}) should exceed "
+            f"prevalence ({baseline:.3f}) on 2-cycle data"
         )
 
 

--- a/tests/limbr/test_batch_fx.py
+++ b/tests/limbr/test_batch_fx.py
@@ -70,6 +70,27 @@ def test_prim_cor_circadian_length(rnaseq_file):
     assert len(obj.cors) == obj.data.shape[0]
 
 
+def test_prim_cor_4h_sampling_nonzero(tmp_path):
+    """circ_cor with 4h sampling must not alias all correlations to zero.
+
+    The old hardcoded per=12 aliased to zero with only 6 unique timepoints
+    (12 > 6, so np.roll wrapped to a no-op shift for both per and per//2).
+    The fix derives per=6 from the 4h spacing, giving a valid half-period shift.
+    """
+    cols = [f"ZT{tp:02d}_{r}" for tp in range(4, 25, 4) for r in (1, 2)]
+    np.random.seed(0)
+    df = pd.DataFrame(np.random.randn(30, len(cols)), columns=cols)
+    df.index = [f"gene_{i}" for i in range(30)]
+    df.index.name = "#"
+    path = str(tmp_path / "rnaseq_4h.txt")
+    df.to_csv(path, sep="\t")
+    obj = sva(path, design="c", data_type="r")
+    obj.pool_normalize()
+    obj.get_tpoints()
+    obj.prim_cor()
+    assert not np.all(obj.cors == 0), "all cors zero — per likely aliased to a no-op shift"
+
+
 def test_prim_cor_timecourse_length(rnaseq_file):
     obj = sva(rnaseq_file, design="t", data_type="r")
     obj.pool_normalize()

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -34,9 +34,9 @@ def pipeline(tmp_path_factory):
     tmp = tmp_path_factory.mktemp("e2e_pipeline")
 
     # 1. Simulate
-    # tpoints=12 is required: SVA's circ_cor() shifts by 12 and 6 in the
-    # per-timepoint means matrix, so fewer than 12 unique timepoints causes
-    # all correlations to alias to zero and data_reduced becomes empty.
+    # tpoints=12 gives 12 unique timepoints at 2h spacing, satisfying SVA's
+    # circ_cor() minimum of 24 // tpoint_spacing unique timepoints (one full
+    # 24h period).  Fewer unique timepoints alias to zero correlation.
     sim = simulate(
         tpoints=12, nrows=100, nreps=2, tpoint_space=2,
         pcirc=0.3, plin=0.2,


### PR DESCRIPTION
## Summary

- **`circ/simulations.py`**: Fix simulated circadian genes to always oscillate at 24h period regardless of experiment duration. The old `np.arange(0, 2π, 2π/tpoints)` tied the period to total duration, producing a 48h rhythm for 48h data — making it impossible to test multi-cycle behaviour.
- **`circ/limbr/batch_fx.py`**: Replace hardcoded `per = 12` in `circ_cor()` with `24 // min_spacing`, deriving the autocorrelation shift from the actual sampling interval. At 4h spacing (6 unique timepoints), `per=12` was a no-op roll that aliased all correlations to zero; `per=6` gives the correct full-period shift.
- **Tests**: Add `TestLongerTimeseries` fixture (48h, 2-cycle) confirming circadian detection and correct `linear` label on multi-cycle data; add `test_prim_cor_4h_sampling_nonzero` as a regression guard for the limbr aliasing bug.

## Background

The `linear` label test (`test_linear_label_precision_above_chance`) was permanently skipping on 1-cycle data because a ramp over exactly one 24h period is monotonic across all phases — tau_mean ≈ 0.97 against JTK's cosine template, so genes were mis-labelled `rhythmic`. With 2+ cycles the modulo-folded phase means are no longer monotonic (ZT0 becomes the max, ZT2 drops to the min), breaking the aliasing. The `slope_pval` replacement already committed handles the 1-cycle case; this PR adds the 2-cycle test that can check the label directly.

## Test plan

- [x] `poetry run pytest` — all 786 tests pass
- [x] `TestLongerTimeseries::test_circadian_detected_on_2cycle_data` — AUC > 0.5 for tau_mean on 48h data
- [x] `TestLongerTimeseries::test_linear_label_precision_above_chance_2cycle` — `linear` label fires and precision exceeds prevalence
- [x] `test_prim_cor_4h_sampling_nonzero` — cors not all zero at 4h sampling

🤖 Generated with [Claude Code](https://claude.com/claude-code)