### PR TITLE
Add type annotations, enforce ruff format, and extend lint coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Lint (ruff)
         run: poetry run ruff check circ/
 
+      - name: Format (ruff)
+        run: poetry run ruff format --check circ/
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/circ/__init__.py
+++ b/circ/__init__.py
@@ -9,6 +9,7 @@ circ.bootjtk               Bootstrap empirical JTK circadian rhythm detection
 circ.expression_classification  Unified PIRS + BooteJTK expression classifier
 circ.compare    Statistical comparison of results between two conditions
 """
+
 from importlib.metadata import version, PackageNotFoundError
 
 try:

--- a/circ/bootjtk/BooteJTK.py
+++ b/circ/bootjtk/BooteJTK.py
@@ -13,23 +13,22 @@ This script bootstraps time series and provides phase and tau distributions from
 Please use ./BooteJTK -h to see the help screen for further instructions on running this script.
 
 """
-VERSION="0.1"
 
-#import cmath
-from scipy.stats import circmean as sscircmean
-from scipy.stats import circstd as sscircstd
-#import scipy.stats as ss
+VERSION = "0.1"
+
+# import cmath
+
+# import scipy.stats as ss
 import numpy as np
-#from scipy.stats import kendalltau as kt
-from scipy.stats import multivariate_normal as mn
+
+# from scipy.stats import kendalltau as kt
 from scipy.stats import rankdata
-from scipy.stats import norm
 from scipy.special import polygamma
 
 import multiprocessing
 import pickle
-#from operator import itemgetter
-import sys
+
+# from operator import itemgetter
 import argparse
 import time
 import os
@@ -41,8 +40,7 @@ from .get_stat_probs import make_references as gsp_make_references
 from .get_stat_probs import rank_references as gsp_rank_references
 from .get_stat_probs import kt
 
-_REF_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ref_files')
-
+_REF_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ref_files")
 
 
 _g_triples = None
@@ -50,13 +48,20 @@ _g_dref = None
 _g_new_header = None
 _g_ref_ranks = None
 
+
 def _init_worker(triples, dref, new_header, ref_ranks):
     global _g_triples, _g_dref, _g_new_header, _g_ref_ranks
-    _g_triples, _g_dref, _g_new_header, _g_ref_ranks = triples, dref, new_header, ref_ranks
+    _g_triples, _g_dref, _g_new_header, _g_ref_ranks = (
+        triples,
+        dref,
+        new_header,
+        ref_ranks,
+    )
+
 
 def _process_gene(args):
     geneID, d_data_item, serie_item, precomputed_dorder, size, fn, waveform = args
-    if fn == 'DEFAULT' or serie_item is None:
+    if fn == "DEFAULT" or serie_item is None:
         mmax = mmin = MAX_AMP = sIQR_FC = smean = sstd = sFC = np.nan
     else:
         mmax, mmin, MAX_AMP = series_char(serie_item)
@@ -77,7 +82,8 @@ def _process_gene(args):
         gene_order_probs = d_op[geneID]
         gene_boots = d_b[geneID]
     out1, out2, d_taugene, d_pergene, d_phgene, d_nagene = gsp_get_stat_probs(
-        dorder, _g_new_header, _g_triples, _g_dref, _g_ref_ranks, size)
+        dorder, _g_new_header, _g_triples, _g_dref, _g_ref_ranks, size
+    )
     out_line = [str(l) for l in [geneID, waveform] + out1 + s_stats + out2]
     return geneID, out_line, d_taugene, d_phgene, gene_order_probs, gene_boots
 
@@ -95,102 +101,114 @@ def main(args):
     fn_phase = args.phase
     fn_width = args.width
     fn_out = args.output
-    fn_out_pkl = args.pickle # This is the output file which could be read in early
-    fn_list = args.id_list # This is the the list of ids to go through
-    fn_null_list = args.null_list # These are geneIDs to be used to estimate the SD
+    fn_out_pkl = args.pickle  # This is the output file which could be read in early
+    fn_list = args.id_list  # This is the the list of ids to go through
+    fn_null_list = args.null_list  # These are geneIDs to be used to estimate the SD
     size = int(args.size)
     reps = int(args.reps)
     write_pickle = args.write
 
-    
     ### If no list file set id_list to empty
-    id_list = read_in_list(fn_list) if fn_list.split('/')[-1]!='DEFAULT' else []
-    null_list = read_in_list(fn_null_list) if fn_null_list.split('/')[-1]!='DEFAULT' else []
-        
+    id_list = read_in_list(fn_list) if fn_list.split("/")[-1] != "DEFAULT" else []
+    null_list = (
+        read_in_list(fn_null_list) if fn_null_list.split("/")[-1] != "DEFAULT" else []
+    )
+
     ### If no pkl out file, modify the option variable
-    opt = 'premade' if os.path.isfile(fn_out_pkl) and fn_out_pkl.split('/')[-1]!='DEFAULT' else ''
+    opt = (
+        "premade"
+        if os.path.isfile(fn_out_pkl) and fn_out_pkl.split("/")[-1] != "DEFAULT"
+        else ""
+    )
 
     ### If not given a new name, name fn_out after the fn file
-    if fn_out.split('/')[-1] == "DEFAULT":
-        endstr = '_{0}_boot{1}-rep{2}.txt'.format(prefix,int(size),int(reps))
-        fn_out = fn.replace('.txt',endstr) if  ".txt" in fn else fn+endstr
+    if fn_out.split("/")[-1] == "DEFAULT":
+        endstr = "_{0}_boot{1}-rep{2}.txt".format(prefix, int(size), int(reps))
+        fn_out = fn.replace(".txt", endstr) if ".txt" in fn else fn + endstr
 
     ### If not given a new name, name fn_out_pkl based on the fn file
-    if fn_out_pkl.split('/')[-1] == 'DEFAULT':
-        endstr = '_{0}_boot{1}-rep{2}_order_probs.pkl'.format(prefix,int(size),int(reps))
-        fn_out_pkl = fn.replace('.txt',endstr) if  ".txt" in fn else fn+endstr
+    if fn_out_pkl.split("/")[-1] == "DEFAULT":
+        endstr = "_{0}_boot{1}-rep{2}_order_probs.pkl".format(
+            prefix, int(size), int(reps)
+        )
+        fn_out_pkl = fn.replace(".txt", endstr) if ".txt" in fn else fn + endstr
 
     ### Name vars file based on pkl out file
-    fn_out_pkl_vars = fn_out_pkl.replace('.pkl','_vars.pkl') 
+    fn_out_pkl_vars = fn_out_pkl.replace(".pkl", "_vars.pkl")
 
-    assert fn.split('/')[-1]!='DEFAULT' or fn_out_pkl.split('/')[-1]!='DEFAULT'   
+    assert fn.split("/")[-1] != "DEFAULT" or fn_out_pkl.split("/")[-1] != "DEFAULT"
 
     ### If we already have the PKL file, we just need a place to put the header information
-    #if fn.split('/')[-1]=='DEFAULT' and fn_out_pkl.split('/')[-1]!='DEFAULT':
+    # if fn.split('/')[-1]=='DEFAULT' and fn_out_pkl.split('/')[-1]!='DEFAULT':
     #    d_series = dict(zip([key for key in d_data_master.keys()],[[]*len(d_data_master)]))
     #    fn_out= fn_out_pkl.replace('.pkl','_{0}-bootejtk.txt'.format(int(size)))
     #    new_header = [0,4,8,12,16,20,0,4,8,12,16,20] if fn_out_pkl[:-4]=='2.pkl' else [0,4,8,12,16,20]
-    ### If we have the initial data we can get it 
-    #elif fn.split('/')[-1]!='DEFAULT':
+    ### If we have the initial data we can get it
+    # elif fn.split('/')[-1]!='DEFAULT':
     ### WE HAVE CHANGED HOW THE DATA GETS PUT IN
 
-    print('Going to read in data now')
+    print("Going to read in data now")
     """ Read in the data """
-    header,data = read_in(fn)
+    header, data = read_in(fn)
     d_series = dict_data(data)
 
-    periods = np.array(read_in_list(fn_period),dtype=int)
+    periods = np.array(read_in_list(fn_period), dtype=int)
     period = float(periods[0])
-    phases = np.array(read_in_list(fn_phase),dtype=int)
-    widths = np.array(read_in_list(fn_width),dtype=int)
+    phases = np.array(read_in_list(fn_phase), dtype=int)
+    widths = np.array(read_in_list(fn_width), dtype=int)
 
-    waveform = 'cosine'
-    
-    if fn_means.split('/')[-1]!='DEFAULT' and fn_sds.split('/')[-1]!='DEFAULT' and fn_ns.split('/')[-1]!='DEFAULT':
-        print('Taking Limma/noreps input')
-        header2,means = read_in(fn_means)
-        _,sds = read_in(fn_sds)
-        _,ns = read_in(fn_ns)
-        d_data_master,new_header = get_data_multi(header,header2,means,sds,ns,period)
+    waveform = "cosine"
+
+    if (
+        fn_means.split("/")[-1] != "DEFAULT"
+        and fn_sds.split("/")[-1] != "DEFAULT"
+        and fn_ns.split("/")[-1] != "DEFAULT"
+    ):
+        print("Taking Limma/noreps input")
+        header2, means = read_in(fn_means)
+        _, sds = read_in(fn_sds)
+        _, ns = read_in(fn_ns)
+        d_data_master, new_header = get_data_multi(
+            header, header2, means, sds, ns, period
+        )
     else:
-        d_data_master,new_header = get_data2(header,data,period)
-        
-        #new_header = list(new_header)*reps
-    
-        if 'premade' not in opt:
-            print('Running internal eBayes')
-            D_null = get_series_data(d_data_master,null_list) if null_list!=[] else {}
-            d_data_master = eBayes(d_data_master,D_null)
-        elif 'premade' in opt:
-            d_data_master,d_order_probs = pickle.load(open(fn_out_pkl,'rb'))
+        d_data_master, new_header = get_data2(header, data, period)
 
-        
+        # new_header = list(new_header)*reps
+
+        if "premade" not in opt:
+            print("Running internal eBayes")
+            D_null = (
+                get_series_data(d_data_master, null_list) if null_list != [] else {}
+            )
+            d_data_master = eBayes(d_data_master, D_null)
+        elif "premade" in opt:
+            d_data_master, d_order_probs = pickle.load(open(fn_out_pkl, "rb"))
+
     def add_on_out(outfile):
         add_on = 1
         while os.path.isfile(outfile):
             print(outfile, "already exists, take evasive action!!!")
-            if '.txt' in outfile:
-                end = '.txt'
-            elif '.pkl' in outfile:
-                end = '.pkl'
-            origstr = end if add_on==1 else '_{0}'.format(add_on-1)+end
-            outfile = outfile.replace(origstr,'_{0}'.format(add_on))+end
+            if ".txt" in outfile:
+                end = ".txt"
+            elif ".pkl" in outfile:
+                end = ".pkl"
+            origstr = end if add_on == 1 else "_{0}".format(add_on - 1) + end
+            outfile = outfile.replace(origstr, "_{0}".format(add_on)) + end
             add_on = add_on + 1
         return outfile
 
-    
     fn_out = add_on_out(fn_out)
     fn_out_pkl = add_on_out(fn_out_pkl)
-    fn_out_pkl_vars = add_on_out(fn_out_pkl_vars)    
+    fn_out_pkl_vars = add_on_out(fn_out_pkl_vars)
 
+    waveform = "cosine"
 
-    waveform = 'cosine'
-
-    triples = gsp_get_waveform_list(periods,phases,widths)
+    triples = gsp_get_waveform_list(periods, phases, widths)
 
     dref = gsp_make_references(new_header, triples, waveform)
     ref_ranks = gsp_rank_references(dref, triples)
-    
+
     d_data_master1 = {}
     d_order_probs_master = {}
     d_boots_master = {}
@@ -203,32 +221,43 @@ def main(args):
     done = []
     remaining = []
 
-    id_list = d_series.keys() if id_list==[] else id_list
+    id_list = d_series.keys() if id_list == [] else id_list
     out_lines = []
 
-    d_order_probs_preloaded = d_order_probs if 'premade' in opt else {}
+    d_order_probs_preloaded = d_order_probs if "premade" in opt else {}
     gene_ids = [geneID for geneID in d_data_master if geneID in id_list]
     gene_args = [
-        (geneID, d_data_master[geneID], d_series.get(geneID),
-         d_order_probs_preloaded.get(geneID),
-         size, fn, waveform)
+        (
+            geneID,
+            d_data_master[geneID],
+            d_series.get(geneID),
+            d_order_probs_preloaded.get(geneID),
+            size,
+            fn,
+            waveform,
+        )
         for geneID in gene_ids
     ]
 
     n_workers = args.workers
     pool_size = n_workers if n_workers > 0 else None
     actual_workers = pool_size or multiprocessing.cpu_count()
-    print(f'Processing {len(gene_ids)} gene(s) with {actual_workers if n_workers != 1 else 1} worker(s)...')
+    print(
+        f"Processing {len(gene_ids)} gene(s) with {actual_workers if n_workers != 1 else 1} worker(s)..."
+    )
     t0 = time.time()
     if n_workers == 1:
         _init_worker(triples, dref, new_header, ref_ranks)
         results = [_process_gene(a) for a in gene_args]
     else:
-        with multiprocessing.Pool(pool_size, initializer=_init_worker,
-                                   initargs=(triples, dref, new_header, ref_ranks)) as pool:
+        with multiprocessing.Pool(
+            pool_size,
+            initializer=_init_worker,
+            initargs=(triples, dref, new_header, ref_ranks),
+        ) as pool:
             chunksize = max(1, len(gene_args) // (actual_workers * 4))
             results = pool.map(_process_gene, gene_args, chunksize=chunksize)
-    print(f'Done in {time.time() - t0:.1f}s')
+    print(f"Done in {time.time() - t0:.1f}s")
 
     for result in results:
         if result is None:
@@ -238,52 +267,56 @@ def main(args):
         done.append(geneID)
         d_tau[geneID] = d_taugene
         d_ph[geneID] = d_phgene
-        if write_pickle and 'premade' not in opt:
+        if write_pickle and "premade" not in opt:
             d_data_master1[geneID] = d_data_master[geneID]
             d_order_probs_master[geneID] = gene_order_probs
             if gene_boots is not None:
                 d_boots_master[geneID] = gene_boots
-            
-    if write_pickle==True: 
-        pickle.dump([d_tau,d_ph],open(fn_out_pkl_vars,'wb'))                    
-        pickle.dump([d_data_master1,d_order_probs_master,d_boots_master],open(fn_out_pkl,'wb'))
-    else:
-        print('Not writing out pickle results')
 
-    taus = [[i,float(out[-2])] for i,out in enumerate(out_lines)]
-    taus = sorted(taus,key=lambda x: np.abs(x[1]),reverse=True)
+    if write_pickle:
+        pickle.dump([d_tau, d_ph], open(fn_out_pkl_vars, "wb"))
+        pickle.dump(
+            [d_data_master1, d_order_probs_master, d_boots_master],
+            open(fn_out_pkl, "wb"),
+        )
+    else:
+        print("Not writing out pickle results")
+
+    taus = [[i, float(out[-2])] for i, out in enumerate(out_lines)]
+    taus = sorted(taus, key=lambda x: np.abs(x[1]), reverse=True)
 
     indexes = np.array([i[0] for i in taus])
 
     out_lines = np.array(out_lines)[np.array(indexes)]
-    g = open(fn_out,'a')
-    g.write("ID\tWaveform\tPeriodMean\tPeriodStdDev\tPhaseMean\tPhaseStdDev\tNadirMean\tNadirStdDev\tMean\tStd_Dev\tMax\tMin\tMax_Amp\tFC\tIQR_FC\tNumBoots\tTauMean\tTauStdDev\n")
+    g = open(fn_out, "a")
+    g.write(
+        "ID\tWaveform\tPeriodMean\tPeriodStdDev\tPhaseMean\tPhaseStdDev\tNadirMean\tNadirStdDev\tMean\tStd_Dev\tMax\tMin\tMax_Amp\tFC\tIQR_FC\tNumBoots\tTauMean\tTauStdDev\n"
+    )
     for out_line in out_lines:
-        g.write("\t".join(out_line)+"\n")
+        g.write("\t".join(out_line) + "\n")
     g.close()
 
-    return fn_out,fn_out_pkl,header
-    
+    return fn_out, fn_out_pkl, header
 
-    
+
 def read_in_EMdata(fn):
-    """Reads in one of the two EM files """
+    """Reads in one of the two EM files"""
     WT = {}
-    with open(fn,'r') as f:
+    with open(fn, "r") as f:
         for line in f:
-            words = line.strip('\n').split()
-            if words[0]=='#':
+            words = line.strip("\n").split()
+            if words[0] == "#":
                 header = words
             else:
                 key = words[0]
                 m = [float(w) for w in words[1:7]]
                 s = [float(s) for s in words[7:]]
-                    
-                WT[key] = [m,s,np.ones(6)*3]
+
+                WT[key] = [m, s, np.ones(6) * 3]
     return WT
 
 
-#def get_SD_distr(dseries,reps,size):
+# def get_SD_distr(dseries,reps,size):
 #    data = np.zeros(size)
 #    for j in xrange(size):
 #        ser = []
@@ -295,15 +328,17 @@ def read_in_EMdata(fn):
 #    return data
 
 
-def append_out(fn_out,line):
+def append_out(fn_out, line):
     line = [str(l) for l in line]
-    with open(fn_out,'a') as g:
-        g.write("\t".join(line)+"\n")
+    with open(fn_out, "a") as g:
+        g.write("\t".join(line) + "\n")
 
-def write_out(fn_out,output):
-    with open(fn_out,'w') as g:
+
+def write_out(fn_out, output):
+    with open(fn_out, "w") as g:
         for line in output:
-            g.write(str(line)+"\n")
+            g.write(str(line) + "\n")
+
 
 def is_number(s):
     try:
@@ -313,19 +348,20 @@ def is_number(s):
 
 
 def read_in_list(fn):
-    with open(fn,'r') as f:
+    with open(fn, "r") as f:
         lines = f.read().splitlines()
     return lines
-        
+
+
 def read_in(fn):
     """Read in data to header and data"""
-    with open(fn,'r') as f:
-        data=[]
-        start_right=0
+    with open(fn, "r") as f:
+        data = []
+        start_right = 0
         for line in f:
             words = line.strip().split()
             words = [word.strip() for word in words]
-            if words[0] == "#" or words[0]=='ID':
+            if words[0] == "#" or words[0] == "ID":
                 start_right = 1
                 header = words[1:]
             else:
@@ -335,6 +371,7 @@ def read_in(fn):
                 elif start_right == 1:
                     data.append(words)
     return header, data
+
 
 def dict_data(data):
     d_series = {}
@@ -348,21 +385,22 @@ def IQR_FC(series):
     qhi = __score_at_percentile__(series, 75)
     if not is_number(qlo) or not is_number(qhi):
         return np.nan
-    elif (qhi==0):
+    elif qhi == 0:
         return 0
-    elif ( qlo==0):
+    elif qlo == 0:
         return np.nan
     else:
-        #print qhi,qlo
-        iqr = qhi/qlo
+        # print qhi,qlo
+        iqr = qhi / qlo
         return iqr
 
+
 def FC(series):
-    series=[float(s) if is_number(s) else 0 for s in series[1:]]
-    if series!=[]:
+    series = [float(s) if is_number(s) else 0 for s in series[1:]]
+    if series != []:
         mmax = max(series)
         mmin = min(series)
-        if mmin==0:
+        if mmin == 0:
             sFC = -10000
         else:
             sFC = mmax / mmin
@@ -373,16 +411,16 @@ def FC(series):
 
 def series_char(series):
     """Uses interquartile range to estimate amplitude of a time series."""
-    series=[float(s) for s in series[1:] if is_number(s)]
-    if series!=[]:
+    series = [float(s) for s in series[1:] if is_number(s)]
+    if series != []:
         mmax = max(series)
         mmin = min(series)
-        diff=mmax-mmin
+        diff = mmax - mmin
     else:
         mmax = "NA"
         mmin = "NA"
         diff = "NA"
-    return mmax,mmin,diff
+    return mmax, mmin, diff
 
 
 def series_mean(series):
@@ -390,61 +428,71 @@ def series_mean(series):
     series = [float(s) for s in series[1:] if is_number(s)]
     return np.mean(series)
 
+
 def series_std(series):
     """Finds the std dev of a timeseries"""
     series = [float(s) for s in series[1:] if is_number(s)]
     return np.std(series)
 
+
 def __score_at_percentile__(ser, per):
     ser = [float(se) for se in ser[1:] if is_number(se)]
-    if len(ser)<5:
-        score ="NA"
+    if len(ser) < 5:
+        score = "NA"
         return score
-    else: 
+    else:
         ser = np.sort(ser)
-        i = int(per/100. * len(ser))
-        if (i % 1 == 0):
+        i = int(per / 100.0 * len(ser))
+        if i % 1 == 0:
             score = ser[i]
         else:
-            interpolate = lambda a,b,frac: a + (b - a)*frac
+            interpolate = lambda a, b, frac: a + (b - a) * frac
             score = interpolate(ser[int(i)], ser[int(i) + 1], i % 1)
         return float(score)
 
-def generate_mod_series(reference,series):
+
+def generate_mod_series(reference, series):
     """
     Takes the series from generate_base_null, takes the list from data, and makes a null
     for each gene in data or uses the one previously calculated.
     Then it runs Kendall's Tau on the exp. series against the null
     """
-    tau,p=kt(series,reference)
+    tau, p = kt(series, reference)
     p = p / 2.0
-    return tau,p
+    return tau, p
+
 
 ##################################
 ### HERE WE INSERT BOOT FUNCTIONS
 ##################################
 
-def get_data(header,data,period):
-    """This function does not use the header information to set the number of replicates """
-    new_h = [float(h[2:].split('_')[0])%period if 'ZT' in h or 'CT' in h else float(h.split('_')[0])%period for h in header]
-    #print new_h
+
+def get_data(header, data, period):
+    """This function does not use the header information to set the number of replicates"""
+    new_h = [
+        float(h[2:].split("_")[0]) % period
+        if "ZT" in h or "CT" in h
+        else float(h.split("_")[0]) % period
+        for h in header
+    ]
+    # print new_h
     length = len(new_h)
     seen = []
     dref = {}
-    for i,h in enumerate(new_h):
+    for i, h in enumerate(new_h):
         if h not in seen:
             seen.append(h)
-            dref[h]=[i]
+            dref[h] = [i]
         else:
             dref[h].append(i)
     d_data = {}
-    #print dref
+    # print dref
     for dat in data:
-        name=dat[0]
+        name = dat[0]
         series = [float(da) if is_number(da) else np.nan for da in dat[1:]]
-        if len(series)==length:
-            out = [[],[],[]]
-            for i,s in enumerate(seen):
+        if len(series) == length:
+            out = [[], [], []]
+            for i, s in enumerate(seen):
                 points = [series[idx] for idx in dref[s]]
                 N = len([p for p in points if not np.isnan(p)])
                 m = np.nanmean(points)
@@ -452,31 +500,36 @@ def get_data(header,data,period):
                 out[0].append(m)
                 out[1].append(std)
                 out[2].append(N)
-            #print name,seen,out
-            d_data[name]=out
-    #print d_data.keys()
-    return d_data,seen
+            # print name,seen,out
+            d_data[name] = out
+    # print d_data.keys()
+    return d_data, seen
 
 
-def get_data2(header,data,period):
-    """ This function uses the header information to set the number of replicates"""
-    new_h = [float(h[2:].split('_')[0])%period if 'ZT' in h or 'CT' in h else float(h.split('_')[0])%period for h in header]
+def get_data2(header, data, period):
+    """This function uses the header information to set the number of replicates"""
+    new_h = [
+        float(h[2:].split("_")[0]) % period
+        if "ZT" in h or "CT" in h
+        else float(h.split("_")[0]) % period
+        for h in header
+    ]
     length = len(new_h)
     seen = []
     dref = {}
-    for i,h in enumerate(new_h):
+    for i, h in enumerate(new_h):
         if h not in seen:
             seen.append(h)
-            dref[h]=[i]
+            dref[h] = [i]
         else:
             dref[h].append(i)
     d_data = {}
     for dat in data:
-        name=dat[0]
+        name = dat[0]
         series = [float(da) if is_number(da) else np.nan for da in dat[1:]]
 
-        out = [[],[],[]]
-        for i,s in enumerate(new_h):
+        out = [[], [], []]
+        for i, s in enumerate(new_h):
             points = [series[idx] for idx in dref[s]]
             N = len([p for p in points if not np.isnan(p)])
             m = np.nanmean(points)
@@ -484,104 +537,126 @@ def get_data2(header,data,period):
             out[0].append(m)
             out[1].append(std)
             out[2].append(N)
-            #print name,seen,out
-        d_data[name]=out
-    #print d_data.keys()
-    return d_data,new_h
+            # print name,seen,out
+        d_data[name] = out
+    # print d_data.keys()
+    return d_data, new_h
 
 
-
-def get_data_multi(header,header2,data,sds,ns,period):
-    """ This function takes in several pre-eBayes files to create the d_data dictionary"""
-    new_h = [float(h[2:].split('_')[0])%period if 'ZT' in h or 'CT' in h else float(h.split('_')[0])%period for h in header]
-    h2 = [float(h[2:].split('_')[0])%period if 'ZT' in h or 'CT' in h else float(h.split('_')[0])%period for h in header2]    
+def get_data_multi(header, header2, data, sds, ns, period):
+    """This function takes in several pre-eBayes files to create the d_data dictionary"""
+    new_h = [
+        float(h[2:].split("_")[0]) % period
+        if "ZT" in h or "CT" in h
+        else float(h.split("_")[0]) % period
+        for h in header
+    ]
+    h2 = [
+        float(h[2:].split("_")[0]) % period
+        if "ZT" in h or "CT" in h
+        else float(h.split("_")[0]) % period
+        for h in header2
+    ]
     length = len(new_h)
     seen = []
     dref = {}
-    for i,h in enumerate(new_h):
+    for i, h in enumerate(new_h):
         seen.append(h2.index(h))
     d_data = {}
-    for j,dat in enumerate(data):
+    for j, dat in enumerate(data):
         g_sds = sds[j]
         g_ns = ns[j]
-        name=dat[0]
+        name = dat[0]
         g_means = [float(da) if is_number(da) else np.nan for da in dat[1:]]
         g_means = [g_means[i] for i in seen]
-        g_sds =   [float(da) if is_number(da) else np.nan for da in g_sds[1:]]
+        g_sds = [float(da) if is_number(da) else np.nan for da in g_sds[1:]]
         g_sds = [g_sds[i] for i in seen]
-        g_ns =   [float(da) if is_number(da) else np.nan for da in g_ns[1:]]
+        g_ns = [float(da) if is_number(da) else np.nan for da in g_ns[1:]]
         g_ns = [g_ns[i] for i in seen]
-        out = [g_means,g_sds,g_ns]
-        d_data[name]=out
+        out = [g_means, g_sds, g_ns]
+        d_data[name] = out
 
-    return d_data,new_h
-
-
+    return d_data, new_h
 
 
-def get_series_data(d_data_master,id_list):
+def get_series_data(d_data_master, id_list):
     d_data = {}
     for key in d_data_master:
         if key in id_list:
             dataset = d_data_master[key]
-            #print key,datase
+            # print key,datase
             N = np.sum(dataset[2])
             length = len(dataset[0])
-            one = 1./N*np.sum([dataset[2][i]*(dataset[1][i]**2+dataset[0][i]**2) for i in range(length)])
-            two = (1./N * np.sum([dataset[2][i]*dataset[0][i] for i in range(length)]))**2
-            std = np.sqrt(one+two)
-            m = 1./N *np.sum([dataset[2][i]*dataset[0][i] for i in range(length)])
-            d_data[key] = [m,std,N]
+            one = (
+                1.0
+                / N
+                * np.sum(
+                    [
+                        dataset[2][i] * (dataset[1][i] ** 2 + dataset[0][i] ** 2)
+                        for i in range(length)
+                    ]
+                )
+            )
+            two = (
+                1.0 / N * np.sum([dataset[2][i] * dataset[0][i] for i in range(length)])
+            ) ** 2
+            std = np.sqrt(one + two)
+            m = 1.0 / N * np.sum([dataset[2][i] * dataset[0][i] for i in range(length)])
+            d_data[key] = [m, std, N]
     return d_data
 
-def eBayes(d_data,D_null={}):
+
+def eBayes(d_data, D_null={}):
     """
     This is based on Smyth 2004 Stat. App. in Gen. and Mol. Biol. 3(1)3
     It generates a dictionary with eBayes adjusted variance values.
     Ns have been set to 1 to not complicate downstream analyses.
     """
-    
-    def get_d0_s0(d_data,D_null):
-        digamma = lambda x: polygamma(0,x)
-        trigamma = lambda x: polygamma(1,x)
-        tetragamma = lambda x: polygamma(2,x)
+
+    def get_d0_s0(d_data, D_null):
+        digamma = lambda x: polygamma(0, x)
+        trigamma = lambda x: polygamma(1, x)
+        tetragamma = lambda x: polygamma(2, x)
 
         def solve_trigamma(x):
             """To solve trigamma(y)=x, x>0"""
-            y0 = 0.5 + 1./x
-            d =1000000.
+            y0 = 0.5 + 1.0 / x
+            d = 1000000.0
             y = y0
-            while -d/y >1e-8:
-                d = trigamma(y)*(1-trigamma(y)/x)/tetragamma(y)
-                y = y+d
+            while -d / y > 1e-8:
+                d = trigamma(y) * (1 - trigamma(y) / x) / tetragamma(y)
+                y = y + d
             return y
 
-        if D_null!={}:
-            dg = np.hstack(np.array(list(D_null.values()))[:,2])
-            s  = np.hstack(np.array(list(D_null.values()))[:,1])
+        if D_null != {}:
+            dg = np.hstack(np.array(list(D_null.values()))[:, 2])
+            s = np.hstack(np.array(list(D_null.values()))[:, 1])
         else:
-            dg = np.hstack(np.array(list(d_data.values()))[:,2])
-            s  = np.hstack(np.array(list(d_data.values()))[:,1])
-        #print D_null.keys()    
-        #print dg,s
+            dg = np.hstack(np.array(list(d_data.values()))[:, 2])
+            s = np.hstack(np.array(list(d_data.values()))[:, 1])
+        # print D_null.keys()
+        # print dg,s
         G = len(d_data)
-        s2 = np.array([ss for ss in s if ss!=0])
-        dg2 = np.array([dg[i] for i,ss in enumerate(s) if ss!=0])
+        s2 = np.array([ss for ss in s if ss != 0])
+        dg2 = np.array([dg[i] for i, ss in enumerate(s) if ss != 0])
         G = len(dg2)
-        z = 2.*np.log(s2)
+        z = 2.0 * np.log(s2)
 
-        e = z - digamma(dg2/2) + np.log(dg2/2)
+        e = z - digamma(dg2 / 2) + np.log(dg2 / 2)
         emean = np.nanmean(e)
-        d0 = 2.* solve_trigamma( np.nanmean( (e-emean)**2 *G/(G-1)-trigamma(dg2/2) )   )
-        s0 = np.sqrt(np.exp(emean + digamma(d0/2)- np.log(d0/2.)))
+        d0 = 2.0 * solve_trigamma(
+            np.nanmean((e - emean) ** 2 * G / (G - 1) - trigamma(dg2 / 2))
+        )
+        s0 = np.sqrt(np.exp(emean + digamma(d0 / 2) - np.log(d0 / 2.0)))
 
-        #print d0,s0
-        return d0,s0
-    def posterior_s(d0,s0,s,d):
-        return np.sqrt( (d0*s0**2 + d*s**2) /(d0+d) )
+        # print d0,s0
+        return d0, s0
 
-    d0,s0=get_d0_s0(d_data,D_null)
-    
+    def posterior_s(d0, s0, s, d):
+        return np.sqrt((d0 * s0**2 + d * s**2) / (d0 + d))
+
+    d0, s0 = get_d0_s0(d_data, D_null)
+
     for key in d_data:
         s_arr = np.array(d_data[key][1], dtype=float)
         d_arr = np.array(d_data[key][2], dtype=float)
@@ -589,31 +664,34 @@ def eBayes(d_data,D_null={}):
         d_data[key][2] = [1] * len(s_arr)
     return d_data
 
-def get_order_prob(d_data,size):
+
+def get_order_prob(d_data, size):
     ### WE WANT TO CHANGE HOW REPS GET INCORPORATED...
     d_order_prob = {}
     d_boots = {}
     for key in d_data:
         res = d_data[key]
-        #print 'res is', res
-        d_order_prob[key],d_boots[key]=dict_of_orders(res[0],res[1],res[2],size)        
-        #d_order_prob[key],d_boots[key]=dict_of_orders(list(res[0])*reps,list(res[1])*reps,list(res[2])*reps,size)
-    return d_order_prob,d_boots
+        # print 'res is', res
+        d_order_prob[key], d_boots[key] = dict_of_orders(res[0], res[1], res[2], size)
+        # d_order_prob[key],d_boots[key]=dict_of_orders(list(res[0])*reps,list(res[1])*reps,list(res[2])*reps,size)
+    return d_order_prob, d_boots
 
-def dict_of_orders(M,SDS,NS,size):
+
+def dict_of_orders(M, SDS, NS, size):
     """
     This produces a dictionary of probabilities
     for the different orders given the data
     """
     index = range(len(M))
-    dorder,s2 = dict_order_probs(M,SDS,NS,size)
+    dorder, s2 = dict_order_probs(M, SDS, NS, size)
     d = {}
     for idx in dorder:
-        d[idx]=dorder[idx]
+        d[idx] = dorder[idx]
     SUM = sum(d.values())
     for key in d:
-        d[key]=d[key]/SUM
-    return d,s2
+        d[key] = d[key] / SUM
+    return d, s2
+
 
 def dict_order_probs(ms, sds, ns, size=100):
     sds = [sd if is_number(sd) else np.nanmean(sds) for sd in sds]
@@ -630,169 +708,227 @@ def dict_order_probs(ms, sds, ns, size=100):
 def __create_parser__():
     p = argparse.ArgumentParser(
         description="Bootstrap empirical JTK_CYCLE (eJTK) for circadian rhythm detection. "
-                    "See Hutchison et al. PLoS Comput Biol 2015 11(3):e1004094.",
+        "See Hutchison et al. PLoS Comput Biol 2015 11(3):e1004094.",
         epilog="Either -f (raw data) or -k (pre-computed pickle) must be supplied.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    p.add_argument('--version', '-V', action='version', version='%(prog)s ' + VERSION)
+    p.add_argument("--version", "-V", action="version", version="%(prog)s " + VERSION)
 
-    p.add_argument("-o", "--output",
-                   dest="output",
-                   action='store',
-                   metavar="FILE",
-                   type=str,
-                   default="DEFAULT",
-                   help="Output filename. Defaults to the input filename with a run-specific suffix.")
+    p.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        action="store",
+        metavar="FILE",
+        type=str,
+        default="DEFAULT",
+        help="Output filename. Defaults to the input filename with a run-specific suffix.",
+    )
 
-    p.add_argument("-k", "--pickle",
-                   dest="pickle",
-                   metavar="FILE",
-                   type=str,
-                   action='store',
-                   default="DEFAULT",
-                   help="Path to a pre-computed bootstrap pickle file. "
-                        "Skips bootstrap generation when provided.")
+    p.add_argument(
+        "-k",
+        "--pickle",
+        dest="pickle",
+        metavar="FILE",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help="Path to a pre-computed bootstrap pickle file. "
+        "Skips bootstrap generation when provided.",
+    )
 
-    p.add_argument("-l", "--list",
-                   dest="id_list",
-                   metavar="FILE",
-                   type=str,
-                   action='store',
-                   default="DEFAULT",
-                   help="File of gene/series IDs to analyse (one per line). "
-                        "Analyses all IDs if omitted.")
+    p.add_argument(
+        "-l",
+        "--list",
+        dest="id_list",
+        metavar="FILE",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help="File of gene/series IDs to analyse (one per line). "
+        "Analyses all IDs if omitted.",
+    )
 
-    p.add_argument("-n", "--null",
-                   dest="null_list",
-                   metavar="FILE",
-                   type=str,
-                   action='store',
-                   default="DEFAULT",
-                   help="File of non-cycling gene IDs used to estimate variance for eBayes shrinkage. "
-                        "Ignored when -k is used.")
+    p.add_argument(
+        "-n",
+        "--null",
+        dest="null_list",
+        metavar="FILE",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help="File of non-cycling gene IDs used to estimate variance for eBayes shrinkage. "
+        "Ignored when -k is used.",
+    )
 
     analysis = p.add_argument_group(title="Analysis options")
 
-    analysis.add_argument("-f", "--filename",
-                          dest="filename",
-                          action='store',
-                          metavar="FILE",
-                          default='DEFAULT',
-                          type=str,
-                          help="Tab-delimited input file. Header row must start with # or ID "
-                               "followed by timepoints in ZTn or CTn format. "
-                               "Use NA for missing values.")
+    analysis.add_argument(
+        "-f",
+        "--filename",
+        dest="filename",
+        action="store",
+        metavar="FILE",
+        default="DEFAULT",
+        type=str,
+        help="Tab-delimited input file. Header row must start with # or ID "
+        "followed by timepoints in ZTn or CTn format. "
+        "Use NA for missing values.",
+    )
 
-    analysis.add_argument("-F", "--means",
-                          dest="means",
-                          action='store',
-                          metavar="FILE",
-                          default='DEFAULT',
-                          type=str,
-                          help="Pre-computed timepoint means file (Limma/no-reps input). "
-                               "Same format as -f.")
+    analysis.add_argument(
+        "-F",
+        "--means",
+        dest="means",
+        action="store",
+        metavar="FILE",
+        default="DEFAULT",
+        type=str,
+        help="Pre-computed timepoint means file (Limma/no-reps input). "
+        "Same format as -f.",
+    )
 
-    analysis.add_argument("-S", "--sds",
-                          dest="sds",
-                          action='store',
-                          metavar="FILE",
-                          default='DEFAULT',
-                          type=str,
-                          help="Pre-computed timepoint standard deviations file (Limma/no-reps input).")
+    analysis.add_argument(
+        "-S",
+        "--sds",
+        dest="sds",
+        action="store",
+        metavar="FILE",
+        default="DEFAULT",
+        type=str,
+        help="Pre-computed timepoint standard deviations file (Limma/no-reps input).",
+    )
 
-    analysis.add_argument("-N", "--ns",
-                          dest="ns",
-                          action='store',
-                          metavar="FILE",
-                          default='DEFAULT',
-                          type=str,
-                          help="Pre-computed timepoint replicate-count file (Limma/no-reps input).")
+    analysis.add_argument(
+        "-N",
+        "--ns",
+        dest="ns",
+        action="store",
+        metavar="FILE",
+        default="DEFAULT",
+        type=str,
+        help="Pre-computed timepoint replicate-count file (Limma/no-reps input).",
+    )
 
-    analysis.add_argument("-W", "--write",
-                          dest="write",
-                          action='store_true',
-                          default=False,
-                          help="Write bootstrap order-probability dictionaries to a pickle file.")
+    analysis.add_argument(
+        "-W",
+        "--write",
+        dest="write",
+        action="store_true",
+        default=False,
+        help="Write bootstrap order-probability dictionaries to a pickle file.",
+    )
 
-    analysis.add_argument('-x', "--prefix",
-                          dest="prefix",
-                          type=str,
-                          metavar="STR",
-                          action='store',
-                          default="",
-                          help="Label inserted into all output filenames for this run.")
+    analysis.add_argument(
+        "-x",
+        "--prefix",
+        dest="prefix",
+        type=str,
+        metavar="STR",
+        action="store",
+        default="",
+        help="Label inserted into all output filenames for this run.",
+    )
 
-    analysis.add_argument('-r', "--reps",
-                          dest="reps",
-                          type=int,
-                          metavar="N",
-                          action='store',
-                          default=2,
-                          help="Replicates per timepoint to bootstrap.")
+    analysis.add_argument(
+        "-r",
+        "--reps",
+        dest="reps",
+        type=int,
+        metavar="N",
+        action="store",
+        default=2,
+        help="Replicates per timepoint to bootstrap.",
+    )
 
-    analysis.add_argument('-z', "--size",
-                          dest="size",
-                          type=int,
-                          metavar="N",
-                          action='store',
-                          default=50,
-                          help="Number of bootstrap resamples per gene.")
+    analysis.add_argument(
+        "-z",
+        "--size",
+        dest="size",
+        type=int,
+        metavar="N",
+        action="store",
+        default=50,
+        help="Number of bootstrap resamples per gene.",
+    )
 
-    analysis.add_argument('-j', '--workers',
-                          dest='workers',
-                          type=int,
-                          metavar='N',
-                          action='store',
-                          default=1,
-                          help='Parallel worker processes. 0 = all available CPUs.')
+    analysis.add_argument(
+        "-j",
+        "--workers",
+        dest="workers",
+        type=int,
+        metavar="N",
+        action="store",
+        default=1,
+        help="Parallel worker processes. 0 = all available CPUs.",
+    )
 
-    analysis.add_argument('-w', "--waveform",
-                          dest="waveform",
-                          type=str,
-                          metavar="STR",
-                          action='store',
-                          default="cosine",
-                          choices=["cosine", "trough", "impulse", "step"],
-                          help="Reference waveform shape to match against.")
+    analysis.add_argument(
+        "-w",
+        "--waveform",
+        dest="waveform",
+        type=str,
+        metavar="STR",
+        action="store",
+        default="cosine",
+        choices=["cosine", "trough", "impulse", "step"],
+        help="Reference waveform shape to match against.",
+    )
 
-    analysis.add_argument("--width", "-a", "--asymmetry",
-                          dest="width",
-                          type=str,
-                          metavar="FILE",
-                          action='store',
-                          default=os.path.join(_REF_DIR, 'asymmetries_02-22_by2.txt'),
-                          help="File listing asymmetry (width) values to search, one per line.")
+    analysis.add_argument(
+        "--width",
+        "-a",
+        "--asymmetry",
+        dest="width",
+        type=str,
+        metavar="FILE",
+        action="store",
+        default=os.path.join(_REF_DIR, "asymmetries_02-22_by2.txt"),
+        help="File listing asymmetry (width) values to search, one per line.",
+    )
 
-    analysis.add_argument('-s', "-ph", "--phase",
-                          dest="phase",
-                          metavar="FILE",
-                          type=str,
-                          default=os.path.join(_REF_DIR, 'phases_00-22_by2.txt'),
-                          help="File listing phases to search (hours), one per line.")
+    analysis.add_argument(
+        "-s",
+        "-ph",
+        "--phase",
+        dest="phase",
+        metavar="FILE",
+        type=str,
+        default=os.path.join(_REF_DIR, "phases_00-22_by2.txt"),
+        help="File listing phases to search (hours), one per line.",
+    )
 
-    analysis.add_argument("-p", "--period",
-                          dest="period",
-                          metavar="FILE",
-                          type=str,
-                          action='store',
-                          default=os.path.join(_REF_DIR, 'period24.txt'),
-                          help="File listing period(s) to search (hours), one per line.")
+    analysis.add_argument(
+        "-p",
+        "--period",
+        dest="period",
+        metavar="FILE",
+        type=str,
+        action="store",
+        default=os.path.join(_REF_DIR, "period24.txt"),
+        help="File listing period(s) to search (hours), one per line.",
+    )
 
     distribution = analysis.add_mutually_exclusive_group(required=False)
-    distribution.add_argument("-e", "--exact",
-                               dest="harding",
-                               action='store_true',
-                               default=False,
-                               help="Use Harding's exact null distribution.")
-    distribution.add_argument("-g", "--gaussian", "--normal",
-                               dest="normal",
-                               action='store_true',
-                               default=False,
-                               help="Use normal approximation to null distribution.")
+    distribution.add_argument(
+        "-e",
+        "--exact",
+        dest="harding",
+        action="store_true",
+        default=False,
+        help="Use Harding's exact null distribution.",
+    )
+    distribution.add_argument(
+        "-g",
+        "--gaussian",
+        "--normal",
+        dest="normal",
+        action="store_true",
+        default=False,
+        help="Use normal approximation to null distribution.",
+    )
 
     return p
-
-
 
 
 def cli():
@@ -801,5 +937,5 @@ def cli():
     main(args)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     cli()

--- a/circ/bootjtk/CalcP.py
+++ b/circ/bootjtk/CalcP.py
@@ -7,96 +7,86 @@ Use ./CalcP.py -h to see usage
 
 Credit for the arbfit code goes to Nablaquabla
 """
+
 import numpy as np
-import matplotlib.pylab as plt
 from .mpfit import mpfit
 
-VERSION="0.9"
+VERSION = "0.9"
 
-from scipy.stats import kendalltau
-from operator import itemgetter
-import numpy as np
 import scipy.stats as ss
-import sys
 import argparse
-import itertools as it
-import time
 from . import arbfit
 import pickle
+
 arbFit = arbfit.arbFit
-#import matplotlib.pyplot as plt
-#import matplotlib.cm as cm
-from scipy.stats import norm
-import os.path
-import scipy.stats as ss
+# import matplotlib.pyplot as plt
+# import matplotlib.cm as cm
 import pandas as pd
 import statsmodels.stats.multitest as ssm
 
-def main(args):
-    #def calcP(fn_jtk,pkl):
 
-    #fn_ser = sys.argv[1]
+def main(args):
+    # def calcP(fn_jtk,pkl):
+
+    # fn_ser = sys.argv[1]
     fn_jtk = args.filename
     fn_pkl = args.null
     fit = args.fit
-    
-    #ser = pd.read_table(fn_ser,index_col=0)
-    #NUM = ser.shape[1]
-    jtk = pd.read_table(fn_jtk,index_col='ID')
 
-    fn_jtk_core = fn_jtk.split('/')[-1] if '/' in fn_jtk else fn_jtk
-    fn_pkl_core = fn_pkl.split('/')[-1] if '/' in fn_pkl else fn_pkl
-    if '.pkl' in fn_pkl:
-        params,taus = pickle.load(open(fn_pkl,'rb'))
+    # ser = pd.read_table(fn_ser,index_col=0)
+    # NUM = ser.shape[1]
+    jtk = pd.read_table(fn_jtk, index_col="ID")
+
+    fn_jtk_core = fn_jtk.split("/")[-1] if "/" in fn_jtk else fn_jtk
+    fn_pkl_core = fn_pkl.split("/")[-1] if "/" in fn_pkl else fn_pkl
+    if ".pkl" in fn_pkl:
+        params, taus = pickle.load(open(fn_pkl, "rb"))
     else:
-        if 'boot' not in fn_pkl_core:
-            taus = pd.read_table(fn_pkl)['Tau']
+        if "boot" not in fn_pkl_core:
+            taus = pd.read_table(fn_pkl)["Tau"]
 
-            keys,intvalues,yerr,p0,limit = prepare(taus)            
+            keys, intvalues, yerr, p0, limit = prepare(taus)
         else:
-            taus = pd.read_table(fn_pkl)['TauMean']
-            keys,intvalues,yerr,p0,limit = prepare(taus)
+            taus = pd.read_table(fn_pkl)["TauMean"]
+            keys, intvalues, yerr, p0, limit = prepare(taus)
         if fit:
             for _ in range(2):
-                params = GammaFit(keys,intvalues,yerr,p0,limit)
+                params = GammaFit(keys, intvalues, yerr, p0, limit)
                 p0 = params[0]
     params = p0
-    gd = ss.gamma(params[0],params[1],params[2])
+    gd = ss.gamma(params[0], params[1], params[2])
 
-
-    if 'boot' not in fn_jtk_core:
-        keys = jtk['Tau']
+    if "boot" not in fn_jtk_core:
+        keys = jtk["Tau"]
     else:
-        keys = jtk['TauMean']
-    #print p0
+        keys = jtk["TauMean"]
+    # print p0
     keys = list(keys)
-    #if 'TauMean' in keys:
-        #print keys.index('TauMean')
-        #print 
-    keys = np.array(list(keys),dtype=float)
+    # if 'TauMean' in keys:
+    # print keys.index('TauMean')
+    # print
+    keys = np.array(list(keys), dtype=float)
 
-    empPs = empP(keys,taus)
-    jtk.loc[:,'empP']=empPs
+    empPs = empP(keys, taus)
+    jtk.loc[:, "empP"] = empPs
 
-    if 'BF' in jtk.columns:
-        empPs = jtk[['BF','empP']].apply(min,axis=1)
-    jtk.loc[:,'empP']=empPs    
-        
+    if "BF" in jtk.columns:
+        empPs = jtk[["BF", "empP"]].apply(min, axis=1)
+    jtk.loc[:, "empP"] = empPs
+
     ps = gd.sf(keys)
-    jtk['GammaP'] = ps
+    jtk["GammaP"] = ps
+
+    ps = jtk[["empP", "GammaP"]].apply(min, axis=1)
+    jtk.loc[:, "GammaP"] = ps
+
+    jtk["GammaBH"] = list(ssm.multipletests(ps, method="fdr_bh")[1])
+
+    fn_out = fn_jtk.replace(".txt", "_GammaP.txt")
+    jtk.to_csv(fn_out, sep="\t", na_rep=np.nan)
 
 
-    ps = jtk[['empP','GammaP']].apply(min,axis=1)
-    jtk.loc[:,'GammaP']=ps
-
-    
-    jtk['GammaBH'] = list(ssm.multipletests(ps,method='fdr_bh')[1])
-    
-    fn_out = fn_jtk.replace('.txt','_GammaP.txt')
-    jtk.to_csv(fn_out,sep='\t',na_rep=np.nan)
-
-    
-def empP(taus,emps):
+def empP(taus, emps):
     taus = np.array(taus)
     emps = np.array(emps)
     ps = (np.sum(emps[None, :] >= taus[:, None], axis=1) + 1) / float(len(emps) + 1)
@@ -105,59 +95,62 @@ def empP(taus,emps):
 
 def prepare(taus):
     i = 0
-    #print NUM
-    #TOT = NUM*(NUM-1)/2
+    # print NUM
+    # TOT = NUM*(NUM-1)/2
     d_hugh = {}
     for tau in taus:
         if tau not in d_hugh:
             d_hugh[tau] = 0
-        d_hugh[tau]+=1
+        d_hugh[tau] += 1
     keys = sorted(d_hugh.keys())
     values = [d_hugh[key] for key in keys]
 
-    #intkeys = [int(np.round((o+1.)/2.*NUM*(NUM-1)/2,0)) for o in keys]
-    intvalues = [v/float(np.sum(values)) for v in values]
-    gd = lambda x,p: ss.gamma(p[0],p[1],p[2]).cdf(x)
-    yerr = [1e-5/(1*i+1)]*(len(intvalues)-sum(np.cumsum(intvalues)>0.9))+[1e-6/(1*i+1)]*sum(np.cumsum(intvalues)>0.9)
+    # intkeys = [int(np.round((o+1.)/2.*NUM*(NUM-1)/2,0)) for o in keys]
+    intvalues = [v / float(np.sum(values)) for v in values]
+    gd = lambda x, p: ss.gamma(p[0], p[1], p[2]).cdf(x)
+    yerr = [1e-5 / (1 * i + 1)] * (len(intvalues) - sum(np.cumsum(intvalues) > 0.9)) + [
+        1e-6 / (1 * i + 1)
+    ] * sum(np.cumsum(intvalues) > 0.9)
 
-    a,b,c = ss.gamma.fit(taus)
-    #a = np.mean(taus)**2/np.var(taus)
-    #b = 1e-8
-    #c = np.var(taus)/(np.mean(taus))
-    p0 = [a,b,c]
-    ind = list(np.cumsum(intvalues)>0.9).index(1)
-    limit = keys[ind]    
-    
-                    
-    return keys,intvalues,yerr,p0,limit
+    a, b, c = ss.gamma.fit(taus)
+    # a = np.mean(taus)**2/np.var(taus)
+    # b = 1e-8
+    # c = np.var(taus)/(np.mean(taus))
+    p0 = [a, b, c]
+    ind = list(np.cumsum(intvalues) > 0.9).index(1)
+    limit = keys[ind]
 
-def GammaFit(x,ydata,yerr,p0,limit):
+    return keys, intvalues, yerr, p0, limit
 
-    gd =  lambda x,p : ss.gamma(p[0],p[1],p[2]).cdf(x)
 
-    #=========================================================================#
+def GammaFit(x, ydata, yerr, p0, limit):
+
+    gd = lambda x, p: ss.gamma(p[0], p[1], p[2]).cdf(x)
+
+    # =========================================================================#
     #     --- 'Magic' happens here ---
-    #=========================================================================#
-    # Create a vectorized function that checks whether a model value 
+    # =========================================================================#
+    # Create a vectorized function that checks whether a model value
     # is larger than a limit set by you. So if the model is smaller than the limit provided
     # the fit function will return the simple chi^2
-    def checkLimit(x,lim,y,model):
-        if x > lim and y<model:
+    def checkLimit(x, lim, y, model):
+        if x > lim and y < model:
             return 1e5
         else:
             return 1.0
+
     checkLimitVectorized = np.vectorize(checkLimit)
 
     # Add a limit=None argument to the fitfunc. The model is your function that you
     # want to fit to the data. In the return statement it now checks for each data
     def fitfunc(p, fjac=None, x=None, y=None, err=None, limit=None):
-        model = gd(x,p)
+        model = gd(x, p)
         status = 0
-        return [status, checkLimitVectorized(x,limit,y,model)*(y-model)/err]
+        return [status, checkLimitVectorized(x, limit, y, model) * (y - model) / err]
 
-    #=========================================================================#
+    # =========================================================================#
     #  Initialize fit info dictionary and try to fit function to data
-    #=========================================================================# 
+    # =========================================================================#
 
     # Create an info dictionary for each parameter in p0
     # If you want to add some bounds to the parameters you can use the limited and
@@ -165,43 +158,43 @@ def GammaFit(x,ydata,yerr,p0,limit):
     # bounds it uses so parinfo[2]['limited'] = [1,0] would mean that p0[2] has a
     # lower bound. parinfo[2]['limits'] = [-10,0] would mean that this lower bound
     # is -10.
-    #print p0
-    parbase1 = {'value':0,'fixed':0,'limited':[1,1],'limits':[0.,1000.]}
-    parbase2 = {'value':0,'fixed':0,'limited':[1,1],'limits':[0.,1000.]}
-    parbase3 = {'value':0,'fixed':0,'limited':[1,1],'limits':[0.,1000.]}
+    # print p0
+    parbase1 = {"value": 0, "fixed": 0, "limited": [1, 1], "limits": [0.0, 1000.0]}
+    parbase2 = {"value": 0, "fixed": 0, "limited": [1, 1], "limits": [0.0, 1000.0]}
+    parbase3 = {"value": 0, "fixed": 0, "limited": [1, 1], "limits": [0.0, 1000.0]}
 
-    parinfo = [parbase1,parbase2,parbase3]
+    parinfo = [parbase1, parbase2, parbase3]
     for i in range(len(p0)):
-        parinfo[i]['value'] = p0[i]
-        parinfo[i]['limits'] = [0.8*p0[i],1.2*p0[i]]
+        parinfo[i]["value"] = p0[i]
+        parinfo[i]["limits"] = [0.8 * p0[i], 1.2 * p0[i]]
 
     # Define the function arguments that you want to pass to your fit. Here you have
     # to adjust the limit keyword properly.
-    #print limit
-    fa = {'x': x, 'y': ydata, 'err': yerr, 'limit': limit}
+    # print limit
+    fa = {"x": x, "y": ydata, "err": yerr, "limit": limit}
 
     # Perform the fit using mpfit
-    #print 'p0 is',p0
-    #print 'fitfunc is',fitfunc
-    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa,quiet=1)
-    #print 'm is', m
+    # print 'p0 is',p0
+    # print 'fitfunc is',fitfunc
+    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa, quiet=1)
+    # print 'm is', m
     # Get degrees of freedom. This assumes that you don't use any bounds on your fit
     # Otherwise you have to substract them from your dof. The -1 takes care of the
     # additional overall limit that you impose on your fit
     dof = len(x) - len(m.params) - 1
 
     # Calculate the fit errors
-    #print 'm.perror is', m.perror
-    #print 'm.fnorm is', m.fnorm
-    #print 'dof is', dof
-    if m.perror==None:
-        m.perror=0
+    # print 'm.perror is', m.perror
+    # print 'm.fnorm is', m.fnorm
+    # print 'dof is', dof
+    if m.perror is None:
+        m.perror = 0
     pcerror = m.perror * np.sqrt(m.fnorm / dof)
 
     # Convert the parameter output to the pars output format from easyfit
-    par = [m.params,m.perror,pcerror]
-    if(m.status <=0):
-        print('status = ', m.status)
+    par = [m.params, m.perror, pcerror]
+    if m.status <= 0:
+        print("status = ", m.status)
     return par
 
 
@@ -209,30 +202,39 @@ def __create_parser__():
     p = argparse.ArgumentParser(
         description="Python script for calculating the p-values generated by empirical JTK_CYCLE with asymmetry search, which is described in Hutchison, Maienschein-Cline, and Chiang et al. Improved statistical methods enable greater sensitivity in rhythm detection for genome-wide data, PLoS Computational Biology 2015 11(3): e1004094. This script was written by Alan L. Hutchison, alanlhutchison@uchicago.edu, Aaron R. Dinner Group, University of Chicago.",
         epilog="Please contact the correpsonding author if you have any questions.",
-        )
-    p.add_argument('--version', '-V', action='version', version='%(prog)s ' + VERSION)
+    )
+    p.add_argument("--version", "-V", action="version", version="%(prog)s " + VERSION)
 
     analysis = p.add_argument_group(title="CalcP analysis options")
 
-    analysis.add_argument("-f", "--filename",
-                   dest="filename",
-                   action='store',
-                   metavar="filename string",
-                   type=str,
-                    help='An output file from eJTK.py containing the time series analyzed')
-    
-    analysis.add_argument("-n", "--null",
-                   dest="null",
-                   action='store',
-                   metavar="null filename string",
-                   type=str,
-                    help='An output file from eJTK.py which is generated from Gaussian noise with the same header (time points) as the time series analyzed and input with the -f flag')
+    analysis.add_argument(
+        "-f",
+        "--filename",
+        dest="filename",
+        action="store",
+        metavar="filename string",
+        type=str,
+        help="An output file from eJTK.py containing the time series analyzed",
+    )
 
-    analysis.add_argument("-t","--fit",
-                          dest="fit",
-                          action='store_true',
-                          default=False,
-                          help="A flag without arguments indicating that the p-value calculation should use the fitting method gauranteed to produce conservative results. THIS FITTING HAS BEEN SHOWN TO BE UNSTABLE IN CERTAIN SITUATIONS AND WILL BE FIXED IN AN UPCOMING VERSION..")
+    analysis.add_argument(
+        "-n",
+        "--null",
+        dest="null",
+        action="store",
+        metavar="null filename string",
+        type=str,
+        help="An output file from eJTK.py which is generated from Gaussian noise with the same header (time points) as the time series analyzed and input with the -f flag",
+    )
+
+    analysis.add_argument(
+        "-t",
+        "--fit",
+        dest="fit",
+        action="store_true",
+        default=False,
+        help="A flag without arguments indicating that the p-value calculation should use the fitting method gauranteed to produce conservative results. THIS FITTING HAS BEEN SHOWN TO BE UNSTABLE IN CERTAIN SITUATIONS AND WILL BE FIXED IN AN UPCOMING VERSION..",
+    )
     return p
 
 
@@ -242,6 +244,5 @@ def cli():
     main(args)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     cli()
-

--- a/circ/bootjtk/arbfit.py
+++ b/circ/bootjtk/arbfit.py
@@ -1,102 +1,112 @@
 # -*- coding: utf-8 -*-
-'''====
+"""====
 Easyfit
 ====
 
 Provides an easy to use wrapper to fit common functions to a data set using the
 Levenberg–Marquardt algorithm provided by mpfit. A full description of the
 suppoerted functions and how to use the wrapper is given in easyfit.fit
-'''
+"""
+
 import numpy as np
 from .mpfit import mpfit
 import warnings
 
 
-def line(x,p):
-    '''Parameter: Slope, Intercept\n
+def line(x, p):
+    """Parameter: Slope, Intercept\n
     Return
     ------
     >>> p[0]*x + p[1]
-    '''
-    return p[0]*x + p[1]
+    """
+    return p[0] * x + p[1]
 
-def line0(x,p):
-    '''Parameter: Slope\n
+
+def line0(x, p):
+    """Parameter: Slope\n
     Return
     ------
     >>> p[0]*x
-    '''
-    return p[0]*x
+    """
+    return p[0] * x
 
-def sine(x,p):
-    '''Parameter: Scale, Wavelength, Phase, Offset\n
+
+def sine(x, p):
+    """Parameter: Scale, Wavelength, Phase, Offset\n
     Return
     ------
     >>> p[0]*np.sin(2*np.pi*x/p[1]+p[2])+p[3]
-    '''
-    return p[0]*np.sin(2*np.pi*x/p[1]+p[2])+p[3]
-    
-def fermi(x,p):
-    '''Parameter: Scale, Edge Position, Width, Offset\n
+    """
+    return p[0] * np.sin(2 * np.pi * x / p[1] + p[2]) + p[3]
+
+
+def fermi(x, p):
+    """Parameter: Scale, Edge Position, Width, Offset\n
     Return
     ------
     >>> p[0]/(np.exp((x-p[1])/p[2])+1)+p[3]
-    '''
-    return p[0]/(np.exp((x-p[1])/p[2])+1)+p[3]
+    """
+    return p[0] / (np.exp((x - p[1]) / p[2]) + 1) + p[3]
 
-def gauss(x,p):
-    '''Parameter: Scale, Mean, Std, Offset\n
+
+def gauss(x, p):
+    """Parameter: Scale, Mean, Std, Offset\n
     Return
     ------
     >>> p[0]*np.exp(-0.5*(x-p[1])**2/p[2]**2)+p[3]
-    '''
-    return p[0]*np.exp(-0.5*(x-p[1])**2/p[2]**2)+p[3]
-    
-def exp(x,p):
-    '''Parameter: Scale, Decay Time, Offset\n
+    """
+    return p[0] * np.exp(-0.5 * (x - p[1]) ** 2 / p[2] ** 2) + p[3]
+
+
+def exp(x, p):
+    """Parameter: Scale, Decay Time, Offset\n
     Return
     ------
     >>> p[0]*np.exp(-x*p[1])+p[2]
-    '''
-    return p[0]*np.exp(-x*p[1])+p[2]
+    """
+    return p[0] * np.exp(-x * p[1]) + p[2]
 
-def poly(x,p,n):
-    '''Parameter: Scale of each power from [0..n]\n
+
+def poly(x, p, n):
+    """Parameter: Scale of each power from [0..n]\n
     Return
     ------
     >>> Sum[n=0,n=N] p[n]*x**n
-    '''
+    """
     y = 0
-    for i in np.arange(n+1, dtype='float64'):
+    for i in np.arange(n + 1, dtype="float64"):
         try:
-            y+=np.power(x,i)*p[i]
+            y += np.power(x, i) * p[i]
         except FloatingPointError:
             print(y)
     return y
 
-def ipoly(x,p,n):
-    '''Parameter: Scale of each power from [0..n]\n
+
+def ipoly(x, p, n):
+    """Parameter: Scale of each power from [0..n]\n
     Return
     ------
     >>> Sum[n=0,n=N] p[n]*x**-n
-    '''
+    """
     y = 0
-    for i in range(n+1):
-        y+=np.power(x,-i)*p[i]
+    for i in range(n + 1):
+        y += np.power(x, -i) * p[i]
     return y
-    
-def plaw(x,p):
-    '''Parameter: Scale, Exponent
+
+
+def plaw(x, p):
+    """Parameter: Scale, Exponent
     Return
     ------
     >>> p[0]*x**p[1]
-    '''
-    return p[0]*x**p[1]
-    
-def fit(typ='line',x=None, y=None, yerr=None,p0=None):
-    '''
+    """
+    return p[0] * x ** p[1]
+
+
+def fit(typ="line", x=None, y=None, yerr=None, p0=None):
+    """
     Takes the data and performs a least square fit of the specified type.
-    
+
     Parameters
     ----------
     typ : string
@@ -120,7 +130,7 @@ def fit(typ='line',x=None, y=None, yerr=None,p0=None):
         Initial guess of fit parameters. If p0 is None all parameters are
         initalized to one or zero depending on the meaning of the individual
         parameter.
-    
+
     Returns
     -------
     x2 : float
@@ -134,9 +144,9 @@ def fit(typ='line',x=None, y=None, yerr=None,p0=None):
         good to justify the scaling of the fit erros. It is pars[2] = pars[1]*
         sqrt(x2)
     xfit,yfit : array_like
-        x and y data that can directly be used within matplotlib or another 
+        x and y data that can directly be used within matplotlib or another
         comparable plotting library to display the fit.
-        
+
     Available functions/fits
     ------------------------
     line
@@ -149,7 +159,7 @@ def fit(typ='line',x=None, y=None, yerr=None,p0=None):
         Sine, parameters: Scaling, Wavelength, Phase, Offset\n
         >>> p[0]*sin(2*Pi*x/p[1]+p[2])+p[3]
     fermi
-        Fermifunction, parameters: Scaling, Edge Position, Width, Offset\n 
+        Fermifunction, parameters: Scaling, Edge Position, Width, Offset\n
         >>> p[0]/(exp((x-p[1])/p[2])+1)+p[3]
     gauss
         Gaussian, parameters: Scaling, Mean, Std, Offset\n
@@ -161,19 +171,19 @@ def fit(typ='line',x=None, y=None, yerr=None,p0=None):
         Power law, parameters: Scaling, Power\n
         >>> p[0]*x**p[1]
     polyN
-        Polynomial of order N. Usage: poly3, poly5, poly10, etc. Parameters: 
+        Polynomial of order N. Usage: poly3, poly5, poly10, etc. Parameters:
         Scalings\n
         >>> Sum[n=0,n=N] p[n]*x**n
     ipolyN
-        Inverse polynomial of order N. Usage: ipoly3, poly5, poly10 etc. 
+        Inverse polynomial of order N. Usage: ipoly3, poly5, poly10 etc.
         Parameters: Scalings\n
         >>> Sum[n=0,n=N] p[n]*x**-n
-        
+
     Example
     -------
-    
+
     The following code snippet explains the use of the easyfit wrapper
-    
+
     >>> import matplotlib.pylab as plt
     >>> import numpy as np
     >>> import easyfit as ef
@@ -187,92 +197,102 @@ def fit(typ='line',x=None, y=None, yerr=None,p0=None):
     >>> plt.scatter(x,y)
     >>> plt.plot(xfit,yfit)
     >>> plt.show()
-    
-    '''
-    #=========================================================================#
+
+    """
+    # =========================================================================#
     #                   Filter Future Warning From Numpy
-    #=========================================================================#
-    warnings.filterwarnings("ignore",category=FutureWarning)
-    
-    #=========================================================================#
+    # =========================================================================#
+    warnings.filterwarnings("ignore", category=FutureWarning)
+
+    # =========================================================================#
     #                           Set default arrays
-    #=========================================================================#
-    n=0
-    if 'ipoly' in typ:
+    # =========================================================================#
+    n = 0
+    if "ipoly" in typ:
         n = int(typ[5:])
-        typ = 'ipoly'
-    elif 'poly' in typ:
+        typ = "ipoly"
+    elif "poly" in typ:
         n = int(typ[4:])
-        typ = 'poly'
-    if x is None: x = np.arange(len(y))
-    if yerr is None: yerr = np.ones(len(y))
+        typ = "poly"
+    if x is None:
+        x = np.arange(len(y))
+    if yerr is None:
+        yerr = np.ones(len(y))
     if p0 is None:
-        if typ == 'line':    p0 = [1,0]
-        elif typ == 'line0': p0 = [1]
-        elif typ == 'sine':  p0 = [1,1,0,0]
-        elif typ == 'fermi': p0 = [1,1,1,0]
-        elif typ == 'gauss': p0 = [1,0,1,0]
-        elif typ == 'exp':   p0 = [1,1,0]
-        elif typ == 'plaw':  p0 = [1,1,0]
-        elif typ == 'poly' or typ == 'ipoly':
-            p0 = [1]*(n+1)
-            
-    #=========================================================================#
+        if typ == "line":
+            p0 = [1, 0]
+        elif typ == "line0":
+            p0 = [1]
+        elif typ == "sine":
+            p0 = [1, 1, 0, 0]
+        elif typ == "fermi":
+            p0 = [1, 1, 1, 0]
+        elif typ == "gauss":
+            p0 = [1, 0, 1, 0]
+        elif typ == "exp":
+            p0 = [1, 1, 0]
+        elif typ == "plaw":
+            p0 = [1, 1, 0]
+        elif typ == "poly" or typ == "ipoly":
+            p0 = [1] * (n + 1)
+
+    # =========================================================================#
     #               Ensure that all given arrays are numpy arrays
-    #=========================================================================#            
+    # =========================================================================#
     x = np.array(x)
     y = np.array(y)
     yerr = np.array(yerr)
     p0 = np.array(p0)
 
-    #=========================================================================#
+    # =========================================================================#
     #                       Setup proper fit function
-    #=========================================================================#
-    models = {'line': line,
-              'line0': line0,
-              'sine': sine,
-              'fermi': fermi,
-              'gauss': gauss,
-              'exp': exp,
-              'plaw': plaw,
-              'poly': lambda x,p: poly(x,p,n),
-              'ipoly': lambda x,p: ipoly(x,p,n)}
+    # =========================================================================#
+    models = {
+        "line": line,
+        "line0": line0,
+        "sine": sine,
+        "fermi": fermi,
+        "gauss": gauss,
+        "exp": exp,
+        "plaw": plaw,
+        "poly": lambda x, p: poly(x, p, n),
+        "ipoly": lambda x, p: ipoly(x, p, n),
+    }
 
-              
     def fitfunc(p, fjac=None, x=None, y=None, err=None):
-        model = models[typ](x,p)
+        model = models[typ](x, p)
         status = 0
-        return [status, (y-model)/err]
+        return [status, (y - model) / err]
 
-    #=========================================================================#
+    # =========================================================================#
     #  Initialize fit info dictionary and try to fit function to data
-    #=========================================================================#    
-    parbase = {'value':0,'fixed':0,'limited':[0,0],'limits':[0.,0.]}
-    parinfo = [parbase]*len(p0)
+    # =========================================================================#
+    parbase = {"value": 0, "fixed": 0, "limited": [0, 0], "limits": [0.0, 0.0]}
+    parinfo = [parbase] * len(p0)
     for i in range(len(p0)):
-        parinfo[i]['value'] = p0[i]
-    fa = {'x': x, 'y': y, 'err': yerr}
-    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa,quiet=1)
+        parinfo[i]["value"] = p0[i]
+    fa = {"x": x, "y": y, "err": yerr}
+    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa, quiet=1)
     dof = len(x) - len(m.params)
     pcerror = m.perror * np.sqrt(m.fnorm / dof)
-    par = [m.params,m.perror,pcerror]
-    if(m.status <=0):
-        print('status = ', m.status)
+    par = [m.params, m.perror, pcerror]
+    if m.status <= 0:
+        print("status = ", m.status)
 
-    #=========================================================================#
+    # =========================================================================#
     #    Calculate goodness of fit and an easy to plot fitted data set
-    #=========================================================================#
-    x2 = m.fnorm/dof
-    xfit = np.linspace(np.min(x),np.max(x),1000)
-    yfit = models[typ](xfit,par[0])
-    
-    return x2,par,xfit,yfit
-    
-    
-def arbFit(fct=line,x=None, y=None, yerr=None,p0=None):
-    '''
+    # =========================================================================#
+    x2 = m.fnorm / dof
+    xfit = np.linspace(np.min(x), np.max(x), 1000)
+    yfit = models[typ](xfit, par[0])
+
+    return x2, par, xfit, yfit
+
+
+def arbFit(fct=line, x=None, y=None, yerr=None, p0=None):
+    """
     Takes the data and performs a least square fit of the specified type.
-    
+
     Parameters
     ----------
     typ : function
@@ -296,7 +316,7 @@ def arbFit(fct=line,x=None, y=None, yerr=None,p0=None):
         Initial guess of fit parameters. If p0 is None all parameters are
         initalized to one or zero depending on the meaning of the individual
         parameter.
-    
+
     Returns
     -------
     x2 : float
@@ -310,13 +330,13 @@ def arbFit(fct=line,x=None, y=None, yerr=None,p0=None):
         good to justify the scaling of the fit erros. It is pars[2] = pars[1]*
         sqrt(x2)
     xfit,yfit : array_like
-        x and y data that can directly be used within matplotlib or another 
+        x and y data that can directly be used within matplotlib or another
         comparable plotting library to display the fit.
     Example
     -------
-    
+
     The following code snippet explains the use of the easyfit wrapper
-    
+
     >>> import matplotlib.pylab as plt
     >>> import numpy as np
     >>> import easyfit as ef
@@ -333,60 +353,62 @@ def arbFit(fct=line,x=None, y=None, yerr=None,p0=None):
     >>> plt.scatter(x,y)
     >>> plt.plot(xfit,yfit)
     >>> plt.show()
-    
-    '''
-    #=========================================================================#
+
+    """
+    # =========================================================================#
     #                   Filter Future Warning From Numpy
-    #=========================================================================#
-    warnings.filterwarnings("ignore",category=FutureWarning)
-    
-    #=========================================================================#
+    # =========================================================================#
+    warnings.filterwarnings("ignore", category=FutureWarning)
+
+    # =========================================================================#
     #                           Set default arrays
-    #=========================================================================#
-    if x is None: x = np.arange(len(y))
-    if yerr is None: yerr = np.ones(len(y))
+    # =========================================================================#
+    if x is None:
+        x = np.arange(len(y))
+    if yerr is None:
+        yerr = np.ones(len(y))
     if p0 is None:
         p0 = np.ones(100)
-            
-    #=========================================================================#
+
+    # =========================================================================#
     #               Ensure that all given arrays are numpy arrays
-    #=========================================================================#            
+    # =========================================================================#
     x = np.array(x)
     y = np.array(y)
     yerr = np.array(yerr)
     p0 = np.array(p0)
 
-    #=========================================================================#
+    # =========================================================================#
     #                       Setup proper fit function
-    #=========================================================================#
+    # =========================================================================#
     def fitfunc(p, fjac=None, x=None, y=None, err=None):
-        model = fct(x,p)
+        model = fct(x, p)
         status = 0
-        return [status, (y-model)/err]
+        return [status, (y - model) / err]
 
-    #=========================================================================#
+    # =========================================================================#
     #  Initialize fit info dictionary and try to fit function to data
-    #=========================================================================#    
-    parbase = {'value':0,'fixed':0,'limited':[0,0],'limits':[0.,0.]}
-    parinfo = [parbase]*len(p0)
+    # =========================================================================#
+    parbase = {"value": 0, "fixed": 0, "limited": [0, 0], "limits": [0.0, 0.0]}
+    parinfo = [parbase] * len(p0)
     for i in range(len(p0)):
-        parinfo[i]['value'] = p0[i]
-    fa = {'x': x, 'y': y, 'err': yerr}
-    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa,quiet=1)
+        parinfo[i]["value"] = p0[i]
+    fa = {"x": x, "y": y, "err": yerr}
+    m = mpfit(fitfunc, p0, parinfo=parinfo, functkw=fa, quiet=1)
     dof = len(x) - len(m.params)
     if m.perror is None:
-        pcerror=None
+        pcerror = None
     else:
         pcerror = m.perror * np.sqrt(m.fnorm / dof)
-    par = [m.params,m.perror,pcerror]
-    if(m.status <=0):
-        print('status = ', m.status)
+    par = [m.params, m.perror, pcerror]
+    if m.status <= 0:
+        print("status = ", m.status)
 
-    #=========================================================================#
+    # =========================================================================#
     #    Calculate goodness of fit and an easy to plot fitted data set
-    #=========================================================================#
-    x2 = m.fnorm/dof
-    xfit = np.linspace(np.min(x),np.max(x),1000)
-    yfit = fct(xfit,par[0])
-    
-    return x2,par,xfit,yfit
+    # =========================================================================#
+    x2 = m.fnorm / dof
+    xfit = np.linspace(np.min(x), np.max(x), 1000)
+    yfit = fct(xfit, par[0])
+
+    return x2, par, xfit, yfit

--- a/circ/bootjtk/get_stat_probs.py
+++ b/circ/bootjtk/get_stat_probs.py
@@ -6,11 +6,13 @@ import numpy as np
 
 try:
     import numba as _numba
+
     _NUMBA = True
 except ImportError:
     _NUMBA = False
 
 if _NUMBA:
+
     @_numba.njit(cache=True)
     def _batch_tau_nb(kkey_arr, ref_ranks):
         """Tau-b of kkey_arr (T,) against every row of ref_ranks (N, T) → (N,)."""
@@ -38,15 +40,15 @@ if _NUMBA:
                         else:
                             d += 1
             denom = nx * ny_i
-            taus[i] = (c - d) / (denom ** 0.5) if denom > 0 else 0.0
+            taus[i] = (c - d) / (denom**0.5) if denom > 0 else 0.0
         return taus
 
 
 def _batch_tau_numpy(kkey_arr, ref_ranks):
     """Vectorized tau-b fallback: kkey_arr (T,) vs ref_ranks (N, T) → (N,)."""
-    sx = np.sign(kkey_arr[:, None] - kkey_arr[None, :])              # (T, T)
-    sy = np.sign(ref_ranks[:, :, None] - ref_ranks[:, None, :])       # (N, T, T)
-    num = np.einsum('ij,nij->n', sx, sy) / 2.0                        # (N,)
+    sx = np.sign(kkey_arr[:, None] - kkey_arr[None, :])  # (T, T)
+    sy = np.sign(ref_ranks[:, :, None] - ref_ranks[:, None, :])  # (N, T, T)
+    num = np.einsum("ij,nij->n", sx, sy) / 2.0  # (N,)
     nx = float(np.count_nonzero(sx)) / 2.0
     ny = np.count_nonzero(sy.reshape(len(ref_ranks), -1), axis=1).astype(float) / 2.0
     denom = np.sqrt(nx * ny)
@@ -92,15 +94,17 @@ def get_stat_probs(dorder, new_header, triples, dref, ref_ranks, size):
         phase_col = np.where(neg_mask, nadirs, phases)
         nadir_col = np.where(neg_mask, phases, nadirs)
 
-        res = np.column_stack([
-            abs_taus,
-            np.zeros(len(triples)),
-            periods,
-            phase_col,
-            nadir_col,
-            np.full(len(triples), maxloc),
-            np.full(len(triples), minloc),
-        ])
+        res = np.column_stack(
+            [
+                abs_taus,
+                np.zeros(len(triples)),
+                periods,
+                phase_col,
+                nadir_col,
+                np.full(len(triples), maxloc),
+                np.full(len(triples), minloc),
+            ]
+        )
 
         r = pick_best_match(res)
         d_taugene[r[0]] = d_taugene.get(r[0], 0) + dorder[kkey]
@@ -108,7 +112,7 @@ def get_stat_probs(dorder, new_header, triples, dref, ref_ranks, size):
         d_phgene[r[3]] = d_phgene.get(r[3], 0) + dorder[kkey]
         d_nagene[r[4]] = d_nagene.get(r[4], 0) + dorder[kkey]
         count = counts[kkey]
-        rs[rs_idx:rs_idx + count] = r
+        rs[rs_idx : rs_idx + count] = r
         rs_idx += count
     m_tau = np.mean(rs[:, 0])
     s_tau = np.std(rs[:, 0])
@@ -118,30 +122,37 @@ def get_stat_probs(dorder, new_header, triples, dref, ref_ranks, size):
     s_ph = sscircstd(rs[:, 3], high=24, low=0)
     m_na = sscircmean(rs[:, 4], high=24, low=0)
     s_na = sscircstd(rs[:, 4], high=24, low=0)
-    return [m_per, s_per, m_ph, s_ph, m_na, s_na], [m_tau, s_tau], d_taugene, d_pergene, d_phgene, d_nagene
+    return (
+        [m_per, s_per, m_ph, s_ph, m_na, s_na],
+        [m_tau, s_tau],
+        d_taugene,
+        d_pergene,
+        d_phgene,
+        d_nagene,
+    )
 
 
-def generate_base_reference(header, waveform="cosine", period=24., phase=0., width=12.):
+def generate_base_reference(
+    header, waveform="cosine", period=24.0, phase=0.0, width=12.0
+):
     ZTs = np.array(header, dtype=float)
     coef = 2.0 * np.pi / period
     w = (width * coef) % (2.0 * np.pi)
     tpoints = ((ZTs - phase) * coef) % (2.0 * np.pi)
-    if waveform == 'cosine':
+    if waveform == "cosine":
         return np.where(
             tpoints <= w,
             np.cos(tpoints / (w / np.pi)),
-            np.cos((tpoints + 2.0 * (np.pi - w)) * np.pi / (2.0 * np.pi - w))
+            np.cos((tpoints + 2.0 * (np.pi - w)) * np.pi / (2.0 * np.pi - w)),
         )
-    elif waveform == 'trough':
+    elif waveform == "trough":
         return np.where(
-            tpoints <= w,
-            1.0 - tpoints / w,
-            (tpoints - w) / (2.0 * np.pi - w)
+            tpoints <= w, 1.0 - tpoints / w, (tpoints - w) / (2.0 * np.pi - w)
         )
-    elif waveform == 'impulse':
+    elif waveform == "impulse":
         d = np.minimum(tpoints, np.abs(2.0 * np.pi - tpoints))
         return np.maximum(-2.0 * d / (3.0 * np.pi / 4.0) + 1.0, 0.0)
-    elif waveform == 'step':
+    elif waveform == "step":
         return np.where(tpoints < np.pi, 1.0, 0.0)
 
 
@@ -152,28 +163,28 @@ def farctanh(x):
 def periodic(x):
     x = float(x)
     while x > 12:
-        x -= 24.
+        x -= 24.0
     while x <= -12:
-        x += 24.
+        x += 24.0
     return x
 
 
 def pick_best_match(res):
     res = np.array(res)
     taus = res[:, 0]
-    tau_mask = (max(taus) == taus)
+    tau_mask = max(taus) == taus
     if np.sum(tau_mask) == 1:
         return res[int(np.argmax(tau_mask))]
 
     res = res[tau_mask]
     phases = np.abs(res[:, 3] - res[:, 5])
-    phasemask = (min(phases) == phases)
+    phasemask = min(phases) == phases
     if np.sum(phasemask) == 1:
         return res[int(np.argmax(phasemask))]
 
     res = res[phasemask]
     diffs = np.abs(res[:, 4] - res[:, 6])
-    diffmask = (min(diffs) == diffs)
+    diffmask = min(diffs) == diffs
     if np.sum(diffmask) == 1:
         return res[int(np.argmax(diffmask))]
 
@@ -195,7 +206,7 @@ def get_waveform_list(periods, phases, widths):
     return np.array(triples, dtype=float)
 
 
-def make_references(new_header, triples, waveform='cosine'):
+def make_references(new_header, triples, waveform="cosine"):
     dref = {}
     for triple in triples:
         period, phase, width = triple

--- a/circ/bootjtk/limma_preprocess.py
+++ b/circ/bootjtk/limma_preprocess.py
@@ -4,9 +4,9 @@ Handles reading TSV files, parsing ZT/CT time-point labels, deduplicating
 row/column names, and writing pivoted output files — the data plumbing that
 was previously embedded in the R scripts.
 """
+
 import re
 import pandas as pd
-import numpy as np
 
 
 def read_timeseries(fn):
@@ -19,12 +19,12 @@ def read_timeseries(fn):
         raw_cols -- list of raw column-header strings (e.g. ['ZT0', 'ZT2', ...])
     """
     with open(fn) as f:
-        raw_cols = f.readline().rstrip('\n').split('\t')[1:]
+        raw_cols = f.readline().rstrip("\n").split("\t")[1:]
     try:
-        df = pd.read_table(fn, index_col='ID')
+        df = pd.read_table(fn, index_col="ID")
     except (ValueError, KeyError):
         df = pd.read_table(fn, index_col=0)
-    df = df.apply(pd.to_numeric, errors='coerce')
+    df = df.apply(pd.to_numeric, errors="coerce")
     return df, raw_cols
 
 
@@ -40,10 +40,10 @@ def parse_timepoint_label(label):
     >>> parse_timepoint_label('0')
     0.0
     """
-    label = re.sub(r'^X', '', str(label).strip())
-    label = re.sub(r'^ZT', '', label)
-    label = re.sub(r'^CT', '', label)
-    label = label.split('_')[0]
+    label = re.sub(r"^X", "", str(label).strip())
+    label = re.sub(r"^ZT", "", label)
+    label = re.sub(r"^CT", "", label)
+    label = label.split("_")[0]
     return float(label)
 
 
@@ -88,7 +88,7 @@ def deduplicate_rownames(rownames):
         new = []
         for name in rownames:
             if name in seen:
-                new.append(f'{name}-xxx{counter}')
+                new.append(f"{name}-xxx{counter}")
             else:
                 seen[name] = True
                 new.append(name)
@@ -110,11 +110,9 @@ def prepare_timeseries(fn, period):
         unique_times -- sorted list of unique time points mod period
     """
     df, raw_cols = read_timeseries(fn)
-    times = deduplicate_timepoints(
-        [parse_timepoint_label(c) for c in raw_cols], period
-    )
+    times = deduplicate_timepoints([parse_timepoint_label(c) for c in raw_cols], period)
     df.columns = pd.Index(times, dtype=float)
-    df.index = pd.Index(deduplicate_rownames(list(df.index)), name='ID')
+    df.index = pd.Index(deduplicate_rownames(list(df.index)), name="ID")
     unique_times = sorted({t % period for t in times})
     return df, unique_times
 
@@ -133,7 +131,12 @@ def write_limma_outputs(long_df, prefix, suffix):
         prefix  -- output path prefix (e.g. '/path/to/sample')
         suffix  -- output suffix (e.g. 'postLimma' or 'postVash')
     """
-    for col, name in [('Mean', 'Means'), ('SD', 'Sds'), ('N', 'Ns'), ('SDpre', 'Sds-pre')]:
-        wide = long_df.pivot(index='ID', columns='Time', values=col)
+    for col, name in [
+        ("Mean", "Means"),
+        ("SD", "Sds"),
+        ("N", "Ns"),
+        ("SDpre", "Sds-pre"),
+    ]:
+        wide = long_df.pivot(index="ID", columns="Time", values=col)
         wide.columns.name = None
-        wide.to_csv(f'{prefix}_{name}_{suffix}.txt', sep='\t', na_rep='NA')
+        wide.to_csv(f"{prefix}_{name}_{suffix}.txt", sep="\t", na_rep="NA")

--- a/circ/bootjtk/limma_voom.py
+++ b/circ/bootjtk/limma_voom.py
@@ -20,6 +20,7 @@ Both return a long-format DataFrame with columns:
     ID, Time, Mean, SD, SDpre, N
 which is the format expected by ``limma_preprocess.write_limma_outputs``.
 """
+
 import warnings
 
 import numpy as np
@@ -30,6 +31,7 @@ from scipy.special import polygamma
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _timepoint_groups(df, period):
     """Yield (time_mod_period, column_subset) for each unique ZT bucket."""
@@ -90,9 +92,9 @@ def _estimate_prior(sds, dfs):
     if len(s) < 3:
         return 0.0, fallback_s0
 
-    dg_fn  = lambda x: polygamma(0, x)   # digamma
-    tg_fn  = lambda x: polygamma(1, x)   # trigamma
-    ttg_fn = lambda x: polygamma(2, x)   # tetragamma
+    dg_fn = lambda x: polygamma(0, x)  # digamma
+    tg_fn = lambda x: polygamma(1, x)  # trigamma
+    ttg_fn = lambda x: polygamma(2, x)  # tetragamma
 
     def _solve_trigamma(x):
         """Solve trigamma(y) = x via Newton iteration (x > 0)."""
@@ -136,6 +138,7 @@ def _posterior_sd(sd_pre, dfs, d0, s0):
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def run_vooma_ebayes(df_wide, period, rnaseq=False):
     """
     Python equivalent of ``Limma_voom_core.R``.
@@ -161,17 +164,17 @@ def run_vooma_ebayes(df_wide, period, rnaseq=False):
     """
     long = _vooma_stats(df_wide, period)
     d0, s0 = _estimate_prior(long["sd_pre"].to_numpy(), long["df"].to_numpy())
-    long["SD"] = _posterior_sd(
-        long["sd_pre"].to_numpy(), long["df"].to_numpy(), d0, s0
+    long["SD"] = _posterior_sd(long["sd_pre"].to_numpy(), long["df"].to_numpy(), d0, s0)
+    return pd.DataFrame(
+        {
+            "ID": long["gene"].to_numpy(),
+            "Time": long["time"].to_numpy(),
+            "Mean": long["mean"].to_numpy(),
+            "SD": long["SD"].to_numpy(),
+            "SDpre": long["sd_pre"].to_numpy(),
+            "N": long["n"].to_numpy(),
+        }
     )
-    return pd.DataFrame({
-        "ID":    long["gene"].to_numpy(),
-        "Time":  long["time"].to_numpy(),
-        "Mean":  long["mean"].to_numpy(),
-        "SD":    long["SD"].to_numpy(),
-        "SDpre": long["sd_pre"].to_numpy(),
-        "N":     long["n"].to_numpy(),
-    })
 
 
 def _impute_na(df):

--- a/circ/bootjtk/mpfit.py
+++ b/circ/bootjtk/mpfit.py
@@ -9,7 +9,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
   IDL version is:
      Craig B. Markwardt, NASA/GSFC Code 662, Greenbelt, MD 20770
      craigm@lheamail.gsfc.nasa.gov
-     UPDATED VERSIONs can be found on my WEB PAGE: 
+     UPDATED VERSIONs can be found on my WEB PAGE:
         http://cow.physics.wisc.edu/~craigm/idl/idl.html
 
   Mark Rivers created this Python version from Craig's IDL version.
@@ -59,7 +59,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  MPFITEXPR, which are driver functions that calculate the deviates
  for you.  If ERR are the 1-sigma uncertainties in Y, then
 
-   TOTAL( DEVIATES^2 ) 
+   TOTAL( DEVIATES^2 )
 
  will be the total chi-squared value.  MPFIT will minimize the
  chi-square value.  The values of X, Y and ERR are passed through
@@ -129,7 +129,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
     # Parameter values are passed in "p"
     # If FJAC!=None then partial derivatives must be comptuer.
     # FJAC contains an array of len(p), where each entry
-    # is 1 if that parameter is free and 0 if it is fixed. 
+    # is 1 if that parameter is free and 0 if it is fixed.
     model = F(x, p)
     Non-negative status value means MPFIT should continue, negative means
     # stop the calculation.
@@ -146,12 +146,12 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  derivative of the model with respect to parameter P[i] at X.  When
  finite differencing is used for computing derivatives (ie, when
  AUTODERIVATIVE=1), or when MPFIT needs only the errors but not the
- derivatives the parameter FJAC=None.  
+ derivatives the parameter FJAC=None.
 
  Derivatives should be returned in the PDERIV array. PDERIV should be an m x
  n array, where m is the number of data points and n is the number
  of parameters.  dp[i,j] is the derivative at the ith point with
- respect to the jth parameter.  
+ respect to the jth parameter.
 
  The derivatives with respect to fixed parameters are ignored; zero
  is an appropriate value to insert for those derivatives.  Upon
@@ -341,7 +341,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    above.  This can be substituted back into eqn (2) after computing
    the derivatives:
 
-       f'  = 2 Sum(hi  hi')     
+       f'  = 2 Sum(hi  hi')
        f'' = 2 Sum(hi' hj') + 2 Sum(hi hi'')                (4)
 
    If one assumes that the parameters are already close enough to a
@@ -381,7 +381,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
                                  REFERENCES
 
    MINPACK-1, Jorge More', available from netlib (www.netlib.org).
-   "Optimization Software Guide," Jorge More' and Stephen Wright, 
+   "Optimization Software Guide," Jorge More' and Stephen Wright,
      SIAM, *Frontiers in Applied Mathematics*, Number 14.
    More', Jorge J., "The Levenberg-Marquardt Algorithm:
      Implementation and Theory," in *Numerical Analysis*, ed. Watson,
@@ -402,9 +402,8 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 """
 
 import numpy
-import types
 
-
+
 #     Original FORTRAN documentation
 #     **********
 #
@@ -586,1671 +585,1845 @@ import types
 #     burton s. garbow, kenneth e. hillstrom, jorge j. more
 #
 #     **********
-
+
+
 class mpfit:
-   def __init__(self, fcn, xall=None, functkw={}, parinfo=None,
-                ftol=1.e-10, xtol=1.e-10, gtol=1.e-10,
-                damp=0., maxiter=200, factor=100., nprint=1,
-                iterfunct='default', iterkw={}, nocovar=0,
-                fastnorm=0, rescale=0, autoderivative=1, quiet=0,
-                diag=None, epsfcn=None, debug=0):
-      """
-Inputs:
-  fcn:
-     The function to be minimized.  The function should return the weighted
-     deviations between the model and the data, as described above.
+    def __init__(
+        self,
+        fcn,
+        xall=None,
+        functkw={},
+        parinfo=None,
+        ftol=1.0e-10,
+        xtol=1.0e-10,
+        gtol=1.0e-10,
+        damp=0.0,
+        maxiter=200,
+        factor=100.0,
+        nprint=1,
+        iterfunct="default",
+        iterkw={},
+        nocovar=0,
+        fastnorm=0,
+        rescale=0,
+        autoderivative=1,
+        quiet=0,
+        diag=None,
+        epsfcn=None,
+        debug=0,
+    ):
+        """
+        Inputs:
+          fcn:
+             The function to be minimized.  The function should return the weighted
+             deviations between the model and the data, as described above.
 
-  xall:
-     An array of starting values for each of the parameters of the model.
-     The number of parameters should be fewer than the number of measurements.
+          xall:
+             An array of starting values for each of the parameters of the model.
+             The number of parameters should be fewer than the number of measurements.
 
-     This parameter is optional if the parinfo keyword is used (but see
-     parinfo).  The parinfo keyword provides a mechanism to fix or constrain
-     individual parameters.  
+             This parameter is optional if the parinfo keyword is used (but see
+             parinfo).  The parinfo keyword provides a mechanism to fix or constrain
+             individual parameters.
 
-Keywords:
+        Keywords:
 
-   autoderivative:
-      If this is set, derivatives of the function will be computed
-      automatically via a finite differencing procedure.  If not set, then
-      fcn must provide the (analytical) derivatives.
-         Default: set (=1) 
-         NOTE: to supply your own analytical derivatives,
-               explicitly pass autoderivative=0
+           autoderivative:
+              If this is set, derivatives of the function will be computed
+              automatically via a finite differencing procedure.  If not set, then
+              fcn must provide the (analytical) derivatives.
+                 Default: set (=1)
+                 NOTE: to supply your own analytical derivatives,
+                       explicitly pass autoderivative=0
 
-   fastnorm:
-      Set this keyword to select a faster algorithm to compute sum-of-square
-      values internally.  For systems with large numbers of data points, the
-      standard algorithm can become prohibitively slow because it cannot be
-      vectorized well.  By setting this keyword, MPFIT will run faster, but
-      it will be more prone to floating point overflows and underflows.  Thus, setting
-      this keyword may sacrifice some stability in the fitting process.
-         Default: clear (=0)
+           fastnorm:
+              Set this keyword to select a faster algorithm to compute sum-of-square
+              values internally.  For systems with large numbers of data points, the
+              standard algorithm can become prohibitively slow because it cannot be
+              vectorized well.  By setting this keyword, MPFIT will run faster, but
+              it will be more prone to floating point overflows and underflows.  Thus, setting
+              this keyword may sacrifice some stability in the fitting process.
+                 Default: clear (=0)
 
-   ftol:
-      A nonnegative input variable. Termination occurs when both the actual
-      and predicted relative reductions in the sum of squares are at most
-      ftol (and status is accordingly set to 1 or 3).  Therefore, ftol
-      measures the relative error desired in the sum of squares.
-         Default: 1E-10
+           ftol:
+              A nonnegative input variable. Termination occurs when both the actual
+              and predicted relative reductions in the sum of squares are at most
+              ftol (and status is accordingly set to 1 or 3).  Therefore, ftol
+              measures the relative error desired in the sum of squares.
+                 Default: 1E-10
 
-   functkw:
-      A dictionary which contains the parameters to be passed to the
-      user-supplied function specified by fcn via the standard Python
-      keyword dictionary mechanism.  This is the way you can pass additional
-      data to your user-supplied function without using global variables.
+           functkw:
+              A dictionary which contains the parameters to be passed to the
+              user-supplied function specified by fcn via the standard Python
+              keyword dictionary mechanism.  This is the way you can pass additional
+              data to your user-supplied function without using global variables.
 
-      Consider the following example:
-         if functkw = {'xval':[1.,2.,3.], 'yval':[1.,4.,9.],
-                       'errval':[1.,1.,1.] }
-      then the user supplied function should be declared like this:
-         def myfunct(p, fjac=None, xval=None, yval=None, errval=None):
+              Consider the following example:
+                 if functkw = {'xval':[1.,2.,3.], 'yval':[1.,4.,9.],
+                               'errval':[1.,1.,1.] }
+              then the user supplied function should be declared like this:
+                 def myfunct(p, fjac=None, xval=None, yval=None, errval=None):
 
-      Default: {}   No extra parameters are passed to the user-supplied
-                    function. 
+              Default: {}   No extra parameters are passed to the user-supplied
+                            function.
 
-   gtol:
-      A nonnegative input variable. Termination occurs when the cosine of
-      the angle between fvec and any column of the jacobian is at most gtol
-      in absolute value (and status is accordingly set to 4). Therefore,
-      gtol measures the orthogonality desired between the function vector
-      and the columns of the jacobian.
-         Default: 1e-10
+           gtol:
+              A nonnegative input variable. Termination occurs when the cosine of
+              the angle between fvec and any column of the jacobian is at most gtol
+              in absolute value (and status is accordingly set to 4). Therefore,
+              gtol measures the orthogonality desired between the function vector
+              and the columns of the jacobian.
+                 Default: 1e-10
 
-   iterkw:
-      The keyword arguments to be passed to iterfunct via the dictionary
-      keyword mechanism.  This should be a dictionary and is similar in
-      operation to FUNCTKW.
-         Default: {}  No arguments are passed.
+           iterkw:
+              The keyword arguments to be passed to iterfunct via the dictionary
+              keyword mechanism.  This should be a dictionary and is similar in
+              operation to FUNCTKW.
+                 Default: {}  No arguments are passed.
 
-   iterfunct:
-      The name of a function to be called upon each NPRINT iteration of the
-      MPFIT routine.  It should be declared in the following way:
-         def iterfunct(myfunct, p, iter, fnorm, functkw=None, 
-                       parinfo=None, quiet=0, dof=None, [iterkw keywords here])
-         # perform custom iteration update
+           iterfunct:
+              The name of a function to be called upon each NPRINT iteration of the
+              MPFIT routine.  It should be declared in the following way:
+                 def iterfunct(myfunct, p, iter, fnorm, functkw=None,
+                               parinfo=None, quiet=0, dof=None, [iterkw keywords here])
+                 # perform custom iteration update
 
-      iterfunct must accept all three keyword parameters (FUNCTKW, PARINFO
-      and QUIET). 
+              iterfunct must accept all three keyword parameters (FUNCTKW, PARINFO
+              and QUIET).
 
-      myfunct:  The user-supplied function to be minimized,
-      p:        The current set of model parameters
-      iter:     The iteration number
-      functkw:  The arguments to be passed to myfunct.
-      fnorm:    The chi-squared value.
-      quiet:    Set when no textual output should be printed.
-      dof:      The number of degrees of freedom, normally the number of points
-                less the number of free parameters.
-      See below for documentation of parinfo.
+              myfunct:  The user-supplied function to be minimized,
+              p:        The current set of model parameters
+              iter:     The iteration number
+              functkw:  The arguments to be passed to myfunct.
+              fnorm:    The chi-squared value.
+              quiet:    Set when no textual output should be printed.
+              dof:      The number of degrees of freedom, normally the number of points
+                        less the number of free parameters.
+              See below for documentation of parinfo.
 
-      In implementation, iterfunct can perform updates to the terminal or
-      graphical user interface, to provide feedback while the fit proceeds.
-      If the fit is to be stopped for any reason, then iterfunct should return a
-      a status value between -15 and -1.  Otherwise it should return None
-      (e.g. no return statement) or 0.
-      In principle, iterfunct should probably not modify the parameter values,
-      because it may interfere with the algorithm's stability.  In practice it
-      is allowed.
+              In implementation, iterfunct can perform updates to the terminal or
+              graphical user interface, to provide feedback while the fit proceeds.
+              If the fit is to be stopped for any reason, then iterfunct should return a
+              a status value between -15 and -1.  Otherwise it should return None
+              (e.g. no return statement) or 0.
+              In principle, iterfunct should probably not modify the parameter values,
+              because it may interfere with the algorithm's stability.  In practice it
+              is allowed.
 
-      Default: an internal routine is used to print the parameter values.
+              Default: an internal routine is used to print the parameter values.
 
-      Set iterfunct=None if there is no user-defined routine and you don't
-      want the internal default routine be called.
+              Set iterfunct=None if there is no user-defined routine and you don't
+              want the internal default routine be called.
 
-   maxiter:
-      The maximum number of iterations to perform.  If the number is exceeded,
-      then the status value is set to 5 and MPFIT returns.
-      Default: 200 iterations
+           maxiter:
+              The maximum number of iterations to perform.  If the number is exceeded,
+              then the status value is set to 5 and MPFIT returns.
+              Default: 200 iterations
 
-   nocovar:
-      Set this keyword to prevent the calculation of the covariance matrix
-      before returning (see COVAR)
-      Default: clear (=0)  The covariance matrix is returned
+           nocovar:
+              Set this keyword to prevent the calculation of the covariance matrix
+              before returning (see COVAR)
+              Default: clear (=0)  The covariance matrix is returned
 
-   nprint:
-      The frequency with which iterfunct is called.  A value of 1 indicates
-      that iterfunct is called with every iteration, while 2 indicates every
-      other iteration, etc.  Note that several Levenberg-Marquardt attempts
-      can be made in a single iteration.
-      Default value: 1
+           nprint:
+              The frequency with which iterfunct is called.  A value of 1 indicates
+              that iterfunct is called with every iteration, while 2 indicates every
+              other iteration, etc.  Note that several Levenberg-Marquardt attempts
+              can be made in a single iteration.
+              Default value: 1
 
-   parinfo
-      Provides a mechanism for more sophisticated constraints to be placed on
-      parameter values.  When parinfo is not passed, then it is assumed that
-      all parameters are free and unconstrained.  Values in parinfo are never
-      modified during a call to MPFIT.
+           parinfo
+              Provides a mechanism for more sophisticated constraints to be placed on
+              parameter values.  When parinfo is not passed, then it is assumed that
+              all parameters are free and unconstrained.  Values in parinfo are never
+              modified during a call to MPFIT.
 
-      See description above for the structure of PARINFO.
+              See description above for the structure of PARINFO.
 
-      Default value: None  All parameters are free and unconstrained.
+              Default value: None  All parameters are free and unconstrained.
 
-   quiet:
-      Set this keyword when no textual output should be printed by MPFIT
+           quiet:
+              Set this keyword when no textual output should be printed by MPFIT
 
-   damp:
-      A scalar number, indicating the cut-off value of residuals where
-      "damping" will occur.  Residuals with magnitudes greater than this
-      number will be replaced by their hyperbolic tangent.  This partially
-      mitigates the so-called large residual problem inherent in
-      least-squares solvers (as for the test problem CURVI,
-      http://www.maxthis.com/curviex.htm).
-      A value of 0 indicates no damping.
-         Default: 0
+           damp:
+              A scalar number, indicating the cut-off value of residuals where
+              "damping" will occur.  Residuals with magnitudes greater than this
+              number will be replaced by their hyperbolic tangent.  This partially
+              mitigates the so-called large residual problem inherent in
+              least-squares solvers (as for the test problem CURVI,
+              http://www.maxthis.com/curviex.htm).
+              A value of 0 indicates no damping.
+                 Default: 0
 
-      Note: DAMP doesn't work with autoderivative=0
+              Note: DAMP doesn't work with autoderivative=0
 
-   xtol:
-      A nonnegative input variable. Termination occurs when the relative error
-      between two consecutive iterates is at most xtol (and status is
-      accordingly set to 2 or 3).  Therefore, xtol measures the relative error
-      desired in the approximate solution.
-      Default: 1E-10
+           xtol:
+              A nonnegative input variable. Termination occurs when the relative error
+              between two consecutive iterates is at most xtol (and status is
+              accordingly set to 2 or 3).  Therefore, xtol measures the relative error
+              desired in the approximate solution.
+              Default: 1E-10
 
- Outputs:
+         Outputs:
 
-   Returns an object of type mpfit.  The results are attributes of this class,
-   e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
+           Returns an object of type mpfit.  The results are attributes of this class,
+           e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
 
-   .status
-      An integer status code is returned.  All values greater than zero can
-      represent success (however .status == 5 may indicate failure to
-      converge). It can have one of the following values:
+           .status
+              An integer status code is returned.  All values greater than zero can
+              represent success (however .status == 5 may indicate failure to
+              converge). It can have one of the following values:
 
-      -16
-         A parameter or function value has become infinite or an undefined
-         number.  This is usually a consequence of numerical overflow in the
-         user's model function, which must be avoided.
+              -16
+                 A parameter or function value has become infinite or an undefined
+                 number.  This is usually a consequence of numerical overflow in the
+                 user's model function, which must be avoided.
 
-      -15 to -1 
-         These are error codes that either MYFUNCT or iterfunct may return to
-         terminate the fitting process.  Values from -15 to -1 are reserved
-         for the user functions and will not clash with MPFIT.
+              -15 to -1
+                 These are error codes that either MYFUNCT or iterfunct may return to
+                 terminate the fitting process.  Values from -15 to -1 are reserved
+                 for the user functions and will not clash with MPFIT.
 
-      0  Improper input parameters.
+              0  Improper input parameters.
 
-      1  Both actual and predicted relative reductions in the sum of squares
-         are at most ftol.
+              1  Both actual and predicted relative reductions in the sum of squares
+                 are at most ftol.
 
-      2  Relative error between two consecutive iterates is at most xtol
+              2  Relative error between two consecutive iterates is at most xtol
 
-      3  Conditions for status = 1 and status = 2 both hold.
+              3  Conditions for status = 1 and status = 2 both hold.
 
-      4  The cosine of the angle between fvec and any column of the jacobian
-         is at most gtol in absolute value.
+              4  The cosine of the angle between fvec and any column of the jacobian
+                 is at most gtol in absolute value.
 
-      5  The maximum number of iterations has been reached.
+              5  The maximum number of iterations has been reached.
 
-      6  ftol is too small. No further reduction in the sum of squares is
-         possible.
+              6  ftol is too small. No further reduction in the sum of squares is
+                 possible.
 
-      7  xtol is too small. No further improvement in the approximate solution
-         x is possible.
+              7  xtol is too small. No further improvement in the approximate solution
+                 x is possible.
 
-      8  gtol is too small. fvec is orthogonal to the columns of the jacobian
-         to machine precision.
+              8  gtol is too small. fvec is orthogonal to the columns of the jacobian
+                 to machine precision.
 
-   .fnorm
-      The value of the summed squared residuals for the returned parameter
-      values.
+           .fnorm
+              The value of the summed squared residuals for the returned parameter
+              values.
 
-   .covar
-      The covariance matrix for the set of parameters returned by MPFIT.
-      The matrix is NxN where N is the number of  parameters.  The square root
-      of the diagonal elements gives the formal 1-sigma statistical errors on
-      the parameters if errors were treated "properly" in fcn.
-      Parameter errors are also returned in .perror.
+           .covar
+              The covariance matrix for the set of parameters returned by MPFIT.
+              The matrix is NxN where N is the number of  parameters.  The square root
+              of the diagonal elements gives the formal 1-sigma statistical errors on
+              the parameters if errors were treated "properly" in fcn.
+              Parameter errors are also returned in .perror.
 
-      To compute the correlation matrix, pcor, use this example:
-         cov = mpfit.covar
-         pcor = cov * 0.
-         for i in range(n):
-            for j in range(n):
-               pcor[i,j] = cov[i,j]/numpy.sqrt(cov[i,i]*cov[j,j])
+              To compute the correlation matrix, pcor, use this example:
+                 cov = mpfit.covar
+                 pcor = cov * 0.
+                 for i in range(n):
+                    for j in range(n):
+                       pcor[i,j] = cov[i,j]/numpy.sqrt(cov[i,i]*cov[j,j])
 
-      If nocovar is set or MPFIT terminated abnormally, then .covar is set to
-      a scalar with value None.
+              If nocovar is set or MPFIT terminated abnormally, then .covar is set to
+              a scalar with value None.
 
-   .errmsg
-      A string error or warning message is returned.
+           .errmsg
+              A string error or warning message is returned.
 
-   .nfev
-      The number of calls to MYFUNCT performed.
+           .nfev
+              The number of calls to MYFUNCT performed.
 
-   .niter
-      The number of iterations completed.
+           .niter
+              The number of iterations completed.
 
-   .perror
-      The formal 1-sigma errors in each parameter, computed from the
-      covariance matrix.  If a parameter is held fixed, or if it touches a
-      boundary, then the error is reported as zero.
+           .perror
+              The formal 1-sigma errors in each parameter, computed from the
+              covariance matrix.  If a parameter is held fixed, or if it touches a
+              boundary, then the error is reported as zero.
 
-      If the fit is unweighted (i.e. no errors were given, or the weights
-      were uniformly set to unity), then .perror will probably not represent
-      the true parameter uncertainties.  
+              If the fit is unweighted (i.e. no errors were given, or the weights
+              were uniformly set to unity), then .perror will probably not represent
+              the true parameter uncertainties.
 
-      *If* you can assume that the true reduced chi-squared value is unity --
-      meaning that the fit is implicitly assumed to be of good quality --
-      then the estimated parameter uncertainties can be computed by scaling
-      .perror by the measured chi-squared value.
+              *If* you can assume that the true reduced chi-squared value is unity --
+              meaning that the fit is implicitly assumed to be of good quality --
+              then the estimated parameter uncertainties can be computed by scaling
+              .perror by the measured chi-squared value.
 
-         dof = len(x) - len(mpfit.params) # deg of freedom
-         # scaled uncertainties
-         pcerror = mpfit.perror * numpy.sqrt(mpfit.fnorm / dof)
+                 dof = len(x) - len(mpfit.params) # deg of freedom
+                 # scaled uncertainties
+                 pcerror = mpfit.perror * numpy.sqrt(mpfit.fnorm / dof)
 
-      """
-      self.niter = 0
-      self.params = None
-      self.covar = None
-      self.perror = None
-      self.status = 0  # Invalid input flag set while we check inputs
-      self.debug = debug
-      self.errmsg = ''
-      self.fastnorm = fastnorm
-      self.nfev = 0
-      self.damp = damp
-      self.machar = machar(double=1)
-      machep = self.machar.machep
+        """
+        self.niter = 0
+        self.params = None
+        self.covar = None
+        self.perror = None
+        self.status = 0  # Invalid input flag set while we check inputs
+        self.debug = debug
+        self.errmsg = ""
+        self.fastnorm = fastnorm
+        self.nfev = 0
+        self.damp = damp
+        self.machar = machar(double=1)
+        machep = self.machar.machep
 
-      if (fcn==None):
-         self.errmsg = "Usage: parms = mpfit('myfunt', ... )"
-         return
-
-      if (iterfunct == 'default'): iterfunct = self.defiter
-
-      ## Parameter damping doesn't work when user is providing their own
-      ## gradients.
-      if (self.damp != 0) and (autoderivative == 0):
-         self.errmsg =  'ERROR: keywords DAMP and AUTODERIVATIVE are mutually exclusive'
-         return
-
-      ## Parameters can either be stored in parinfo, or x. x takes precedence if it exists
-      if (xall is None) and (parinfo is None):
-         self.errmsg = 'ERROR: must pass parameters in P or PARINFO'
-         return
-
-      ## Be sure that PARINFO is of the right type
-      if (parinfo is not None):
-         if not isinstance(parinfo, list):
-            self.errmsg = 'ERROR: PARINFO must be a list of dictionaries.'
-            return
-         else:
-            if not isinstance(parinfo[0], dict):
-              self.errmsg = 'ERROR: PARINFO must be a list of dictionaries.'
-              return
-         if ((xall is not None) and (len(xall) != len(parinfo))):
-            self.errmsg = 'ERROR: number of elements in PARINFO and P must agree'
+        if fcn is None:
+            self.errmsg = "Usage: parms = mpfit('myfunt', ... )"
             return
 
-      ## If the parameters were not specified at the command line, then
-      ## extract them from PARINFO
-      if (xall is None):
-         xall = self.parinfo(parinfo, 'value')
-         if (xall is None):
-            self.errmsg = 'ERROR: either P or PARINFO(*)["value"] must be supplied.'
+        if iterfunct == "default":
+            iterfunct = self.defiter
+
+        ## Parameter damping doesn't work when user is providing their own
+        ## gradients.
+        if (self.damp != 0) and (autoderivative == 0):
+            self.errmsg = (
+                "ERROR: keywords DAMP and AUTODERIVATIVE are mutually exclusive"
+            )
             return
 
-      ## Make sure parameters are numpy arrays of type numpy.float
-      xall = numpy.asarray(xall, float)
-
-      npar = len(xall)
-      self.fnorm  = -1.
-      fnorm1 = -1.
-
-      ## TIED parameters?
-      ptied = self.parinfo(parinfo, 'tied', default='', n=npar)
-      self.qanytied = 0
-      for i in range(npar):
-         ptied[i] = ptied[i].strip()
-         if (ptied[i] != ''): self.qanytied = 1
-      self.ptied = ptied
-
-      ## FIXED parameters ?
-      pfixed = self.parinfo(parinfo, 'fixed', default=0, n=npar)
-      pfixed = (pfixed == 1)
-      for i in range(npar):
-         pfixed[i] = pfixed[i] or (ptied[i] != '') ## Tied parameters are also effectively fixed
-
-      ## Finite differencing step, absolute and relative, and sidedness of deriv.
-      step = self.parinfo(parinfo, 'step', default=0., n=npar)
-      dstep = self.parinfo(parinfo, 'relstep', default=0., n=npar)
-      dside = self.parinfo(parinfo, 'mpside',  default=0, n=npar)
-
-      ## Maximum and minimum steps allowed to be taken in one iteration
-      maxstep = self.parinfo(parinfo, 'mpmaxstep', default=0., n=npar)
-      minstep = self.parinfo(parinfo, 'mpminstep', default=0., n=npar)
-      qmin = minstep * 0  ## Remove minstep for now!!
-      qmax = maxstep != 0
-      wh, = numpy.nonzero(((qmin != 0.) & (qmax != 0.)) & (maxstep < minstep))
-      if (len(wh) > 0):
-         self.errmsg = 'ERROR: MPMINSTEP is greater than MPMAXSTEP'
-         return
-      wh, = numpy.nonzero((qmin!=0.) & (qmax!=0.))
-      qminmax = len(wh > 0)
-
-      ## Finish up the free parameters
-      ifree, = numpy.nonzero(pfixed != 1)
-      nfree = len(ifree)
-      if nfree == 0:
-         self.errmsg = 'ERROR: no free parameters'
-         return
-      dside = dside.take(ifree)
-
-      ## Compose only VARYING parameters
-      self.params = xall      ## self.params is the set of parameters to be returned
-      x = numpy.take(self.params, ifree)  ## x is the set of free parameters
-
-      ## LIMITED parameters ?
-      limited = self.parinfo(parinfo, 'limited', default=[0,0])
-      limits = self.parinfo(parinfo, 'limits', default=[0.,0.])
-      if (limited is not None) and (limits is not None):
-         ## Error checking on limits in parinfo
-         wh, = numpy.nonzero((limited[:,0] & (xall < limits[:,0])) |
-                              (limited[:,1] & (xall > limits[:,1])))
-         if (len(wh) > 0):
-            self.errmsg = 'ERROR: parameters are not within PARINFO limits'
-            return
-         wh, = numpy.nonzero((limited[:,0] & limited[:,1]) &
-                              (limits[:,0] >= limits[:,1]) &
-                              (pfixed == 0))
-         if (len(wh) > 0):
-            self.errmsg = 'ERROR: PARINFO parameter limits are not consistent'
+        ## Parameters can either be stored in parinfo, or x. x takes precedence if it exists
+        if (xall is None) and (parinfo is None):
+            self.errmsg = "ERROR: must pass parameters in P or PARINFO"
             return
 
-         ## Transfer structure values to local variables
-         qulim = numpy.take(limited[:,1], ifree)
-         ulim  = numpy.take(limits [:,1], ifree)
-         qllim = numpy.take(limited[:,0], ifree)
-         llim  = numpy.take(limits [:,0], ifree)
-
-         wh, = numpy.nonzero((qulim!=0.) | (qllim!=0.))
-         if (len(wh) > 0): qanylim = 1
-         else: qanylim = 0
-      else:
-         ## Fill in local variables with dummy values
-         qulim = numpy.zeros(nfree)
-         ulim  = x * 0.
-         qllim = qulim
-         llim  = x * 0.
-         qanylim = 0
-
-      n = len(x)
-      ## Check input parameters for errors
-      if ((n < 0) or (ftol <= 0) or (xtol <= 0) or (gtol <= 0)
-                  or (maxiter <= 0) or (factor <= 0)):
-         self.errmsg = 'ERROR: input keywords are inconsistent'
-         return
-
-      if (rescale != 0):
-         self.errmsg = 'ERROR: DIAG parameter scales are inconsistent'
-         if (len(diag) < n): return
-         wh, = numpy.nonzero(diag <= 0)
-         if (len(wh) > 0): return
-         self.errmsg = ''
-
-      # Make sure x is a numpy array of type numpy.float
-      x = numpy.asarray(x, float)
-
-      [self.status, fvec] = self.call(fcn, self.params, functkw)
-      if (self.status < 0):
-         self.errmsg = 'ERROR: first call to "'+str(fcn)+'" failed'
-         return
-
-      m = len(fvec)
-      if (m < n):
-         self.errmsg = 'ERROR: number of parameters must not exceed data'
-         return
-
-      self.fnorm = self.enorm(fvec)
-
-      ## Initialize Levelberg-Marquardt parameter and iteration counter
-
-      par = 0.
-      self.niter = 1
-      qtf = x * 0.
-      self.status = 0
-
-      ## Beginning of the outer loop
-
-      while(1):
-
-         ## If requested, call fcn to enable printing of iterates
-         numpy.put(self.params, ifree, x)
-         if (self.qanytied): self.params = self.tie(self.params, ptied)
-
-         if (nprint > 0) and (iterfunct is not None):
-            if (((self.niter-1) % nprint) == 0):
-               mperr = 0
-               xnew0 = self.params.copy()
-
-               dof = max(len(fvec) - len(x), 0)
-               status = iterfunct(fcn, self.params, self.niter, self.fnorm**2, 
-                  functkw=functkw, parinfo=parinfo, quiet=quiet, 
-                  dof=dof, **iterkw)
-               if (status is not None): self.status = status
-
-               ## Check for user termination
-               if (self.status < 0):  
-                  self.errmsg = 'WARNING: premature termination by ' + str(iterfunct)
-                  return
-
-               ## If parameters were changed (grrr..) then re-tie
-               if (max(abs(xnew0-self.params)) > 0):
-                  if (self.qanytied): self.params = self.tie(self.params, ptied)
-                  x = numpy.take(self.params, ifree)
-
-
-         ## Calculate the jacobian matrix
-         self.status = 2
-         catch_msg = 'calling MPFIT_FDJAC2'
-         fjac = self.fdjac2(fcn, x, fvec, step, qulim, ulim, dside, 
-                       epsfcn=epsfcn, 
-                       autoderivative=autoderivative, dstep=dstep, 
-                       functkw=functkw, ifree=ifree, xall=self.params)
-         if (fjac is None):
-            self.errmsg = 'WARNING: premature termination by FDJAC2'
-            return
-
-         ## Determine if any of the parameters are pegged at the limits
-         if (qanylim):
-            catch_msg = 'zeroing derivatives of pegged parameters'
-            whlpeg, = numpy.nonzero(qllim & (x == llim))
-            nlpeg = len(whlpeg)
-            whupeg, = numpy.nonzero(qulim & (x == ulim))
-            nupeg = len(whupeg)
-            ## See if any "pegged" values should keep their derivatives
-            if (nlpeg > 0):
-               ## Total derivative of sum wrt lower pegged parameters
-               for i in range(nlpeg):
-                  sum = numpy.sum(fvec * fjac[:,whlpeg[i]])
-                  if (sum > 0): fjac[:,whlpeg[i]] = 0
-            if (nupeg > 0):
-               ## Total derivative of sum wrt upper pegged parameters
-               for i in range(nupeg):
-                  sum = numpy.sum(fvec * fjac[:,whupeg[i]])
-                  if (sum < 0): fjac[:,whupeg[i]] = 0
-
-         ## Compute the QR factorization of the jacobian
-         [fjac, ipvt, wa1, wa2] = self.qrfac(fjac, pivot=1)
-
-         ## On the first iteration if "diag" is unspecified, scale
-         ## according to the norms of the columns of the initial jacobian
-         catch_msg = 'rescaling diagonal elements'
-         if (self.niter == 1):
-            if ((rescale==0) or (len(diag) < n)):
-               diag = wa2.copy()
-               wh, = numpy.nonzero(diag == 0)
-               numpy.put(diag, wh, 1.)
-
-            ## On the first iteration, calculate the norm of the scaled x
-            ## and initialize the step bound delta 
-            wa3 = diag * x
-            xnorm = self.enorm(wa3)
-            delta = factor*xnorm
-            if (delta == 0.): delta = factor
-
-         ## Form (q transpose)*fvec and store the first n components in qtf
-         catch_msg = 'forming (q transpose)*fvec'
-         wa4 = fvec.copy()
-         for j in range(n):
-            lj = ipvt[j]
-            temp3 = fjac[j,lj]
-            if (temp3 != 0):
-               fj = fjac[j:,lj]
-               wj = wa4[j:]
-               ## *** optimization wa4(j:*)
-               wa4[j:] = wj - fj * numpy.sum(fj*wj) / temp3  
-            fjac[j,lj] = wa1[j]
-            qtf[j] = wa4[j]
-         ## From this point on, only the square matrix, consisting of the
-         ## triangle of R, is needed.
-         fjac = fjac[0:n, 0:n]
-         fjac.shape = [n, n]
-         temp = fjac.copy()
-         for i in range(n):
-            temp[:,i] = fjac[:, ipvt[i]]
-         fjac = temp.copy()
-
-         ## Check for overflow.  This should be a cheap test here since FJAC
-         ## has been reduced to a (small) square matrix, and the test is
-         ## O(N^2).
-         #wh = where(finite(fjac) EQ 0, ct)
-         #if ct GT 0 then goto, FAIL_OVERFLOW
-
-         ## Compute the norm of the scaled gradient
-         catch_msg = 'computing the scaled gradient'
-         gnorm = 0.
-         if (self.fnorm != 0):
-            for j in range(n):
-               l = ipvt[j]
-               if (wa2[l] != 0):
-                  sum = numpy.sum(fjac[0:j+1,j]*qtf[0:j+1])/self.fnorm
-                  gnorm = max([gnorm,abs(sum/wa2[l])])
-
-         ## Test for convergence of the gradient norm
-         if (gnorm <= gtol):
-            self.status = 4
-            return
-
-         ## Rescale if necessary
-         if (rescale == 0):
-            diag = numpy.choose(diag>wa2, (wa2, diag))
-
-         ## Beginning of the inner loop
-         while(1):
-
-            ## Determine the levenberg-marquardt parameter
-            catch_msg = 'calculating LM parameter (MPFIT_)'
-            [fjac, par, wa1, wa2] = self.lmpar(fjac, ipvt, diag, qtf,
-                                                 delta, wa1, wa2, par=par)
-            ## Store the direction p and x+p. Calculate the norm of p
-            wa1 = -wa1
-
-            if (qanylim == 0) and (qminmax == 0):
-               ## No parameter limits, so just move to new position WA2
-               alpha = 1.
-               wa2 = x + wa1
-
+        ## Be sure that PARINFO is of the right type
+        if parinfo is not None:
+            if not isinstance(parinfo, list):
+                self.errmsg = "ERROR: PARINFO must be a list of dictionaries."
+                return
             else:
+                if not isinstance(parinfo[0], dict):
+                    self.errmsg = "ERROR: PARINFO must be a list of dictionaries."
+                    return
+            if (xall is not None) and (len(xall) != len(parinfo)):
+                self.errmsg = "ERROR: number of elements in PARINFO and P must agree"
+                return
 
-               ## Respect the limits.  If a step were to go out of bounds, then
-               ## we should take a step in the same direction but shorter distance.
-               ## The step should take us right to the limit in that case.
-               alpha = 1.
+        ## If the parameters were not specified at the command line, then
+        ## extract them from PARINFO
+        if xall is None:
+            xall = self.parinfo(parinfo, "value")
+            if xall is None:
+                self.errmsg = 'ERROR: either P or PARINFO(*)["value"] must be supplied.'
+                return
 
-               if (qanylim):
-                  ## Do not allow any steps out of bounds
-                  catch_msg = 'checking for a step out of bounds'
-                  if (nlpeg > 0):
-                     numpy.put(wa1, whlpeg, numpy.clip(
-                        numpy.take(wa1, whlpeg), 0., max(wa1)))
-                  if (nupeg > 0):
-                     numpy.put(wa1, whupeg, numpy.clip(
-                        numpy.take(wa1, whupeg), min(wa1), 0.))
+        ## Make sure parameters are numpy arrays of type numpy.float
+        xall = numpy.asarray(xall, float)
 
-                  dwa1 = abs(wa1) > machep
-                  whl, = numpy.nonzero(((dwa1!=0.) & qllim) & ((x + wa1) < llim))
-                  if (len(whl) > 0):
-                     t = ((numpy.take(llim, whl) - numpy.take(x, whl)) /
-                           numpy.take(wa1, whl))
-                     alpha = min(alpha, min(t))
-                  whu, = numpy.nonzero(((dwa1!=0.) & qulim) & ((x + wa1) > ulim))
-                  if (len(whu) > 0):
-                     t = ((numpy.take(ulim, whu) - numpy.take(x, whu)) /
-                           numpy.take(wa1, whu))
-                     alpha = min(alpha, min(t))
+        npar = len(xall)
+        self.fnorm = -1.0
+        fnorm1 = -1.0
 
-               ## Obey any max step values.
-               if (qminmax):
-                  nwa1 = wa1 * alpha
-                  whmax, = numpy.nonzero((qmax != 0.) & (maxstep > 0))
-                  if (len(whmax) > 0):
-                     mrat = max(numpy.take(nwa1, whmax) /
-                                numpy.take(maxstep, whmax))
-                     if (mrat > 1): alpha = alpha / mrat
+        ## TIED parameters?
+        ptied = self.parinfo(parinfo, "tied", default="", n=npar)
+        self.qanytied = 0
+        for i in range(npar):
+            ptied[i] = ptied[i].strip()
+            if ptied[i] != "":
+                self.qanytied = 1
+        self.ptied = ptied
 
-               ## Scale the resulting vector
-               wa1 = wa1 * alpha
-               wa2 = x + wa1
+        ## FIXED parameters ?
+        pfixed = self.parinfo(parinfo, "fixed", default=0, n=npar)
+        pfixed = pfixed == 1
+        for i in range(npar):
+            pfixed[i] = pfixed[i] or (
+                ptied[i] != ""
+            )  ## Tied parameters are also effectively fixed
 
-               ## Adjust the final output values.  If the step put us exactly
-               ## on a boundary, make sure it is exact.
-               wh, = numpy.nonzero((qulim!=0.) & (wa2 >= ulim*(1-machep)))
-               if (len(wh) > 0): numpy.put(wa2, wh, numpy.take(ulim, wh))
-               wh, = numpy.nonzero((qllim!=0.) & (wa2 <= llim*(1+machep)))
-               if (len(wh) > 0): numpy.put(wa2, wh, numpy.take(llim, wh))
-            # endelse
-            wa3 = diag * wa1
-            pnorm = self.enorm(wa3)
+        ## Finite differencing step, absolute and relative, and sidedness of deriv.
+        step = self.parinfo(parinfo, "step", default=0.0, n=npar)
+        dstep = self.parinfo(parinfo, "relstep", default=0.0, n=npar)
+        dside = self.parinfo(parinfo, "mpside", default=0, n=npar)
 
-            ## On the first iteration, adjust the initial step bound
-            if (self.niter == 1): delta = min([delta,pnorm])
+        ## Maximum and minimum steps allowed to be taken in one iteration
+        maxstep = self.parinfo(parinfo, "mpmaxstep", default=0.0, n=npar)
+        minstep = self.parinfo(parinfo, "mpminstep", default=0.0, n=npar)
+        qmin = minstep * 0  ## Remove minstep for now!!
+        qmax = maxstep != 0
+        (wh,) = numpy.nonzero(((qmin != 0.0) & (qmax != 0.0)) & (maxstep < minstep))
+        if len(wh) > 0:
+            self.errmsg = "ERROR: MPMINSTEP is greater than MPMAXSTEP"
+            return
+        (wh,) = numpy.nonzero((qmin != 0.0) & (qmax != 0.0))
+        qminmax = len(wh > 0)
 
-            numpy.put(self.params, ifree, wa2)
+        ## Finish up the free parameters
+        (ifree,) = numpy.nonzero(pfixed != 1)
+        nfree = len(ifree)
+        if nfree == 0:
+            self.errmsg = "ERROR: no free parameters"
+            return
+        dside = dside.take(ifree)
 
-            ## Evaluate the function at x+p and calculate its norm
-            mperr = 0
-            catch_msg = 'calling '+str(fcn)
-            [self.status, wa4] = self.call(fcn, self.params, functkw)
-            if (self.status < 0):
-               self.errmsg = 'WARNING: premature termination by "'+fcn+'"'
-               return
-            fnorm1 = self.enorm(wa4)
+        ## Compose only VARYING parameters
+        self.params = xall  ## self.params is the set of parameters to be returned
+        x = numpy.take(self.params, ifree)  ## x is the set of free parameters
 
-            ## Compute the scaled actual reduction
-            catch_msg = 'computing convergence criteria'
-            actred = -1.
-            if ((0.1 * fnorm1) < self.fnorm): actred = - (fnorm1/self.fnorm)**2 + 1.
-
-            ## Compute the scaled predicted reduction and the scaled directional
-            ## derivative
-            for j in range(n):
-               wa3[j] = 0
-               wa3[0:j+1] = wa3[0:j+1] + fjac[0:j+1,j]*wa1[ipvt[j]]
-
-            ## Remember, alpha is the fraction of the full LM step actually
-            ## taken
-            temp1 = self.enorm(alpha*wa3)/self.fnorm
-            temp2 = (numpy.sqrt(alpha*par)*pnorm)/self.fnorm
-            prered = temp1*temp1 + (temp2*temp2)/0.5
-            dirder = -(temp1*temp1 + temp2*temp2)
-
-            ## Compute the ratio of the actual to the predicted reduction.
-            ratio = 0.
-            if (prered != 0): ratio = actred/prered
-
-            ## Update the step bound
-            if (ratio <= 0.25):
-               if (actred >= 0): temp = .5
-               else: temp = .5*dirder/(dirder + .5*actred)
-               if ((0.1*fnorm1) >= self.fnorm) or (temp < 0.1): temp = 0.1
-               delta = temp*min([delta,pnorm/0.1])
-               par = par/temp
-            else: 
-               if (par == 0) or (ratio >= 0.75):
-                  delta = pnorm/.5
-                  par = .5*par
-
-            ## Test for successful iteration
-            if (ratio >= 0.0001): 
-               ## Successful iteration.  Update x, fvec, and their norms
-               x = wa2
-               wa2 = diag * x
-               fvec = wa4
-               xnorm = self.enorm(wa2)
-               self.fnorm = fnorm1
-               self.niter = self.niter + 1
-
-            ## Tests for convergence
-            if ((abs(actred) <= ftol) and (prered <= ftol)
-                 and (0.5 * ratio <= 1)): self.status = 1
-            if delta <= xtol*xnorm: self.status = 2
-            if ((abs(actred) <= ftol) and (prered <= ftol)
-                 and (0.5 * ratio <= 1) and (self.status == 2)): self.status = 3
-            if (self.status != 0): break
-
-            ## Tests for termination and stringent tolerances
-            if (self.niter >= maxiter): self.status = 5
-            if ((abs(actred) <= machep) and (prered <= machep) 
-                and (0.5*ratio <= 1)): self.status = 6
-            if delta <= machep*xnorm: self.status = 7
-            if gnorm <= machep: self.status = 8
-            if (self.status != 0): break
-
-            ## End of inner loop. Repeat if iteration unsuccessful
-            if (ratio >= 0.0001): break
-
-         ## Check for over/underflow - SKIP FOR NOW
-         ##wh = where(finite(wa1) EQ 0 OR finite(wa2) EQ 0 OR finite(x) EQ 0, ct)
-         ##if ct GT 0 OR finite(ratio) EQ 0 then begin
-         ##   errmsg = ('ERROR: parameter or function value(s) have become '+$
-         ##      'infinite# check model function for over- '+$
-         ##      'and underflow')
-         ##   self.status = -16
-         ##   break
-         if (self.status != 0): break;
-      ## End of outer loop.
-
-      catch_msg = 'in the termination phase'
-      ## Termination, either normal or user imposed.
-      if (len(self.params) == 0):
-         return
-      if (nfree == 0): self.params = xall.copy()
-      else: numpy.put(self.params, ifree, x)
-      if (nprint > 0) and (self.status > 0):
-         catch_msg = 'calling ' + str(fcn)
-         [status, fvec] = self.call(fcn, self.params, functkw)
-         catch_msg = 'in the termination phase'
-         self.fnorm = self.enorm(fvec)
-
-      if ((self.fnorm is not None) and (fnorm1 is not None)):
-         self.fnorm = max([self.fnorm, fnorm1])
-         self.fnorm = self.fnorm**2.
-
-      self.covar = None
-      self.perror = None
-      ## (very carefully) set the covariance matrix COVAR
-      if ((self.status > 0) and (nocovar==0) and (n is not None)
-                     and (fjac is not None) and (ipvt is not None)):
-         sz = numpy.shape(fjac)
-         if ((n > 0) and (sz[0] >= n) and (sz[1] >= n)
-             and (len(ipvt) >= n)):
-            catch_msg = 'computing the covariance matrix'
-            cv = self.calc_covar(fjac[0:n,0:n], ipvt[0:n])
-            cv.shape = [n, n]
-            nn = len(xall)
-
-            ## Fill in actual covariance matrix, accounting for fixed
-            ## parameters.
-            self.covar = numpy.zeros([nn, nn], float)
-            for i in range(n):
-               indices = ifree+ifree[i]*n
-               numpy.put(self.covar, indices, cv[:,i])
-
-            ## Compute errors in parameters
-            catch_msg = 'computing parameter errors'
-            self.perror = numpy.zeros(nn, float)
-            d = numpy.diagonal(self.covar).copy()
-            wh, = numpy.nonzero(d >= 0)
+        ## LIMITED parameters ?
+        limited = self.parinfo(parinfo, "limited", default=[0, 0])
+        limits = self.parinfo(parinfo, "limits", default=[0.0, 0.0])
+        if (limited is not None) and (limits is not None):
+            ## Error checking on limits in parinfo
+            (wh,) = numpy.nonzero(
+                (limited[:, 0] & (xall < limits[:, 0]))
+                | (limited[:, 1] & (xall > limits[:, 1]))
+            )
             if len(wh) > 0:
-              numpy.put(self.perror, wh, numpy.sqrt(numpy.take(d, wh)))
-      return
+                self.errmsg = "ERROR: parameters are not within PARINFO limits"
+                return
+            (wh,) = numpy.nonzero(
+                (limited[:, 0] & limited[:, 1])
+                & (limits[:, 0] >= limits[:, 1])
+                & (pfixed == 0)
+            )
+            if len(wh) > 0:
+                self.errmsg = "ERROR: PARINFO parameter limits are not consistent"
+                return
 
-
-   ## Default procedure to be called every iteration.  It simply prints
-   ## the parameter values.
-   def defiter(self, fcn, x, iter, fnorm=None, functkw=None, 
-                      quiet=0, iterstop=None, parinfo=None, 
-                      format=None, pformat='%.10g', dof=1):
+            ## Transfer structure values to local variables
+            qulim = numpy.take(limited[:, 1], ifree)
+            ulim = numpy.take(limits[:, 1], ifree)
+            qllim = numpy.take(limited[:, 0], ifree)
+            llim = numpy.take(limits[:, 0], ifree)
 
-      if (self.debug): print('Entering defiter...')
-      if (quiet): return
-      if (fnorm is None):
-         [status, fvec] = self.call(fcn, x, functkw)
-         fnorm = self.enorm(fvec)**2
+            (wh,) = numpy.nonzero((qulim != 0.0) | (qllim != 0.0))
+            if len(wh) > 0:
+                qanylim = 1
+            else:
+                qanylim = 0
+        else:
+            ## Fill in local variables with dummy values
+            qulim = numpy.zeros(nfree)
+            ulim = x * 0.0
+            qllim = qulim
+            llim = x * 0.0
+            qanylim = 0
 
-      ## Determine which parameters to print
-      nprint = len(x)
-      print("Iter ", ('%6i' % iter),"   CHI-SQUARE = ",('%.10g' % fnorm)," DOF = ", ('%i' % dof))
-      for i in range(nprint):
-         if (parinfo is not None) and ('parname' in parinfo[i]):
-            p = '   ' + parinfo[i]['parname'] + ' = '
-         else:
-            p = '   P' + str(i) + ' = '
-         if (parinfo is not None) and ('mpprint' in parinfo[i]):
-            iprint = parinfo[i]['mpprint']
-         else:
-            iprint = 1
-         if (iprint):
-            print(p + (pformat % x[i]) + '  ')
-      return(0)
+        n = len(x)
+        ## Check input parameters for errors
+        if (
+            (n < 0)
+            or (ftol <= 0)
+            or (xtol <= 0)
+            or (gtol <= 0)
+            or (maxiter <= 0)
+            or (factor <= 0)
+        ):
+            self.errmsg = "ERROR: input keywords are inconsistent"
+            return
 
-   ##  DO_ITERSTOP:
-   ##  if keyword_set(iterstop) then begin
-   ##      k = get_kbrd(0)
-   ##      if k EQ string(byte(7)) then begin
-   ##          message, 'WARNING: minimization not complete', /info
-   ##          print, 'Do you want to terminate this procedure? (y/n)', $
-   ##            format='(A,$)'
-   ##          k = ''
-   ##          read, k
-   ##          if strupcase(strmid(k,0,1)) EQ 'Y' then begin
-   ##              message, 'WARNING: Procedure is terminating.', /info
-   ##              mperr = -1
-   ##          endif
-   ##      endif
-   ##  endif
+        if rescale != 0:
+            self.errmsg = "ERROR: DIAG parameter scales are inconsistent"
+            if len(diag) < n:
+                return
+            (wh,) = numpy.nonzero(diag <= 0)
+            if len(wh) > 0:
+                return
+            self.errmsg = ""
 
-
-   ## Procedure to parse the parameter values in PARINFO, which is a list of dictionaries
-   def parinfo(self, parinfo=None, key='a', default=None, n=0):
-      if (self.debug): print('Entering parinfo...')
-      if (n == 0) and (parinfo is not None): n = len(parinfo)
-      if (n == 0):
-         values = default
-         return(values)
+        # Make sure x is a numpy array of type numpy.float
+        x = numpy.asarray(x, float)
 
-      values = []
-      for i in range(n):
-         if ((parinfo is not None) and (key in parinfo[i])):
-           values.append(parinfo[i][key])
-         else:
-           values.append(default)
+        [self.status, fvec] = self.call(fcn, self.params, functkw)
+        if self.status < 0:
+            self.errmsg = 'ERROR: first call to "' + str(fcn) + '" failed'
+            return
 
-      # Convert to numeric arrays if possible
-      test = default
-      if isinstance(default, list): test=default[0]
-      if isinstance(test, int):
-         values = numpy.asarray(values, int)
-      elif isinstance(test, float):
-         values = numpy.asarray(values, float)
-      return(values)
+        m = len(fvec)
+        if m < n:
+            self.errmsg = "ERROR: number of parameters must not exceed data"
+            return
 
-
-   ## Call user function or procedure, with _EXTRA or not, with
-   ## derivatives or not.
-   def call(self, fcn, x, functkw, fjac=None):
-      if (self.debug): print('Entering call...')
-      if (self.qanytied): x = self.tie(x, self.ptied)
-      self.nfev = self.nfev + 1
-      if (fjac is None):
-         [status, f] = fcn(x, fjac=fjac, **functkw)
-         if (self.damp > 0):
-            ## Apply the damping if requested.  This replaces the residuals
-            ## with their hyperbolic tangent.  Thus residuals larger than
-            ## DAMP are essentially clipped.
-            f = numpy.tanh(f/self.damp)
-         return([status, f])
-      else:
-         return(fcn(x, fjac=fjac, **functkw))
+        self.fnorm = self.enorm(fvec)
 
-
-   def enorm(self, vec):
+        ## Initialize Levelberg-Marquardt parameter and iteration counter
 
-        if (self.debug): print('Entering enorm...')
+        par = 0.0
+        self.niter = 1
+        qtf = x * 0.0
+        self.status = 0
+
+        ## Beginning of the outer loop
+
+        while 1:
+            ## If requested, call fcn to enable printing of iterates
+            numpy.put(self.params, ifree, x)
+            if self.qanytied:
+                self.params = self.tie(self.params, ptied)
+
+            if (nprint > 0) and (iterfunct is not None):
+                if ((self.niter - 1) % nprint) == 0:
+                    mperr = 0
+                    xnew0 = self.params.copy()
+
+                    dof = max(len(fvec) - len(x), 0)
+                    status = iterfunct(
+                        fcn,
+                        self.params,
+                        self.niter,
+                        self.fnorm**2,
+                        functkw=functkw,
+                        parinfo=parinfo,
+                        quiet=quiet,
+                        dof=dof,
+                        **iterkw,
+                    )
+                    if status is not None:
+                        self.status = status
+
+                    ## Check for user termination
+                    if self.status < 0:
+                        self.errmsg = "WARNING: premature termination by " + str(
+                            iterfunct
+                        )
+                        return
+
+                    ## If parameters were changed (grrr..) then re-tie
+                    if max(abs(xnew0 - self.params)) > 0:
+                        if self.qanytied:
+                            self.params = self.tie(self.params, ptied)
+                        x = numpy.take(self.params, ifree)
+
+            ## Calculate the jacobian matrix
+            self.status = 2
+            catch_msg = "calling MPFIT_FDJAC2"
+            fjac = self.fdjac2(
+                fcn,
+                x,
+                fvec,
+                step,
+                qulim,
+                ulim,
+                dside,
+                epsfcn=epsfcn,
+                autoderivative=autoderivative,
+                dstep=dstep,
+                functkw=functkw,
+                ifree=ifree,
+                xall=self.params,
+            )
+            if fjac is None:
+                self.errmsg = "WARNING: premature termination by FDJAC2"
+                return
+
+            ## Determine if any of the parameters are pegged at the limits
+            if qanylim:
+                catch_msg = "zeroing derivatives of pegged parameters"
+                (whlpeg,) = numpy.nonzero(qllim & (x == llim))
+                nlpeg = len(whlpeg)
+                (whupeg,) = numpy.nonzero(qulim & (x == ulim))
+                nupeg = len(whupeg)
+                ## See if any "pegged" values should keep their derivatives
+                if nlpeg > 0:
+                    ## Total derivative of sum wrt lower pegged parameters
+                    for i in range(nlpeg):
+                        sum = numpy.sum(fvec * fjac[:, whlpeg[i]])
+                        if sum > 0:
+                            fjac[:, whlpeg[i]] = 0
+                if nupeg > 0:
+                    ## Total derivative of sum wrt upper pegged parameters
+                    for i in range(nupeg):
+                        sum = numpy.sum(fvec * fjac[:, whupeg[i]])
+                        if sum < 0:
+                            fjac[:, whupeg[i]] = 0
+
+            ## Compute the QR factorization of the jacobian
+            [fjac, ipvt, wa1, wa2] = self.qrfac(fjac, pivot=1)
+
+            ## On the first iteration if "diag" is unspecified, scale
+            ## according to the norms of the columns of the initial jacobian
+            catch_msg = "rescaling diagonal elements"
+            if self.niter == 1:
+                if (rescale == 0) or (len(diag) < n):
+                    diag = wa2.copy()
+                    (wh,) = numpy.nonzero(diag == 0)
+                    numpy.put(diag, wh, 1.0)
+
+                ## On the first iteration, calculate the norm of the scaled x
+                ## and initialize the step bound delta
+                wa3 = diag * x
+                xnorm = self.enorm(wa3)
+                delta = factor * xnorm
+                if delta == 0.0:
+                    delta = factor
+
+            ## Form (q transpose)*fvec and store the first n components in qtf
+            catch_msg = "forming (q transpose)*fvec"
+            wa4 = fvec.copy()
+            for j in range(n):
+                lj = ipvt[j]
+                temp3 = fjac[j, lj]
+                if temp3 != 0:
+                    fj = fjac[j:, lj]
+                    wj = wa4[j:]
+                    ## *** optimization wa4(j:*)
+                    wa4[j:] = wj - fj * numpy.sum(fj * wj) / temp3
+                fjac[j, lj] = wa1[j]
+                qtf[j] = wa4[j]
+            ## From this point on, only the square matrix, consisting of the
+            ## triangle of R, is needed.
+            fjac = fjac[0:n, 0:n]
+            fjac.shape = [n, n]
+            temp = fjac.copy()
+            for i in range(n):
+                temp[:, i] = fjac[:, ipvt[i]]
+            fjac = temp.copy()
+
+            ## Check for overflow.  This should be a cheap test here since FJAC
+            ## has been reduced to a (small) square matrix, and the test is
+            ## O(N^2).
+            # wh = where(finite(fjac) EQ 0, ct)
+            # if ct GT 0 then goto, FAIL_OVERFLOW
+
+            ## Compute the norm of the scaled gradient
+            catch_msg = "computing the scaled gradient"
+            gnorm = 0.0
+            if self.fnorm != 0:
+                for j in range(n):
+                    l = ipvt[j]
+                    if wa2[l] != 0:
+                        sum = (
+                            numpy.sum(fjac[0 : j + 1, j] * qtf[0 : j + 1]) / self.fnorm
+                        )
+                        gnorm = max([gnorm, abs(sum / wa2[l])])
+
+            ## Test for convergence of the gradient norm
+            if gnorm <= gtol:
+                self.status = 4
+                return
+
+            ## Rescale if necessary
+            if rescale == 0:
+                diag = numpy.choose(diag > wa2, (wa2, diag))
+
+            ## Beginning of the inner loop
+            while 1:
+                ## Determine the levenberg-marquardt parameter
+                catch_msg = "calculating LM parameter (MPFIT_)"
+                [fjac, par, wa1, wa2] = self.lmpar(
+                    fjac, ipvt, diag, qtf, delta, wa1, wa2, par=par
+                )
+                ## Store the direction p and x+p. Calculate the norm of p
+                wa1 = -wa1
+
+                if (qanylim == 0) and (qminmax == 0):
+                    ## No parameter limits, so just move to new position WA2
+                    alpha = 1.0
+                    wa2 = x + wa1
+
+                else:
+                    ## Respect the limits.  If a step were to go out of bounds, then
+                    ## we should take a step in the same direction but shorter distance.
+                    ## The step should take us right to the limit in that case.
+                    alpha = 1.0
+
+                    if qanylim:
+                        ## Do not allow any steps out of bounds
+                        catch_msg = "checking for a step out of bounds"
+                        if nlpeg > 0:
+                            numpy.put(
+                                wa1,
+                                whlpeg,
+                                numpy.clip(numpy.take(wa1, whlpeg), 0.0, max(wa1)),
+                            )
+                        if nupeg > 0:
+                            numpy.put(
+                                wa1,
+                                whupeg,
+                                numpy.clip(numpy.take(wa1, whupeg), min(wa1), 0.0),
+                            )
+
+                        dwa1 = abs(wa1) > machep
+                        (whl,) = numpy.nonzero(
+                            ((dwa1 != 0.0) & qllim) & ((x + wa1) < llim)
+                        )
+                        if len(whl) > 0:
+                            t = (
+                                numpy.take(llim, whl) - numpy.take(x, whl)
+                            ) / numpy.take(wa1, whl)
+                            alpha = min(alpha, min(t))
+                        (whu,) = numpy.nonzero(
+                            ((dwa1 != 0.0) & qulim) & ((x + wa1) > ulim)
+                        )
+                        if len(whu) > 0:
+                            t = (
+                                numpy.take(ulim, whu) - numpy.take(x, whu)
+                            ) / numpy.take(wa1, whu)
+                            alpha = min(alpha, min(t))
+
+                    ## Obey any max step values.
+                    if qminmax:
+                        nwa1 = wa1 * alpha
+                        (whmax,) = numpy.nonzero((qmax != 0.0) & (maxstep > 0))
+                        if len(whmax) > 0:
+                            mrat = max(
+                                numpy.take(nwa1, whmax) / numpy.take(maxstep, whmax)
+                            )
+                            if mrat > 1:
+                                alpha = alpha / mrat
+
+                    ## Scale the resulting vector
+                    wa1 = wa1 * alpha
+                    wa2 = x + wa1
+
+                    ## Adjust the final output values.  If the step put us exactly
+                    ## on a boundary, make sure it is exact.
+                    (wh,) = numpy.nonzero((qulim != 0.0) & (wa2 >= ulim * (1 - machep)))
+                    if len(wh) > 0:
+                        numpy.put(wa2, wh, numpy.take(ulim, wh))
+                    (wh,) = numpy.nonzero((qllim != 0.0) & (wa2 <= llim * (1 + machep)))
+                    if len(wh) > 0:
+                        numpy.put(wa2, wh, numpy.take(llim, wh))
+                # endelse
+                wa3 = diag * wa1
+                pnorm = self.enorm(wa3)
+
+                ## On the first iteration, adjust the initial step bound
+                if self.niter == 1:
+                    delta = min([delta, pnorm])
+
+                numpy.put(self.params, ifree, wa2)
+
+                ## Evaluate the function at x+p and calculate its norm
+                mperr = 0
+                catch_msg = "calling " + str(fcn)
+                [self.status, wa4] = self.call(fcn, self.params, functkw)
+                if self.status < 0:
+                    self.errmsg = 'WARNING: premature termination by "' + fcn + '"'
+                    return
+                fnorm1 = self.enorm(wa4)
+
+                ## Compute the scaled actual reduction
+                catch_msg = "computing convergence criteria"
+                actred = -1.0
+                if (0.1 * fnorm1) < self.fnorm:
+                    actred = -((fnorm1 / self.fnorm) ** 2) + 1.0
+
+                ## Compute the scaled predicted reduction and the scaled directional
+                ## derivative
+                for j in range(n):
+                    wa3[j] = 0
+                    wa3[0 : j + 1] = wa3[0 : j + 1] + fjac[0 : j + 1, j] * wa1[ipvt[j]]
+
+                ## Remember, alpha is the fraction of the full LM step actually
+                ## taken
+                temp1 = self.enorm(alpha * wa3) / self.fnorm
+                temp2 = (numpy.sqrt(alpha * par) * pnorm) / self.fnorm
+                prered = temp1 * temp1 + (temp2 * temp2) / 0.5
+                dirder = -(temp1 * temp1 + temp2 * temp2)
+
+                ## Compute the ratio of the actual to the predicted reduction.
+                ratio = 0.0
+                if prered != 0:
+                    ratio = actred / prered
+
+                ## Update the step bound
+                if ratio <= 0.25:
+                    if actred >= 0:
+                        temp = 0.5
+                    else:
+                        temp = 0.5 * dirder / (dirder + 0.5 * actred)
+                    if ((0.1 * fnorm1) >= self.fnorm) or (temp < 0.1):
+                        temp = 0.1
+                    delta = temp * min([delta, pnorm / 0.1])
+                    par = par / temp
+                else:
+                    if (par == 0) or (ratio >= 0.75):
+                        delta = pnorm / 0.5
+                        par = 0.5 * par
+
+                ## Test for successful iteration
+                if ratio >= 0.0001:
+                    ## Successful iteration.  Update x, fvec, and their norms
+                    x = wa2
+                    wa2 = diag * x
+                    fvec = wa4
+                    xnorm = self.enorm(wa2)
+                    self.fnorm = fnorm1
+                    self.niter = self.niter + 1
+
+                ## Tests for convergence
+                if (abs(actred) <= ftol) and (prered <= ftol) and (0.5 * ratio <= 1):
+                    self.status = 1
+                if delta <= xtol * xnorm:
+                    self.status = 2
+                if (
+                    (abs(actred) <= ftol)
+                    and (prered <= ftol)
+                    and (0.5 * ratio <= 1)
+                    and (self.status == 2)
+                ):
+                    self.status = 3
+                if self.status != 0:
+                    break
+
+                ## Tests for termination and stringent tolerances
+                if self.niter >= maxiter:
+                    self.status = 5
+                if (
+                    (abs(actred) <= machep)
+                    and (prered <= machep)
+                    and (0.5 * ratio <= 1)
+                ):
+                    self.status = 6
+                if delta <= machep * xnorm:
+                    self.status = 7
+                if gnorm <= machep:
+                    self.status = 8
+                if self.status != 0:
+                    break
+
+                ## End of inner loop. Repeat if iteration unsuccessful
+                if ratio >= 0.0001:
+                    break
+
+            ## Check for over/underflow - SKIP FOR NOW
+            ##wh = where(finite(wa1) EQ 0 OR finite(wa2) EQ 0 OR finite(x) EQ 0, ct)
+            ##if ct GT 0 OR finite(ratio) EQ 0 then begin
+            ##   errmsg = ('ERROR: parameter or function value(s) have become '+$
+            ##      'infinite# check model function for over- '+$
+            ##      'and underflow')
+            ##   self.status = -16
+            ##   break
+            if self.status != 0:
+                break
+        ## End of outer loop.
+
+        catch_msg = "in the termination phase"
+        ## Termination, either normal or user imposed.
+        if len(self.params) == 0:
+            return
+        if nfree == 0:
+            self.params = xall.copy()
+        else:
+            numpy.put(self.params, ifree, x)
+        if (nprint > 0) and (self.status > 0):
+            catch_msg = "calling " + str(fcn)
+            [status, fvec] = self.call(fcn, self.params, functkw)
+            catch_msg = "in the termination phase"
+            self.fnorm = self.enorm(fvec)
+
+        if (self.fnorm is not None) and (fnorm1 is not None):
+            self.fnorm = max([self.fnorm, fnorm1])
+            self.fnorm = self.fnorm**2.0
+
+        self.covar = None
+        self.perror = None
+        ## (very carefully) set the covariance matrix COVAR
+        if (
+            (self.status > 0)
+            and (nocovar == 0)
+            and (n is not None)
+            and (fjac is not None)
+            and (ipvt is not None)
+        ):
+            sz = numpy.shape(fjac)
+            if (n > 0) and (sz[0] >= n) and (sz[1] >= n) and (len(ipvt) >= n):
+                catch_msg = "computing the covariance matrix"
+                cv = self.calc_covar(fjac[0:n, 0:n], ipvt[0:n])
+                cv.shape = [n, n]
+                nn = len(xall)
+
+                ## Fill in actual covariance matrix, accounting for fixed
+                ## parameters.
+                self.covar = numpy.zeros([nn, nn], float)
+                for i in range(n):
+                    indices = ifree + ifree[i] * n
+                    numpy.put(self.covar, indices, cv[:, i])
+
+                ## Compute errors in parameters
+                catch_msg = "computing parameter errors"
+                self.perror = numpy.zeros(nn, float)
+                d = numpy.diagonal(self.covar).copy()
+                (wh,) = numpy.nonzero(d >= 0)
+                if len(wh) > 0:
+                    numpy.put(self.perror, wh, numpy.sqrt(numpy.take(d, wh)))
+        return
+
+    ## Default procedure to be called every iteration.  It simply prints
+    ## the parameter values.
+    def defiter(
+        self,
+        fcn,
+        x,
+        iter,
+        fnorm=None,
+        functkw=None,
+        quiet=0,
+        iterstop=None,
+        parinfo=None,
+        format=None,
+        pformat="%.10g",
+        dof=1,
+    ):
+
+        if self.debug:
+            print("Entering defiter...")
+        if quiet:
+            return
+        if fnorm is None:
+            [status, fvec] = self.call(fcn, x, functkw)
+            fnorm = self.enorm(fvec) ** 2
+
+        ## Determine which parameters to print
+        nprint = len(x)
+        print(
+            "Iter ",
+            ("%6i" % iter),
+            "   CHI-SQUARE = ",
+            ("%.10g" % fnorm),
+            " DOF = ",
+            ("%i" % dof),
+        )
+        for i in range(nprint):
+            if (parinfo is not None) and ("parname" in parinfo[i]):
+                p = "   " + parinfo[i]["parname"] + " = "
+            else:
+                p = "   P" + str(i) + " = "
+            if (parinfo is not None) and ("mpprint" in parinfo[i]):
+                iprint = parinfo[i]["mpprint"]
+            else:
+                iprint = 1
+            if iprint:
+                print(p + (pformat % x[i]) + "  ")
+        return 0
+
+    ##  DO_ITERSTOP:
+    ##  if keyword_set(iterstop) then begin
+    ##      k = get_kbrd(0)
+    ##      if k EQ string(byte(7)) then begin
+    ##          message, 'WARNING: minimization not complete', /info
+    ##          print, 'Do you want to terminate this procedure? (y/n)', $
+    ##            format='(A,$)'
+    ##          k = ''
+    ##          read, k
+    ##          if strupcase(strmid(k,0,1)) EQ 'Y' then begin
+    ##              message, 'WARNING: Procedure is terminating.', /info
+    ##              mperr = -1
+    ##          endif
+    ##      endif
+    ##  endif
+
+    ## Procedure to parse the parameter values in PARINFO, which is a list of dictionaries
+    def parinfo(self, parinfo=None, key="a", default=None, n=0):
+        if self.debug:
+            print("Entering parinfo...")
+        if (n == 0) and (parinfo is not None):
+            n = len(parinfo)
+        if n == 0:
+            values = default
+            return values
+
+        values = []
+        for i in range(n):
+            if (parinfo is not None) and (key in parinfo[i]):
+                values.append(parinfo[i][key])
+            else:
+                values.append(default)
+
+        # Convert to numeric arrays if possible
+        test = default
+        if isinstance(default, list):
+            test = default[0]
+        if isinstance(test, int):
+            values = numpy.asarray(values, int)
+        elif isinstance(test, float):
+            values = numpy.asarray(values, float)
+        return values
+
+    ## Call user function or procedure, with _EXTRA or not, with
+    ## derivatives or not.
+    def call(self, fcn, x, functkw, fjac=None):
+        if self.debug:
+            print("Entering call...")
+        if self.qanytied:
+            x = self.tie(x, self.ptied)
+        self.nfev = self.nfev + 1
+        if fjac is None:
+            [status, f] = fcn(x, fjac=fjac, **functkw)
+            if self.damp > 0:
+                ## Apply the damping if requested.  This replaces the residuals
+                ## with their hyperbolic tangent.  Thus residuals larger than
+                ## DAMP are essentially clipped.
+                f = numpy.tanh(f / self.damp)
+            return [status, f]
+        else:
+            return fcn(x, fjac=fjac, **functkw)
+
+    def enorm(self, vec):
+
+        if self.debug:
+            print("Entering enorm...")
         ## NOTE: it turns out that, for systems that have a lot of data
         ## points, this routine is a big computing bottleneck.  The extended
         ## computations that need to be done cannot be effectively
         ## vectorized.  The introduction of the FASTNORM configuration
-        ## parameter allows the user to select a faster routine, which is 
+        ## parameter allows the user to select a faster routine, which is
         ## based on TOTAL() alone.
 
         # Very simple-minded sum-of-squares
-        if (self.fastnorm):
-           ans = numpy.sqrt(numpy.sum(vec*vec))
+        if self.fastnorm:
+            ans = numpy.sqrt(numpy.sum(vec * vec))
         else:
-           agiant = self.machar.rgiant / len(vec)
-           adwarf = self.machar.rdwarf * len(vec)
+            agiant = self.machar.rgiant / len(vec)
+            adwarf = self.machar.rdwarf * len(vec)
 
-           ## This is hopefully a compromise between speed and robustness.
-           ## Need to do this because of the possibility of over- or underflow.
-           mx = max(vec)
-           mn = min(vec)
-           mx = max(abs(mx), abs(mn))
-           if mx == 0: return(vec[0]*0.)
-           if mx > agiant or mx < adwarf:
-              ans = mx * numpy.sqrt(numpy.sum((vec/mx)*(vec/mx)))
-           else:
-              ans = numpy.sqrt(numpy.sum(vec*vec))
-
-        return(ans)
-
-
-   def fdjac2(self, fcn, x, fvec, step=None, ulimited=None, ulimit=None, dside=None,
-              epsfcn=None, autoderivative=1,
-              functkw=None, xall=None, ifree=None, dstep=None):
-
-      if (self.debug): print('Entering fdjac2...')
-      machep = self.machar.machep
-      if epsfcn is None:  epsfcn = machep
-      if xall is None:    xall = x
-      if ifree is None:   ifree = numpy.arange(len(xall))
-      if step is None:    step = x * 0.
-      nall = len(xall)
-
-      eps = numpy.sqrt(max([epsfcn, machep]))
-      m = len(fvec)
-      n = len(x)
-
-      ## Compute analytical derivative if requested
-      if (autoderivative == 0):
-         mperr = 0
-         fjac = numpy.zeros(nall, float)
-         numpy.put(fjac, ifree, 1.0)  ## Specify which parameters need derivatives
-         [status, fp, pderiv] = self.call(fcn, xall, functkw, fjac=fjac)
-
-         fjac = pderiv
-
-         if fjac.shape != (m, nall):
-             print('ERROR: Derivative matrix was not computed properly.')
-             return(None)
-
-         ## This definition is c1onsistent with CURVEFIT
-         ## Sign error found (thanks Jesus Fernandez <fernande@irm.chu-caen.fr>)
-         fjac = -fjac
-
-         ## Select only the free parameters
-         if len(ifree) < nall:
-            fjac = fjac[:,ifree]
-            fjac.shape = [m, n]
-            return(fjac)
-
-      fjac = numpy.zeros([m, n], float)
-
-      h = eps * abs(x)
-
-      ## if STEP is given, use that
-      if step is not None:
-         stepi = numpy.take(step, ifree)
-         wh, = numpy.nonzero(stepi > 0)
-         if (len(wh) > 0): numpy.put(h, wh, numpy.take(stepi, wh))
-
-      ## if relative step is given, use that
-      if (len(dstep) > 0):
-         dstepi = numpy.take(dstep, ifree)
-         wh, = numpy.nonzero(dstepi > 0)
-         if len(wh) > 0: numpy.put(h, wh, abs(numpy.take(dstepi,wh)*numpy.take(x,wh)))
-
-      ## In case any of the step values are zero
-      wh, = numpy.nonzero(h == 0)
-      if len(wh) > 0: numpy.put(h, wh, eps)
-
-      ## Reverse the sign of the step if we are up against the parameter
-      ## limit, or if the user requested it.
-      mask = dside == -1
-      if len(ulimited) > 0 and len(ulimit) > 0:
-         mask = mask | (ulimited & (x > ulimit-h))
-         wh, = numpy.nonzero(mask)
-         if len(wh) > 0: numpy.put(h, wh, -numpy.take(h, wh))
-      ## Loop through parameters, computing the derivative for each
-      for j in range(n):
-         xp = xall.copy()
-         xp[ifree[j]] = xp[ifree[j]] + h[j]
-         [status, fp] = self.call(fcn, xp, functkw)
-         if (status < 0): return(None)
-
-         if abs(dside[j]) <= 1:
-             ## COMPUTE THE ONE-SIDED DERIVATIVE
-             ## Note optimization fjac(0:*,j)
-             fjac[0:,j] = (fp-fvec)/h[j]
-
-         else:
-            ## COMPUTE THE TWO-SIDED DERIVATIVE
-            xp[ifree[j]] = xall[ifree[j]] - h[j]
-
-            mperr = 0
-            [status, fm] = self.call(fcn, xp, functkw)
-            if (status < 0): return(None)
-
-            ## Note optimization fjac(0:*,j)
-            fjac[0:,j] = (fp-fm)/(2*h[j])
-      return(fjac)
-
-
-
-   #     Original FORTRAN documentation
-   #     **********
-   #
-   #     subroutine qrfac
-   #
-   #     this subroutine uses householder transformations with column
-   #     pivoting (optional) to compute a qr factorization of the
-   #     m by n matrix a. that is, qrfac determines an orthogonal
-   #     matrix q, a permutation matrix p, and an upper trapezoidal
-   #     matrix r with diagonal elements of nonincreasing magnitude,
-   #     such that a*p = q*r. the householder transformation for
-   #     column k, k = 1,2,...,min(m,n), is of the form
-   #
-   #                        t
-   #        i - (1/u(k))*u*u
-   #
-   #     where u has zeros in the first k-1 positions. the form of
-   #     this transformation and the method of pivoting first
-   #     appeared in the corresponding linpack subroutine.
-   #
-   #     the subroutine statement is
-   #
-   #    subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
-   #
-   #     where
-   #
-   #    m is a positive integer input variable set to the number
-   #      of rows of a.
-   #
-   #    n is a positive integer input variable set to the number
-   #      of columns of a.
-   #
-   #    a is an m by n array. on input a contains the matrix for
-   #      which the qr factorization is to be computed. on output
-   #      the strict upper trapezoidal part of a contains the strict
-   #      upper trapezoidal part of r, and the lower trapezoidal
-   #      part of a contains a factored form of q (the non-trivial
-   #      elements of the u vectors described above).
-   #
-   #    lda is a positive integer input variable not less than m
-   #      which specifies the leading dimension of the array a.
-   #
-   #    pivot is a logical input variable. if pivot is set true,
-   #      then column pivoting is enforced. if pivot is set false,
-   #      then no column pivoting is done.
-   #
-   #    ipvt is an integer output array of length lipvt. ipvt
-   #      defines the permutation matrix p such that a*p = q*r.
-   #      column j of p is column ipvt(j) of the identity matrix.
-   #      if pivot is false, ipvt is not referenced.
-   #
-   #    lipvt is a positive integer input variable. if pivot is false,
-   #      then lipvt may be as small as 1. if pivot is true, then
-   #      lipvt must be at least n.
-   #
-   #    rdiag is an output array of length n which contains the
-   #      diagonal elements of r.
-   #
-   #    acnorm is an output array of length n which contains the
-   #      norms of the corresponding columns of the input matrix a.
-   #      if this information is not needed, then acnorm can coincide
-   #      with rdiag.
-   #
-   #    wa is a work array of length n. if pivot is false, then wa
-   #      can coincide with rdiag.
-   #
-   #     subprograms called
-   #
-   #    minpack-supplied ... dpmpar,enorm
-   #
-   #    fortran-supplied ... dmax1,dsqrt,min0
-   #
-   #     argonne national laboratory. minpack project. march 1980.
-   #     burton s. garbow, kenneth e. hillstrom, jorge j. more
-   #
-   #     **********
-
-   # NOTE: in IDL the factors appear slightly differently than described
-   # above.  The matrix A is still m x n where m >= n.  
-   #
-   # The "upper" triangular matrix R is actually stored in the strict
-   # lower left triangle of A under the standard notation of IDL.
-   #
-   # The reflectors that generate Q are in the upper trapezoid of A upon
-   # output.
-   #
-   #  EXAMPLE:  decompose the matrix [[9.,2.,6.],[4.,8.,7.]]
-   #    aa = [[9.,2.,6.],[4.,8.,7.]]
-   #    mpfit_qrfac, aa, aapvt, rdiag, aanorm
-   #     IDL> print, aa
-   #          1.81818*     0.181818*     0.545455*
-   #         -8.54545+      1.90160*     0.432573*
-   #     IDL> print, rdiag
-   #         -11.0000+     -7.48166+
-   #
-   # The components marked with a * are the components of the
-   # reflectors, and those marked with a + are components of R.
-   #
-   # To reconstruct Q and R we proceed as follows.  First R.
-   #    r = fltarr(m, n)
-   #    for i = 0, n-1 do r(0:i,i) = aa(0:i,i)  # fill in lower diag
-   #    r(lindgen(n)*(m+1)) = rdiag
-   #
-   # Next, Q, which are composed from the reflectors.  Each reflector v
-   # is taken from the upper trapezoid of aa, and converted to a matrix
-   # via (I - 2 vT . v / (v . vT)).
-   #
-   #   hh = ident                                    ## identity matrix
-   #   for i = 0, n-1 do begin
-   #    v = aa(*,i) & if i GT 0 then v(0:i-1) = 0    ## extract reflector
-   #    hh = hh ## (ident - 2*(v # v)/total(v * v))  ## generate matrix
-   #   endfor
-   #
-   # Test the result:
-   #    IDL> print, hh ## transpose(r)
-   #          9.00000      4.00000
-   #          2.00000      8.00000
-   #          6.00000      7.00000
-   #
-   # Note that it is usually never necessary to form the Q matrix
-   # explicitly, and MPFIT does not.
-   
-
-   def qrfac(self, a, pivot=0):
-
-      if (self.debug): print('Entering qrfac...')
-      machep = self.machar.machep
-      sz = numpy.shape(a)
-      m = sz[0]
-      n = sz[1]
-
-      ## Compute the initial column norms and initialize arrays
-      acnorm = numpy.zeros(n, float)
-      for j in range(n):
-         acnorm[j] = self.enorm(a[:,j])
-      rdiag = acnorm.copy()
-      wa = rdiag.copy()
-      ipvt = numpy.arange(n)
-
-      ## Reduce a to r with householder transformations
-      minmn = min([m,n])
-      for j in range(minmn):
-         if (pivot != 0):
-            ## Bring the column of largest norm into the pivot position
-            rmax = max(rdiag[j:])
-            kmax, = numpy.nonzero(rdiag[j:] == rmax)
-            ct = len(kmax)
-            kmax = kmax + j
-            if ct > 0:
-               kmax = kmax[0]
-
-               ## Exchange rows via the pivot only.  Avoid actually exchanging
-               ## the rows, in case there is lots of memory transfer.  The
-               ## exchange occurs later, within the body of MPFIT, after the
-               ## extraneous columns of the matrix have been shed.
-               if kmax != j:
-                  temp = ipvt[j] ; ipvt[j] = ipvt[kmax] ; ipvt[kmax] = temp
-                  rdiag[kmax] = rdiag[j]
-                  wa[kmax] = wa[j]
-
-         ## Compute the householder transformation to reduce the jth
-         ## column of A to a multiple of the jth unit vector
-         lj = ipvt[j]
-         ajj = a[j:,lj]
-         ajnorm = self.enorm(ajj)
-         if ajnorm == 0: break
-         if a[j,j] < 0: ajnorm = -ajnorm
-
-         ajj = ajj / ajnorm
-         ajj[0] = ajj[0] + 1
-         ## *** Note optimization a(j:*,j)
-         a[j:,lj] = ajj
-
-         ## Apply the transformation to the remaining columns
-         ## and update the norms
-
-         ## NOTE to SELF: tried to optimize this by removing the loop,
-         ## but it actually got slower.  Reverted to "for" loop to keep
-         ## it simple.
-         if (j+1 < n):
-            for k in range(j+1, n):
-               lk = ipvt[k]
-               ajk = a[j:,lk]
-               ## *** Note optimization a(j:*,lk) 
-               ## (corrected 20 Jul 2000)
-               if a[j,lj] != 0: 
-                  a[j:,lk] = ajk - ajj * numpy.sum(ajk*ajj)/a[j,lj]
-                  if ((pivot != 0) and (rdiag[k] != 0)):
-                     temp = a[j,lk]/rdiag[k]
-                     rdiag[k] = rdiag[k] * numpy.sqrt(max((1.-temp**2), 0.))
-                     temp = rdiag[k]/wa[k]
-                     if ((0.05*temp*temp) <= machep):
-                        rdiag[k] = self.enorm(a[j+1:,lk])
-                        wa[k] = rdiag[k]
-         rdiag[j] = -ajnorm
-      return([a, ipvt, rdiag, acnorm])
-
-   
-   #     Original FORTRAN documentation
-   #     **********
-   #
-   #     subroutine qrsolv
-   #
-   #     given an m by n matrix a, an n by n diagonal matrix d,
-   #     and an m-vector b, the problem is to determine an x which
-   #     solves the system
-   #
-   #           a*x = b ,     d*x = 0 ,
-   #
-   #     in the least squares sense.
-   #
-   #     this subroutine completes the solution of the problem
-   #     if it is provided with the necessary information from the
-   #     factorization, with column pivoting, of a. that is, if
-   #     a*p = q*r, where p is a permutation matrix, q has orthogonal
-   #     columns, and r is an upper triangular matrix with diagonal
-   #     elements of nonincreasing magnitude, then qrsolv expects
-   #     the full upper triangle of r, the permutation matrix p,
-   #     and the first n components of (q transpose)*b. the system
-   #     a*x = b, d*x = 0, is then equivalent to
-   #
-   #                  t       t
-   #           r*z = q *b ,  p *d*p*z = 0 ,
-   #
-   #     where x = p*z. if this system does not have full rank,
-   #     then a least squares solution is obtained. on output qrsolv
-   #     also provides an upper triangular matrix s such that
-   #
-   #            t   t               t
-   #           p *(a *a + d*d)*p = s *s .
-   #
-   #     s is computed within qrsolv and may be of separate interest.
-   #
-   #     the subroutine statement is
-   #
-   #       subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
-   #
-   #     where
-   #
-   #       n is a positive integer input variable set to the order of r.
-   #
-   #       r is an n by n array. on input the full upper triangle
-   #         must contain the full upper triangle of the matrix r.
-   #         on output the full upper triangle is unaltered, and the
-   #         strict lower triangle contains the strict upper triangle
-   #         (transposed) of the upper triangular matrix s.
-   #
-   #       ldr is a positive integer input variable not less than n
-   #         which specifies the leading dimension of the array r.
-   #
-   #       ipvt is an integer input array of length n which defines the
-   #         permutation matrix p such that a*p = q*r. column j of p
-   #         is column ipvt(j) of the identity matrix.
-   #
-   #       diag is an input array of length n which must contain the
-   #         diagonal elements of the matrix d.
-   #
-   #       qtb is an input array of length n which must contain the first
-   #         n elements of the vector (q transpose)*b.
-   #
-   #       x is an output array of length n which contains the least
-   #         squares solution of the system a*x = b, d*x = 0.
-   #
-   #       sdiag is an output array of length n which contains the
-   #         diagonal elements of the upper triangular matrix s.
-   #
-   #       wa is a work array of length n.
-   #
-   #     subprograms called
-   #
-   #       fortran-supplied ... dabs,dsqrt
-   #
-   #     argonne national laboratory. minpack project. march 1980.
-   #     burton s. garbow, kenneth e. hillstrom, jorge j. more
-   #
-   
-   def qrsolv(self, r, ipvt, diag, qtb, sdiag):
-      if (self.debug): print('Entering qrsolv...')
-      sz = numpy.shape(r)
-      m = sz[0]
-      n = sz[1]
-
-      ## copy r and (q transpose)*b to preserve input and initialize s.
-      ## in particular, save the diagonal elements of r in x.
-
-      for j in range(n):
-         r[j:n,j] = r[j,j:n]
-      x = numpy.diagonal(r).copy()
-      wa = qtb.copy()
-
-      ## Eliminate the diagonal matrix d using a givens rotation
-      for j in range(n):
-         l = ipvt[j]
-         if (diag[l] == 0): break
-         sdiag[j:] = 0
-         sdiag[j] = diag[l]
-
-         ## The transformations to eliminate the row of d modify only a
-         ## single element of (q transpose)*b beyond the first n, which
-         ## is initially zero.
-
-         qtbpj = 0.
-         for k in range(j,n):
-            if (sdiag[k] == 0): break
-            if (abs(r[k,k]) < abs(sdiag[k])):
-               cotan  = r[k,k]/sdiag[k]
-               sine   = 0.5/numpy.sqrt(.25 + .25*cotan*cotan)
-               cosine = sine*cotan
+            ## This is hopefully a compromise between speed and robustness.
+            ## Need to do this because of the possibility of over- or underflow.
+            mx = max(vec)
+            mn = min(vec)
+            mx = max(abs(mx), abs(mn))
+            if mx == 0:
+                return vec[0] * 0.0
+            if mx > agiant or mx < adwarf:
+                ans = mx * numpy.sqrt(numpy.sum((vec / mx) * (vec / mx)))
             else:
-               tang   = sdiag[k]/r[k,k]
-               cosine = 0.5/numpy.sqrt(.25 + .25*tang*tang)
-               sine   = cosine*tang
+                ans = numpy.sqrt(numpy.sum(vec * vec))
 
-            ## Compute the modified diagonal element of r and the
-            ## modified element of ((q transpose)*b,0).
-            r[k,k] = cosine*r[k,k] + sine*sdiag[k]
-            temp = cosine*wa[k] + sine*qtbpj
-            qtbpj = -sine*wa[k] + cosine*qtbpj
-            wa[k] = temp
+        return ans
 
-            ## Accumulate the transformation in the row of s
-            if (n > k+1):
-               temp = cosine*r[k+1:n,k] + sine*sdiag[k+1:n]
-               sdiag[k+1:n] = -sine*r[k+1:n,k] + cosine*sdiag[k+1:n]
-               r[k+1:n,k] = temp
-         sdiag[j] = r[j,j]
-         r[j,j] = x[j]
+    def fdjac2(
+        self,
+        fcn,
+        x,
+        fvec,
+        step=None,
+        ulimited=None,
+        ulimit=None,
+        dside=None,
+        epsfcn=None,
+        autoderivative=1,
+        functkw=None,
+        xall=None,
+        ifree=None,
+        dstep=None,
+    ):
 
-      ## Solve the triangular system for z.  If the system is singular
-      ## then obtain a least squares solution
-      nsing = n
-      wh, = numpy.nonzero(sdiag == 0)
-      if (len(wh) > 0):
-         nsing = wh[0]
-         wa[nsing:] = 0
+        if self.debug:
+            print("Entering fdjac2...")
+        machep = self.machar.machep
+        if epsfcn is None:
+            epsfcn = machep
+        if xall is None:
+            xall = x
+        if ifree is None:
+            ifree = numpy.arange(len(xall))
+        if step is None:
+            step = x * 0.0
+        nall = len(xall)
 
-      if (nsing >= 1):
-         wa[nsing-1] = wa[nsing-1]/sdiag[nsing-1] ## Degenerate case
-         ## *** Reverse loop ***
-         for j in range(nsing-2,-1,-1):  
-            sum = numpy.sum(r[j+1:nsing,j]*wa[j+1:nsing])
-            wa[j] = (wa[j]-sum)/sdiag[j]
+        eps = numpy.sqrt(max([epsfcn, machep]))
+        m = len(fvec)
+        n = len(x)
 
-      ## Permute the components of z back to components of x
-      #print "wa = ",wa, ipvt
-      numpy.put(x, ipvt, wa)
-      return(r, x, sdiag)
+        ## Compute analytical derivative if requested
+        if autoderivative == 0:
+            mperr = 0
+            fjac = numpy.zeros(nall, float)
+            numpy.put(fjac, ifree, 1.0)  ## Specify which parameters need derivatives
+            [status, fp, pderiv] = self.call(fcn, xall, functkw, fjac=fjac)
 
+            fjac = pderiv
 
+            if fjac.shape != (m, nall):
+                print("ERROR: Derivative matrix was not computed properly.")
+                return None
 
-   
-   #     Original FORTRAN documentation
-   #
-   #     subroutine lmpar
-   #
-   #     given an m by n matrix a, an n by n nonsingular diagonal
-   #     matrix d, an m-vector b, and a positive number delta,
-   #     the problem is to determine a value for the parameter
-   #     par such that if x solves the system
-   #
-   #        a*x = b ,     sqrt(par)*d*x = 0 ,
-   #
-   #     in the least squares sense, and dxnorm is the euclidean
-   #     norm of d*x, then either par is zero and
-   #
-   #        (dxnorm-delta) .le. 0.1*delta ,
-   #
-   #     or par is positive and
-   #
-   #        abs(dxnorm-delta) .le. 0.1*delta .
-   #
-   #     this subroutine completes the solution of the problem
-   #     if it is provided with the necessary information from the
-   #     qr factorization, with column pivoting, of a. that is, if
-   #     a*p = q*r, where p is a permutation matrix, q has orthogonal
-   #     columns, and r is an upper triangular matrix with diagonal
-   #     elements of nonincreasing magnitude, then lmpar expects
-   #     the full upper triangle of r, the permutation matrix p,
-   #     and the first n components of (q transpose)*b. on output
-   #     lmpar also provides an upper triangular matrix s such that
-   #
-   #         t   t                   t
-   #        p *(a *a + par*d*d)*p = s *s .
-   #
-   #     s is employed within lmpar and may be of separate interest.
-   #
-   #     only a few iterations are generally needed for convergence
-   #     of the algorithm. if, however, the limit of 10 iterations
-   #     is reached, then the output par will contain the best
-   #     value obtained so far.
-   #
-   #     the subroutine statement is
-   #
-   #    subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,
-   #                     wa1,wa2)
-   #
-   #     where
-   #
-   #    n is a positive integer input variable set to the order of r.
-   #
-   #    r is an n by n array. on input the full upper triangle
-   #      must contain the full upper triangle of the matrix r.
-   #      on output the full upper triangle is unaltered, and the
-   #      strict lower triangle contains the strict upper triangle
-   #      (transposed) of the upper triangular matrix s.
-   #
-   #    ldr is a positive integer input variable not less than n
-   #      which specifies the leading dimension of the array r.
-   #
-   #    ipvt is an integer input array of length n which defines the
-   #      permutation matrix p such that a*p = q*r. column j of p
-   #      is column ipvt(j) of the identity matrix.
-   #
-   #    diag is an input array of length n which must contain the
-   #      diagonal elements of the matrix d.
-   #
-   #    qtb is an input array of length n which must contain the first
-   #      n elements of the vector (q transpose)*b.
-   #
-   #    delta is a positive input variable which specifies an upper
-   #      bound on the euclidean norm of d*x.
-   #
-   #    par is a nonnegative variable. on input par contains an
-   #      initial estimate of the levenberg-marquardt parameter.
-   #      on output par contains the final estimate.
-   #
-   #    x is an output array of length n which contains the least
-   #      squares solution of the system a*x = b, sqrt(par)*d*x = 0,
-   #      for the output par.
-   #
-   #    sdiag is an output array of length n which contains the
-   #      diagonal elements of the upper triangular matrix s.
-   #
-   #    wa1 and wa2 are work arrays of length n.
-   #
-   #     subprograms called
-   #
-   #    minpack-supplied ... dpmpar,enorm,qrsolv
-   #
-   #    fortran-supplied ... dabs,dmax1,dmin1,dsqrt
-   #
-   #     argonne national laboratory. minpack project. march 1980.
-   #     burton s. garbow, kenneth e. hillstrom, jorge j. more
-   #
-   
-   def lmpar(self, r, ipvt, diag, qtb, delta, x, sdiag, par=None):
+            ## This definition is c1onsistent with CURVEFIT
+            ## Sign error found (thanks Jesus Fernandez <fernande@irm.chu-caen.fr>)
+            fjac = -fjac
 
-      if (self.debug): print('Entering lmpar...')
-      dwarf = self.machar.minnum
-      sz = numpy.shape(r)
-      m = sz[0]
-      n = sz[1]
+            ## Select only the free parameters
+            if len(ifree) < nall:
+                fjac = fjac[:, ifree]
+                fjac.shape = [m, n]
+                return fjac
 
-      ## Compute and store in x the gauss-newton direction.  If the
-      ## jacobian is rank-deficient, obtain a least-squares solution
-      nsing = n
-      wa1 = qtb.copy()
-      wh, = numpy.nonzero(numpy.diagonal(r) == 0)
-      if len(wh) > 0:
-         nsing = wh[0]
-         wa1[wh[0]:] = 0
-      if nsing > 1:
-         ## *** Reverse loop ***
-         for j in range(nsing-1,-1,-1):  
-            wa1[j] = wa1[j]/r[j,j]
-            if (j-1 >= 0):
-               wa1[0:j] = wa1[0:j] - r[0:j,j]*wa1[j]
+        fjac = numpy.zeros([m, n], float)
 
-      ## Note: ipvt here is a permutation array
-      numpy.put(x, ipvt, wa1)
+        h = eps * abs(x)
 
-      ## Initialize the iteration counter.  Evaluate the function at the
-      ## origin, and test for acceptance of the gauss-newton direction
-      iter = 0
-      wa2 = diag * x
-      dxnorm = self.enorm(wa2)
-      fp = dxnorm - delta
-      if (fp <= 0.1*delta):
-         return[r, 0., x, sdiag]
+        ## if STEP is given, use that
+        if step is not None:
+            stepi = numpy.take(step, ifree)
+            (wh,) = numpy.nonzero(stepi > 0)
+            if len(wh) > 0:
+                numpy.put(h, wh, numpy.take(stepi, wh))
 
-      ## If the jacobian is not rank deficient, the newton step provides a
-      ## lower bound, parl, for the zero of the function.  Otherwise set
-      ## this bound to zero.
+        ## if relative step is given, use that
+        if len(dstep) > 0:
+            dstepi = numpy.take(dstep, ifree)
+            (wh,) = numpy.nonzero(dstepi > 0)
+            if len(wh) > 0:
+                numpy.put(h, wh, abs(numpy.take(dstepi, wh) * numpy.take(x, wh)))
 
-      parl = 0.
-      if nsing >= n:
-         wa1 = numpy.take(diag, ipvt)*numpy.take(wa2, ipvt)/dxnorm
-         wa1[0] = wa1[0] / r[0,0] ## Degenerate case 
-         for j in range(1,n):   ## Note "1" here, not zero
-            sum = numpy.sum(r[0:j,j]*wa1[0:j])
-            wa1[j] = (wa1[j] - sum)/r[j,j]
+        ## In case any of the step values are zero
+        (wh,) = numpy.nonzero(h == 0)
+        if len(wh) > 0:
+            numpy.put(h, wh, eps)
 
-         temp = self.enorm(wa1)
-         parl = ((fp/delta)/temp)/temp
+        ## Reverse the sign of the step if we are up against the parameter
+        ## limit, or if the user requested it.
+        mask = dside == -1
+        if len(ulimited) > 0 and len(ulimit) > 0:
+            mask = mask | (ulimited & (x > ulimit - h))
+            (wh,) = numpy.nonzero(mask)
+            if len(wh) > 0:
+                numpy.put(h, wh, -numpy.take(h, wh))
+        ## Loop through parameters, computing the derivative for each
+        for j in range(n):
+            xp = xall.copy()
+            xp[ifree[j]] = xp[ifree[j]] + h[j]
+            [status, fp] = self.call(fcn, xp, functkw)
+            if status < 0:
+                return None
 
-      ## Calculate an upper bound, paru, for the zero of the function
-      for j in range(n):
-         sum = numpy.sum(r[0:j+1,j]*qtb[0:j+1])
-         wa1[j] = sum/diag[ipvt[j]]
-      gnorm = self.enorm(wa1)
-      paru = gnorm/delta
-      if paru == 0: paru = dwarf/min([delta,0.1])
+            if abs(dside[j]) <= 1:
+                ## COMPUTE THE ONE-SIDED DERIVATIVE
+                ## Note optimization fjac(0:*,j)
+                fjac[0:, j] = (fp - fvec) / h[j]
 
-      ## If the input par lies outside of the interval (parl,paru), set
-      ## par to the closer endpoint
+            else:
+                ## COMPUTE THE TWO-SIDED DERIVATIVE
+                xp[ifree[j]] = xall[ifree[j]] - h[j]
 
-      par = max([par,parl])
-      par = min([par,paru])
-      if par == 0: par = gnorm/dxnorm
+                mperr = 0
+                [status, fm] = self.call(fcn, xp, functkw)
+                if status < 0:
+                    return None
 
-      ## Beginning of an interation
-      while(1):
-         iter = iter + 1
+                ## Note optimization fjac(0:*,j)
+                fjac[0:, j] = (fp - fm) / (2 * h[j])
+        return fjac
 
-         ## Evaluate the function at the current value of par
-         if par == 0: par = max([dwarf, paru*0.001])
-         temp = numpy.sqrt(par)
-         wa1 = temp * diag
-         [r, x, sdiag] = self.qrsolv(r, ipvt, wa1, qtb, sdiag)
-         wa2 = diag*x
-         dxnorm = self.enorm(wa2)
-         temp = fp
-         fp = dxnorm - delta
+    #     Original FORTRAN documentation
+    #     **********
+    #
+    #     subroutine qrfac
+    #
+    #     this subroutine uses householder transformations with column
+    #     pivoting (optional) to compute a qr factorization of the
+    #     m by n matrix a. that is, qrfac determines an orthogonal
+    #     matrix q, a permutation matrix p, and an upper trapezoidal
+    #     matrix r with diagonal elements of nonincreasing magnitude,
+    #     such that a*p = q*r. the householder transformation for
+    #     column k, k = 1,2,...,min(m,n), is of the form
+    #
+    #                        t
+    #        i - (1/u(k))*u*u
+    #
+    #     where u has zeros in the first k-1 positions. the form of
+    #     this transformation and the method of pivoting first
+    #     appeared in the corresponding linpack subroutine.
+    #
+    #     the subroutine statement is
+    #
+    #    subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
+    #
+    #     where
+    #
+    #    m is a positive integer input variable set to the number
+    #      of rows of a.
+    #
+    #    n is a positive integer input variable set to the number
+    #      of columns of a.
+    #
+    #    a is an m by n array. on input a contains the matrix for
+    #      which the qr factorization is to be computed. on output
+    #      the strict upper trapezoidal part of a contains the strict
+    #      upper trapezoidal part of r, and the lower trapezoidal
+    #      part of a contains a factored form of q (the non-trivial
+    #      elements of the u vectors described above).
+    #
+    #    lda is a positive integer input variable not less than m
+    #      which specifies the leading dimension of the array a.
+    #
+    #    pivot is a logical input variable. if pivot is set true,
+    #      then column pivoting is enforced. if pivot is set false,
+    #      then no column pivoting is done.
+    #
+    #    ipvt is an integer output array of length lipvt. ipvt
+    #      defines the permutation matrix p such that a*p = q*r.
+    #      column j of p is column ipvt(j) of the identity matrix.
+    #      if pivot is false, ipvt is not referenced.
+    #
+    #    lipvt is a positive integer input variable. if pivot is false,
+    #      then lipvt may be as small as 1. if pivot is true, then
+    #      lipvt must be at least n.
+    #
+    #    rdiag is an output array of length n which contains the
+    #      diagonal elements of r.
+    #
+    #    acnorm is an output array of length n which contains the
+    #      norms of the corresponding columns of the input matrix a.
+    #      if this information is not needed, then acnorm can coincide
+    #      with rdiag.
+    #
+    #    wa is a work array of length n. if pivot is false, then wa
+    #      can coincide with rdiag.
+    #
+    #     subprograms called
+    #
+    #    minpack-supplied ... dpmpar,enorm
+    #
+    #    fortran-supplied ... dmax1,dsqrt,min0
+    #
+    #     argonne national laboratory. minpack project. march 1980.
+    #     burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #
+    #     **********
 
-         if ((abs(fp) <= 0.1*delta) or
-            ((parl == 0) and (fp <= temp) and (temp < 0)) or
-            (iter == 10)): break;
+    # NOTE: in IDL the factors appear slightly differently than described
+    # above.  The matrix A is still m x n where m >= n.
+    #
+    # The "upper" triangular matrix R is actually stored in the strict
+    # lower left triangle of A under the standard notation of IDL.
+    #
+    # The reflectors that generate Q are in the upper trapezoid of A upon
+    # output.
+    #
+    #  EXAMPLE:  decompose the matrix [[9.,2.,6.],[4.,8.,7.]]
+    #    aa = [[9.,2.,6.],[4.,8.,7.]]
+    #    mpfit_qrfac, aa, aapvt, rdiag, aanorm
+    #     IDL> print, aa
+    #          1.81818*     0.181818*     0.545455*
+    #         -8.54545+      1.90160*     0.432573*
+    #     IDL> print, rdiag
+    #         -11.0000+     -7.48166+
+    #
+    # The components marked with a * are the components of the
+    # reflectors, and those marked with a + are components of R.
+    #
+    # To reconstruct Q and R we proceed as follows.  First R.
+    #    r = fltarr(m, n)
+    #    for i = 0, n-1 do r(0:i,i) = aa(0:i,i)  # fill in lower diag
+    #    r(lindgen(n)*(m+1)) = rdiag
+    #
+    # Next, Q, which are composed from the reflectors.  Each reflector v
+    # is taken from the upper trapezoid of aa, and converted to a matrix
+    # via (I - 2 vT . v / (v . vT)).
+    #
+    #   hh = ident                                    ## identity matrix
+    #   for i = 0, n-1 do begin
+    #    v = aa(*,i) & if i GT 0 then v(0:i-1) = 0    ## extract reflector
+    #    hh = hh ## (ident - 2*(v # v)/total(v * v))  ## generate matrix
+    #   endfor
+    #
+    # Test the result:
+    #    IDL> print, hh ## transpose(r)
+    #          9.00000      4.00000
+    #          2.00000      8.00000
+    #          6.00000      7.00000
+    #
+    # Note that it is usually never necessary to form the Q matrix
+    # explicitly, and MPFIT does not.
 
-         ## Compute the newton correction
-         wa1 = numpy.take(diag, ipvt)*numpy.take(wa2, ipvt)/dxnorm
+    def qrfac(self, a, pivot=0):
 
-         for j in range(n-1):
-            wa1[j] = wa1[j]/sdiag[j]
-            wa1[j+1:n] = wa1[j+1:n] - r[j+1:n,j]*wa1[j]
-         wa1[n-1] = wa1[n-1]/sdiag[n-1] ## Degenerate case
+        if self.debug:
+            print("Entering qrfac...")
+        machep = self.machar.machep
+        sz = numpy.shape(a)
+        m = sz[0]
+        n = sz[1]
 
-         temp = self.enorm(wa1)
-         parc = ((fp/delta)/temp)/temp
+        ## Compute the initial column norms and initialize arrays
+        acnorm = numpy.zeros(n, float)
+        for j in range(n):
+            acnorm[j] = self.enorm(a[:, j])
+        rdiag = acnorm.copy()
+        wa = rdiag.copy()
+        ipvt = numpy.arange(n)
 
-         ## Depending on the sign of the function, update parl or paru
-         if fp > 0: parl = max([parl,par])
-         if fp < 0: paru = min([paru,par])
+        ## Reduce a to r with householder transformations
+        minmn = min([m, n])
+        for j in range(minmn):
+            if pivot != 0:
+                ## Bring the column of largest norm into the pivot position
+                rmax = max(rdiag[j:])
+                (kmax,) = numpy.nonzero(rdiag[j:] == rmax)
+                ct = len(kmax)
+                kmax = kmax + j
+                if ct > 0:
+                    kmax = kmax[0]
 
-         ## Compute an improved estimate for par
-         par = max([parl, par+parc])
+                    ## Exchange rows via the pivot only.  Avoid actually exchanging
+                    ## the rows, in case there is lots of memory transfer.  The
+                    ## exchange occurs later, within the body of MPFIT, after the
+                    ## extraneous columns of the matrix have been shed.
+                    if kmax != j:
+                        temp = ipvt[j]
+                        ipvt[j] = ipvt[kmax]
+                        ipvt[kmax] = temp
+                        rdiag[kmax] = rdiag[j]
+                        wa[kmax] = wa[j]
 
-         ## End of an iteration
+            ## Compute the householder transformation to reduce the jth
+            ## column of A to a multiple of the jth unit vector
+            lj = ipvt[j]
+            ajj = a[j:, lj]
+            ajnorm = self.enorm(ajj)
+            if ajnorm == 0:
+                break
+            if a[j, j] < 0:
+                ajnorm = -ajnorm
 
-      ## Termination
-      return[r, par, x, sdiag]
+            ajj = ajj / ajnorm
+            ajj[0] = ajj[0] + 1
+            ## *** Note optimization a(j:*,j)
+            a[j:, lj] = ajj
 
-   
-   ## Procedure to tie one parameter to another.
-   def tie(self, p, ptied=None):
-      if (self.debug): print('Entering tie...')
-      if (ptied is None): return
-      for i in range(len(ptied)):
-         if ptied[i] == '': continue
-         cmd = 'p[' + str(i) + '] = ' + ptied[i]
-         exec(cmd)
-      return(p)
+            ## Apply the transformation to the remaining columns
+            ## and update the norms
 
-   
-   #     Original FORTRAN documentation
-   #     **********
-   #
-   #     subroutine covar
-   #
-   #     given an m by n matrix a, the problem is to determine
-   #     the covariance matrix corresponding to a, defined as
-   #
-   #                    t
-   #           inverse(a *a) .
-   #
-   #     this subroutine completes the solution of the problem
-   #     if it is provided with the necessary information from the
-   #     qr factorization, with column pivoting, of a. that is, if
-   #     a*p = q*r, where p is a permutation matrix, q has orthogonal
-   #     columns, and r is an upper triangular matrix with diagonal
-   #     elements of nonincreasing magnitude, then covar expects
-   #     the full upper triangle of r and the permutation matrix p.
-   #     the covariance matrix is then computed as
-   #
-   #                      t     t
-   #           p*inverse(r *r)*p  .
-   #
-   #     if a is nearly rank deficient, it may be desirable to compute
-   #     the covariance matrix corresponding to the linearly independent
-   #     columns of a. to define the numerical rank of a, covar uses
-   #     the tolerance tol. if l is the largest integer such that
-   #
-   #           abs(r(l,l)) .gt. tol*abs(r(1,1)) ,
-   #
-   #     then covar computes the covariance matrix corresponding to
-   #     the first l columns of r. for k greater than l, column
-   #     and row ipvt(k) of the covariance matrix are set to zero.
-   #
-   #     the subroutine statement is
-   #
-   #       subroutine covar(n,r,ldr,ipvt,tol,wa)
-   #
-   #     where
-   #
-   #       n is a positive integer input variable set to the order of r.
-   #
-   #       r is an n by n array. on input the full upper triangle must
-   #         contain the full upper triangle of the matrix r. on output
-   #         r contains the square symmetric covariance matrix.
-   #
-   #       ldr is a positive integer input variable not less than n
-   #         which specifies the leading dimension of the array r.
-   #
-   #       ipvt is an integer input array of length n which defines the
-   #         permutation matrix p such that a*p = q*r. column j of p
-   #         is column ipvt(j) of the identity matrix.
-   #
-   #       tol is a nonnegative input variable used to define the
-   #         numerical rank of a in the manner described above.
-   #
-   #       wa is a work array of length n.
-   #
-   #     subprograms called
-   #
-   #       fortran-supplied ... dabs
-   #
-   #     argonne national laboratory. minpack project. august 1980.
-   #     burton s. garbow, kenneth e. hillstrom, jorge j. more
-   #
-   #     **********
-   
-   def calc_covar(self, rr, ipvt=None, tol=1.e-14):
+            ## NOTE to SELF: tried to optimize this by removing the loop,
+            ## but it actually got slower.  Reverted to "for" loop to keep
+            ## it simple.
+            if j + 1 < n:
+                for k in range(j + 1, n):
+                    lk = ipvt[k]
+                    ajk = a[j:, lk]
+                    ## *** Note optimization a(j:*,lk)
+                    ## (corrected 20 Jul 2000)
+                    if a[j, lj] != 0:
+                        a[j:, lk] = ajk - ajj * numpy.sum(ajk * ajj) / a[j, lj]
+                        if (pivot != 0) and (rdiag[k] != 0):
+                            temp = a[j, lk] / rdiag[k]
+                            rdiag[k] = rdiag[k] * numpy.sqrt(max((1.0 - temp**2), 0.0))
+                            temp = rdiag[k] / wa[k]
+                            if (0.05 * temp * temp) <= machep:
+                                rdiag[k] = self.enorm(a[j + 1 :, lk])
+                                wa[k] = rdiag[k]
+            rdiag[j] = -ajnorm
+        return [a, ipvt, rdiag, acnorm]
 
-      if (self.debug): print('Entering calc_covar...')
-      if numpy.ndim(rr) != 2:
-         print('ERROR: r must be a two-dimensional matrix')
-         return(-1)
-      s = numpy.shape(rr)
-      n = s[0]
-      if s[0] != s[1]:
-         print('ERROR: r must be a square matrix')
-         return(-1)
+    #     Original FORTRAN documentation
+    #     **********
+    #
+    #     subroutine qrsolv
+    #
+    #     given an m by n matrix a, an n by n diagonal matrix d,
+    #     and an m-vector b, the problem is to determine an x which
+    #     solves the system
+    #
+    #           a*x = b ,     d*x = 0 ,
+    #
+    #     in the least squares sense.
+    #
+    #     this subroutine completes the solution of the problem
+    #     if it is provided with the necessary information from the
+    #     factorization, with column pivoting, of a. that is, if
+    #     a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #     columns, and r is an upper triangular matrix with diagonal
+    #     elements of nonincreasing magnitude, then qrsolv expects
+    #     the full upper triangle of r, the permutation matrix p,
+    #     and the first n components of (q transpose)*b. the system
+    #     a*x = b, d*x = 0, is then equivalent to
+    #
+    #                  t       t
+    #           r*z = q *b ,  p *d*p*z = 0 ,
+    #
+    #     where x = p*z. if this system does not have full rank,
+    #     then a least squares solution is obtained. on output qrsolv
+    #     also provides an upper triangular matrix s such that
+    #
+    #            t   t               t
+    #           p *(a *a + d*d)*p = s *s .
+    #
+    #     s is computed within qrsolv and may be of separate interest.
+    #
+    #     the subroutine statement is
+    #
+    #       subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
+    #
+    #     where
+    #
+    #       n is a positive integer input variable set to the order of r.
+    #
+    #       r is an n by n array. on input the full upper triangle
+    #         must contain the full upper triangle of the matrix r.
+    #         on output the full upper triangle is unaltered, and the
+    #         strict lower triangle contains the strict upper triangle
+    #         (transposed) of the upper triangular matrix s.
+    #
+    #       ldr is a positive integer input variable not less than n
+    #         which specifies the leading dimension of the array r.
+    #
+    #       ipvt is an integer input array of length n which defines the
+    #         permutation matrix p such that a*p = q*r. column j of p
+    #         is column ipvt(j) of the identity matrix.
+    #
+    #       diag is an input array of length n which must contain the
+    #         diagonal elements of the matrix d.
+    #
+    #       qtb is an input array of length n which must contain the first
+    #         n elements of the vector (q transpose)*b.
+    #
+    #       x is an output array of length n which contains the least
+    #         squares solution of the system a*x = b, d*x = 0.
+    #
+    #       sdiag is an output array of length n which contains the
+    #         diagonal elements of the upper triangular matrix s.
+    #
+    #       wa is a work array of length n.
+    #
+    #     subprograms called
+    #
+    #       fortran-supplied ... dabs,dsqrt
+    #
+    #     argonne national laboratory. minpack project. march 1980.
+    #     burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #
 
-      if (ipvt is None): ipvt = numpy.arange(n)
-      r = rr.copy()
-      r.shape = [n,n]
+    def qrsolv(self, r, ipvt, diag, qtb, sdiag):
+        if self.debug:
+            print("Entering qrsolv...")
+        sz = numpy.shape(r)
+        m = sz[0]
+        n = sz[1]
 
-      ## For the inverse of r in the full upper triangle of r
-      l = -1
-      tolr = tol * abs(r[0,0])
-      for k in range(n):
-         if (abs(r[k,k]) <= tolr): break
-         r[k,k] = 1./r[k,k]
-         for j in range(k):
-            temp = r[k,k] * r[j,k]
-            r[j,k] = 0.
-            r[0:j+1,k] = r[0:j+1,k] - temp*r[0:j+1,j]
-         l = k
+        ## copy r and (q transpose)*b to preserve input and initialize s.
+        ## in particular, save the diagonal elements of r in x.
 
-      ## Form the full upper triangle of the inverse of (r transpose)*r
-      ## in the full upper triangle of r
-      if l >= 0:
-         for k in range(l+1):
+        for j in range(n):
+            r[j:n, j] = r[j, j:n]
+        x = numpy.diagonal(r).copy()
+        wa = qtb.copy()
+
+        ## Eliminate the diagonal matrix d using a givens rotation
+        for j in range(n):
+            l = ipvt[j]
+            if diag[l] == 0:
+                break
+            sdiag[j:] = 0
+            sdiag[j] = diag[l]
+
+            ## The transformations to eliminate the row of d modify only a
+            ## single element of (q transpose)*b beyond the first n, which
+            ## is initially zero.
+
+            qtbpj = 0.0
+            for k in range(j, n):
+                if sdiag[k] == 0:
+                    break
+                if abs(r[k, k]) < abs(sdiag[k]):
+                    cotan = r[k, k] / sdiag[k]
+                    sine = 0.5 / numpy.sqrt(0.25 + 0.25 * cotan * cotan)
+                    cosine = sine * cotan
+                else:
+                    tang = sdiag[k] / r[k, k]
+                    cosine = 0.5 / numpy.sqrt(0.25 + 0.25 * tang * tang)
+                    sine = cosine * tang
+
+                ## Compute the modified diagonal element of r and the
+                ## modified element of ((q transpose)*b,0).
+                r[k, k] = cosine * r[k, k] + sine * sdiag[k]
+                temp = cosine * wa[k] + sine * qtbpj
+                qtbpj = -sine * wa[k] + cosine * qtbpj
+                wa[k] = temp
+
+                ## Accumulate the transformation in the row of s
+                if n > k + 1:
+                    temp = cosine * r[k + 1 : n, k] + sine * sdiag[k + 1 : n]
+                    sdiag[k + 1 : n] = (
+                        -sine * r[k + 1 : n, k] + cosine * sdiag[k + 1 : n]
+                    )
+                    r[k + 1 : n, k] = temp
+            sdiag[j] = r[j, j]
+            r[j, j] = x[j]
+
+        ## Solve the triangular system for z.  If the system is singular
+        ## then obtain a least squares solution
+        nsing = n
+        (wh,) = numpy.nonzero(sdiag == 0)
+        if len(wh) > 0:
+            nsing = wh[0]
+            wa[nsing:] = 0
+
+        if nsing >= 1:
+            wa[nsing - 1] = wa[nsing - 1] / sdiag[nsing - 1]  ## Degenerate case
+            ## *** Reverse loop ***
+            for j in range(nsing - 2, -1, -1):
+                sum = numpy.sum(r[j + 1 : nsing, j] * wa[j + 1 : nsing])
+                wa[j] = (wa[j] - sum) / sdiag[j]
+
+        ## Permute the components of z back to components of x
+        # print "wa = ",wa, ipvt
+        numpy.put(x, ipvt, wa)
+        return (r, x, sdiag)
+
+    #     Original FORTRAN documentation
+    #
+    #     subroutine lmpar
+    #
+    #     given an m by n matrix a, an n by n nonsingular diagonal
+    #     matrix d, an m-vector b, and a positive number delta,
+    #     the problem is to determine a value for the parameter
+    #     par such that if x solves the system
+    #
+    #        a*x = b ,     sqrt(par)*d*x = 0 ,
+    #
+    #     in the least squares sense, and dxnorm is the euclidean
+    #     norm of d*x, then either par is zero and
+    #
+    #        (dxnorm-delta) .le. 0.1*delta ,
+    #
+    #     or par is positive and
+    #
+    #        abs(dxnorm-delta) .le. 0.1*delta .
+    #
+    #     this subroutine completes the solution of the problem
+    #     if it is provided with the necessary information from the
+    #     qr factorization, with column pivoting, of a. that is, if
+    #     a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #     columns, and r is an upper triangular matrix with diagonal
+    #     elements of nonincreasing magnitude, then lmpar expects
+    #     the full upper triangle of r, the permutation matrix p,
+    #     and the first n components of (q transpose)*b. on output
+    #     lmpar also provides an upper triangular matrix s such that
+    #
+    #         t   t                   t
+    #        p *(a *a + par*d*d)*p = s *s .
+    #
+    #     s is employed within lmpar and may be of separate interest.
+    #
+    #     only a few iterations are generally needed for convergence
+    #     of the algorithm. if, however, the limit of 10 iterations
+    #     is reached, then the output par will contain the best
+    #     value obtained so far.
+    #
+    #     the subroutine statement is
+    #
+    #    subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,
+    #                     wa1,wa2)
+    #
+    #     where
+    #
+    #    n is a positive integer input variable set to the order of r.
+    #
+    #    r is an n by n array. on input the full upper triangle
+    #      must contain the full upper triangle of the matrix r.
+    #      on output the full upper triangle is unaltered, and the
+    #      strict lower triangle contains the strict upper triangle
+    #      (transposed) of the upper triangular matrix s.
+    #
+    #    ldr is a positive integer input variable not less than n
+    #      which specifies the leading dimension of the array r.
+    #
+    #    ipvt is an integer input array of length n which defines the
+    #      permutation matrix p such that a*p = q*r. column j of p
+    #      is column ipvt(j) of the identity matrix.
+    #
+    #    diag is an input array of length n which must contain the
+    #      diagonal elements of the matrix d.
+    #
+    #    qtb is an input array of length n which must contain the first
+    #      n elements of the vector (q transpose)*b.
+    #
+    #    delta is a positive input variable which specifies an upper
+    #      bound on the euclidean norm of d*x.
+    #
+    #    par is a nonnegative variable. on input par contains an
+    #      initial estimate of the levenberg-marquardt parameter.
+    #      on output par contains the final estimate.
+    #
+    #    x is an output array of length n which contains the least
+    #      squares solution of the system a*x = b, sqrt(par)*d*x = 0,
+    #      for the output par.
+    #
+    #    sdiag is an output array of length n which contains the
+    #      diagonal elements of the upper triangular matrix s.
+    #
+    #    wa1 and wa2 are work arrays of length n.
+    #
+    #     subprograms called
+    #
+    #    minpack-supplied ... dpmpar,enorm,qrsolv
+    #
+    #    fortran-supplied ... dabs,dmax1,dmin1,dsqrt
+    #
+    #     argonne national laboratory. minpack project. march 1980.
+    #     burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #
+
+    def lmpar(self, r, ipvt, diag, qtb, delta, x, sdiag, par=None):
+
+        if self.debug:
+            print("Entering lmpar...")
+        dwarf = self.machar.minnum
+        sz = numpy.shape(r)
+        m = sz[0]
+        n = sz[1]
+
+        ## Compute and store in x the gauss-newton direction.  If the
+        ## jacobian is rank-deficient, obtain a least-squares solution
+        nsing = n
+        wa1 = qtb.copy()
+        (wh,) = numpy.nonzero(numpy.diagonal(r) == 0)
+        if len(wh) > 0:
+            nsing = wh[0]
+            wa1[wh[0] :] = 0
+        if nsing > 1:
+            ## *** Reverse loop ***
+            for j in range(nsing - 1, -1, -1):
+                wa1[j] = wa1[j] / r[j, j]
+                if j - 1 >= 0:
+                    wa1[0:j] = wa1[0:j] - r[0:j, j] * wa1[j]
+
+        ## Note: ipvt here is a permutation array
+        numpy.put(x, ipvt, wa1)
+
+        ## Initialize the iteration counter.  Evaluate the function at the
+        ## origin, and test for acceptance of the gauss-newton direction
+        iter = 0
+        wa2 = diag * x
+        dxnorm = self.enorm(wa2)
+        fp = dxnorm - delta
+        if fp <= 0.1 * delta:
+            return [r, 0.0, x, sdiag]
+
+        ## If the jacobian is not rank deficient, the newton step provides a
+        ## lower bound, parl, for the zero of the function.  Otherwise set
+        ## this bound to zero.
+
+        parl = 0.0
+        if nsing >= n:
+            wa1 = numpy.take(diag, ipvt) * numpy.take(wa2, ipvt) / dxnorm
+            wa1[0] = wa1[0] / r[0, 0]  ## Degenerate case
+            for j in range(1, n):  ## Note "1" here, not zero
+                sum = numpy.sum(r[0:j, j] * wa1[0:j])
+                wa1[j] = (wa1[j] - sum) / r[j, j]
+
+            temp = self.enorm(wa1)
+            parl = ((fp / delta) / temp) / temp
+
+        ## Calculate an upper bound, paru, for the zero of the function
+        for j in range(n):
+            sum = numpy.sum(r[0 : j + 1, j] * qtb[0 : j + 1])
+            wa1[j] = sum / diag[ipvt[j]]
+        gnorm = self.enorm(wa1)
+        paru = gnorm / delta
+        if paru == 0:
+            paru = dwarf / min([delta, 0.1])
+
+        ## If the input par lies outside of the interval (parl,paru), set
+        ## par to the closer endpoint
+
+        par = max([par, parl])
+        par = min([par, paru])
+        if par == 0:
+            par = gnorm / dxnorm
+
+        ## Beginning of an interation
+        while 1:
+            iter = iter + 1
+
+            ## Evaluate the function at the current value of par
+            if par == 0:
+                par = max([dwarf, paru * 0.001])
+            temp = numpy.sqrt(par)
+            wa1 = temp * diag
+            [r, x, sdiag] = self.qrsolv(r, ipvt, wa1, qtb, sdiag)
+            wa2 = diag * x
+            dxnorm = self.enorm(wa2)
+            temp = fp
+            fp = dxnorm - delta
+
+            if (
+                (abs(fp) <= 0.1 * delta)
+                or ((parl == 0) and (fp <= temp) and (temp < 0))
+                or (iter == 10)
+            ):
+                break
+
+            ## Compute the newton correction
+            wa1 = numpy.take(diag, ipvt) * numpy.take(wa2, ipvt) / dxnorm
+
+            for j in range(n - 1):
+                wa1[j] = wa1[j] / sdiag[j]
+                wa1[j + 1 : n] = wa1[j + 1 : n] - r[j + 1 : n, j] * wa1[j]
+            wa1[n - 1] = wa1[n - 1] / sdiag[n - 1]  ## Degenerate case
+
+            temp = self.enorm(wa1)
+            parc = ((fp / delta) / temp) / temp
+
+            ## Depending on the sign of the function, update parl or paru
+            if fp > 0:
+                parl = max([parl, par])
+            if fp < 0:
+                paru = min([paru, par])
+
+            ## Compute an improved estimate for par
+            par = max([parl, par + parc])
+
+            ## End of an iteration
+
+        ## Termination
+        return [r, par, x, sdiag]
+
+    ## Procedure to tie one parameter to another.
+    def tie(self, p, ptied=None):
+        if self.debug:
+            print("Entering tie...")
+        if ptied is None:
+            return
+        for i in range(len(ptied)):
+            if ptied[i] == "":
+                continue
+            cmd = "p[" + str(i) + "] = " + ptied[i]
+            exec(cmd)
+        return p
+
+    #     Original FORTRAN documentation
+    #     **********
+    #
+    #     subroutine covar
+    #
+    #     given an m by n matrix a, the problem is to determine
+    #     the covariance matrix corresponding to a, defined as
+    #
+    #                    t
+    #           inverse(a *a) .
+    #
+    #     this subroutine completes the solution of the problem
+    #     if it is provided with the necessary information from the
+    #     qr factorization, with column pivoting, of a. that is, if
+    #     a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #     columns, and r is an upper triangular matrix with diagonal
+    #     elements of nonincreasing magnitude, then covar expects
+    #     the full upper triangle of r and the permutation matrix p.
+    #     the covariance matrix is then computed as
+    #
+    #                      t     t
+    #           p*inverse(r *r)*p  .
+    #
+    #     if a is nearly rank deficient, it may be desirable to compute
+    #     the covariance matrix corresponding to the linearly independent
+    #     columns of a. to define the numerical rank of a, covar uses
+    #     the tolerance tol. if l is the largest integer such that
+    #
+    #           abs(r(l,l)) .gt. tol*abs(r(1,1)) ,
+    #
+    #     then covar computes the covariance matrix corresponding to
+    #     the first l columns of r. for k greater than l, column
+    #     and row ipvt(k) of the covariance matrix are set to zero.
+    #
+    #     the subroutine statement is
+    #
+    #       subroutine covar(n,r,ldr,ipvt,tol,wa)
+    #
+    #     where
+    #
+    #       n is a positive integer input variable set to the order of r.
+    #
+    #       r is an n by n array. on input the full upper triangle must
+    #         contain the full upper triangle of the matrix r. on output
+    #         r contains the square symmetric covariance matrix.
+    #
+    #       ldr is a positive integer input variable not less than n
+    #         which specifies the leading dimension of the array r.
+    #
+    #       ipvt is an integer input array of length n which defines the
+    #         permutation matrix p such that a*p = q*r. column j of p
+    #         is column ipvt(j) of the identity matrix.
+    #
+    #       tol is a nonnegative input variable used to define the
+    #         numerical rank of a in the manner described above.
+    #
+    #       wa is a work array of length n.
+    #
+    #     subprograms called
+    #
+    #       fortran-supplied ... dabs
+    #
+    #     argonne national laboratory. minpack project. august 1980.
+    #     burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #
+    #     **********
+
+    def calc_covar(self, rr, ipvt=None, tol=1.0e-14):
+
+        if self.debug:
+            print("Entering calc_covar...")
+        if numpy.ndim(rr) != 2:
+            print("ERROR: r must be a two-dimensional matrix")
+            return -1
+        s = numpy.shape(rr)
+        n = s[0]
+        if s[0] != s[1]:
+            print("ERROR: r must be a square matrix")
+            return -1
+
+        if ipvt is None:
+            ipvt = numpy.arange(n)
+        r = rr.copy()
+        r.shape = [n, n]
+
+        ## For the inverse of r in the full upper triangle of r
+        l = -1
+        tolr = tol * abs(r[0, 0])
+        for k in range(n):
+            if abs(r[k, k]) <= tolr:
+                break
+            r[k, k] = 1.0 / r[k, k]
             for j in range(k):
-               temp = r[j,k]
-               r[0:j+1,j] = r[0:j+1,j] + temp*r[0:j+1,k]
-            temp = r[k,k]
-            r[0:k+1,k] = temp * r[0:k+1,k]
+                temp = r[k, k] * r[j, k]
+                r[j, k] = 0.0
+                r[0 : j + 1, k] = r[0 : j + 1, k] - temp * r[0 : j + 1, j]
+            l = k
 
-      ## For the full lower triangle of the covariance matrix
-      ## in the strict lower triangle or and in wa
-      wa = numpy.repeat([r[0,0]], n)
-      for j in range(n):
-         jj = ipvt[j]
-         sing = j > l
-         for i in range(j+1):
-             if sing: r[i,j] = 0.
-             ii = ipvt[i]
-             if ii > jj: r[ii,jj] = r[i,j]
-             if ii < jj: r[jj,ii] = r[i,j]
-         wa[jj] = r[j,j]
+        ## Form the full upper triangle of the inverse of (r transpose)*r
+        ## in the full upper triangle of r
+        if l >= 0:
+            for k in range(l + 1):
+                for j in range(k):
+                    temp = r[j, k]
+                    r[0 : j + 1, j] = r[0 : j + 1, j] + temp * r[0 : j + 1, k]
+                temp = r[k, k]
+                r[0 : k + 1, k] = temp * r[0 : k + 1, k]
 
-      ## Symmetrize the covariance matrix in r
-      for j in range(n):
-         r[0:j+1,j] = r[j,0:j+1]
-         r[j,j] = wa[j]
+        ## For the full lower triangle of the covariance matrix
+        ## in the strict lower triangle or and in wa
+        wa = numpy.repeat([r[0, 0]], n)
+        for j in range(n):
+            jj = ipvt[j]
+            sing = j > l
+            for i in range(j + 1):
+                if sing:
+                    r[i, j] = 0.0
+                ii = ipvt[i]
+                if ii > jj:
+                    r[ii, jj] = r[i, j]
+                if ii < jj:
+                    r[jj, ii] = r[i, j]
+            wa[jj] = r[j, j]
 
-      return(r)
+        ## Symmetrize the covariance matrix in r
+        for j in range(n):
+            r[0 : j + 1, j] = r[j, 0 : j + 1]
+            r[j, j] = wa[j]
+
+        return r
+
 
 class machar:
-   def __init__(self, double=1):
-      if (double == 0):
-         self.machep = 1.19209e-007
-         self.maxnum = 3.40282e+038
-         self.minnum = 1.17549e-038
-         self.maxgam = 171.624376956302725
-      else:
-         self.machep = 2.2204460e-016
-         self.maxnum = 1.7976931e+308
-         self.minnum = 2.2250739e-308
-         self.maxgam = 171.624376956302725
+    def __init__(self, double=1):
+        if double == 0:
+            self.machep = 1.19209e-007
+            self.maxnum = 3.40282e038
+            self.minnum = 1.17549e-038
+            self.maxgam = 171.624376956302725
+        else:
+            self.machep = 2.2204460e-016
+            self.maxnum = 1.7976931e308
+            self.minnum = 2.2250739e-308
+            self.maxgam = 171.624376956302725
 
-      self.maxlog = numpy.log(self.maxnum)
-      self.minlog = numpy.log(self.minnum)
-      self.rdwarf = numpy.sqrt(self.minnum*1.5) * 10
-      self.rgiant = numpy.sqrt(self.maxnum) * 0.1
-
-
+        self.maxlog = numpy.log(self.maxnum)
+        self.minlog = numpy.log(self.minnum)
+        self.rdwarf = numpy.sqrt(self.minnum * 1.5) * 10
+        self.rgiant = numpy.sqrt(self.maxnum) * 0.1

--- a/circ/bootjtk/pipeline.py
+++ b/circ/bootjtk/pipeline.py
@@ -13,24 +13,19 @@ This script bootstraps time series and provides phase and tau distributions from
 Please use ./BooteJTK -h to see the help screen for further instructions on running this script.
 
 """
-VERSION="1.0"
 
-#import cmath
-from scipy.stats import circmean as sscircmean
-from scipy.stats import circstd as sscircstd
-#import scipy.stats as ss
+VERSION = "1.0"
+
+# import cmath
+
+# import scipy.stats as ss
 import numpy as np
-#from scipy.stats import kendalltau as kt
-from scipy.stats import multivariate_normal as mn
-from scipy.stats import rankdata
-from scipy.stats import norm
-from scipy.special import polygamma
+
+# from scipy.stats import kendalltau as kt
 import pandas as pd
-import pickle
-#from operator import itemgetter
-import sys
+
+# from operator import itemgetter
 import argparse
-import time
 import os.path
 
 import hashlib
@@ -45,35 +40,50 @@ from .limma_preprocess import prepare_timeseries, write_limma_outputs
 from .limma_voom import run_vooma_ebayes, run_vooma_vash
 
 _PKG_DIR = os.path.dirname(os.path.abspath(__file__))
-_NULL_CACHE_DIR = Path.home() / '.cache' / 'circ' / 'null_cache'
+_NULL_CACHE_DIR = Path.home() / ".cache" / "circ" / "null_cache"
 
 
-def _null_cache_key(header, period_file, phase_file, width_file, waveform, reps, size, limma, vash, noreps):
+def _null_cache_key(
+    header,
+    period_file,
+    phase_file,
+    width_file,
+    waveform,
+    reps,
+    size,
+    limma,
+    vash,
+    noreps,
+):
     """Return a hex digest that uniquely identifies a null distribution configuration."""
+
     def _read(path):
         try:
             return open(path).read()
         except (OSError, TypeError):
             return str(path)
 
-    payload = json.dumps({
-        'header':  sorted(header),
-        'period':  _read(period_file),
-        'phase':   _read(phase_file),
-        'width':   _read(width_file),
-        'waveform': str(waveform),
-        'reps':    int(reps),
-        'size':    int(size),
-        'limma':   bool(limma),
-        'vash':    bool(vash),
-        'noreps':  bool(noreps),
-    }, sort_keys=True)
+    payload = json.dumps(
+        {
+            "header": sorted(header),
+            "period": _read(period_file),
+            "phase": _read(phase_file),
+            "width": _read(width_file),
+            "waveform": str(waveform),
+            "reps": int(reps),
+            "size": int(size),
+            "limma": bool(limma),
+            "vash": bool(vash),
+            "noreps": bool(noreps),
+        },
+        sort_keys=True,
+    )
     return hashlib.sha256(payload.encode()).hexdigest()[:20]
 
 
 def _cached_null_path(key):
     # Filename must contain 'boot' so CalcP reads the TauMean column correctly.
-    return _NULL_CACHE_DIR / f'null_boot_{key}.txt'
+    return _NULL_CACHE_DIR / f"null_boot_{key}.txt"
 
 
 def _load_null_cache(key):
@@ -86,160 +96,174 @@ def _save_null_cache(key, src_path):
     _NULL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src_path, _cached_null_path(key))
 
+
 def main(args):
 
     fn = args.filename
 
     ### INTEGRATING THIS INTO THE R CODE
-    #fn_means = args.means
-    #fn_sds = args.sds
-    #fn_ns = args.ns
-    
+    # fn_means = args.means
+    # fn_sds = args.sds
+    # fn_ns = args.ns
+
     prefix = args.prefix
     fn_waveform = args.waveform
     fn_period = args.period
     fn_phase = args.phase
     fn_width = args.width
     fn_out = args.output
-    fn_out_pkl = args.pickle # This is the output file which could be read in early
-    fn_list = args.id_list # This is the the list of ids to go through
-    fn_null_list = args.null_list # These are geneIDs to be used to estimate the SD
+    fn_out_pkl = args.pickle  # This is the output file which could be read in early
+    fn_list = args.id_list  # This is the the list of ids to go through
+    fn_null_list = args.null_list  # These are geneIDs to be used to estimate the SD
     size = int(args.size)
     reps = int(args.reps)
 
     try:
-        assert '.txt' in fn or '.txt' in args.means
+        assert ".txt" in fn or ".txt" in args.means
     except AssertionError:
-        print('Please make the suffix of your raw data file or means file .txt')
+        print("Please make the suffix of your raw data file or means file .txt")
         assert 0
 
-    if args.basic==False:
-        args.limma=True
-        args.vash =True
-    elif args.basic==True and args.limma==True and args.vash==False:
-        args.limma=True
-        args.vash =False
+    if not args.basic:
+        args.limma = True
+        args.vash = True
+    elif args.basic and args.limma and not args.vash:
+        args.limma = True
+        args.vash = False
 
-    print('Basic:', args.basic)
-    print('Limma:', args.limma)
-    print('Vash:', args.vash)
+    print("Basic:", args.basic)
+    print("Limma:", args.limma)
+    print("Vash:", args.vash)
 
-    #fn_null = args.null
-    if args.noreps==True:
-        args.prefix = 'NoRepSD_'+args.prefix
-        print('No replicates, skipping Limma procedure')
-        print('Estimating time point variance from arrhythmic genes')
+    # fn_null = args.null
+    if args.noreps:
+        args.prefix = "NoRepSD_" + args.prefix
+        print("No replicates, skipping Limma procedure")
+        print("Estimating time point variance from arrhythmic genes")
         try:
-            df = pd.read_table(fn,index_col='ID')
+            df = pd.read_table(fn, index_col="ID")
         except ValueError:
-            df = pd.read_table(fn,index_col='#')
+            df = pd.read_table(fn, index_col="#")
         except ValueError:
             print('Header needs to begin with "ID" or with "#"')
 
-        j = pd.read_table(args.jtk,index_col='ID')
-        mean = df.loc[j[j.GammaP>0.8].index].std(axis=1).dropna().mean()
+        j = pd.read_table(args.jtk, index_col="ID")
+        mean = df.loc[j[j.GammaP > 0.8].index].std(axis=1).dropna().mean()
 
-        df_sds = pd.DataFrame(np.ones(df.shape)*mean,index=df.index,columns=df.columns)
-        df_ns =  pd.DataFrame(np.ones(df.shape),index=df.index,columns=df.columns)
-        fn_sds = fn.replace('.txt','_Sds_noRepsEst.txt')
-        df_sds.to_csv(fn_sds,na_rep=np.nan,sep='\t')
-        fn_ns = fn.replace('.txt','_Ns_noRepsEst.txt')
-        df_sds.to_csv(fn_ns,na_rep=np.nan,sep='\t')
-                      
+        df_sds = pd.DataFrame(
+            np.ones(df.shape) * mean, index=df.index, columns=df.columns
+        )
+        df_ns = pd.DataFrame(np.ones(df.shape), index=df.index, columns=df.columns)
+        fn_sds = fn.replace(".txt", "_Sds_noRepsEst.txt")
+        df_sds.to_csv(fn_sds, na_rep=np.nan, sep="\t")
+        fn_ns = fn.replace(".txt", "_Ns_noRepsEst.txt")
+        df_sds.to_csv(fn_ns, na_rep=np.nan, sep="\t")
+
         args.means = fn
         args.sds = fn_sds
         args.ns = fn_ns
-        
-    elif args.limma==True:
 
-        pref = fn.replace('.txt', '')
+    elif args.limma:
+        pref = fn.replace(".txt", "")
         period_val = float(pd.read_table(fn_period, header=None)[0][0])
 
-        if args.vash==False and fn is not None:
-            print('Running the Limma commands')
-            args.prefix = 'Limma_' + args.prefix
-            suffix = 'postLimma'
-        elif args.vash==True and fn is not None:
-            print('Running the Vash commands')
-            args.prefix = 'Vash_' + args.prefix
-            suffix = 'postVash'
+        if not args.vash and fn is not None:
+            print("Running the Limma commands")
+            args.prefix = "Limma_" + args.prefix
+            suffix = "postLimma"
+        elif args.vash and fn is not None:
+            print("Running the Vash commands")
+            args.prefix = "Vash_" + args.prefix
+            suffix = "postVash"
 
-        args.means = fn.replace('.txt', f'_Means_{suffix}.txt')
-        args.sds   = fn.replace('.txt', f'_Sds_{suffix}.txt')
-        args.ns    = fn.replace('.txt', f'_Ns_{suffix}.txt')
+        args.means = fn.replace(".txt", f"_Means_{suffix}.txt")
+        args.sds = fn.replace(".txt", f"_Sds_{suffix}.txt")
+        args.ns = fn.replace(".txt", f"_Ns_{suffix}.txt")
 
         df_clean, _ = prepare_timeseries(fn, period_val)
         preprocessor = run_vooma_vash if args.vash else run_vooma_ebayes
         long_df = preprocessor(df_clean, period_val, rnaseq=args.rnaseq)
         write_limma_outputs(long_df, pref, suffix)
     else:
-        print('Using neither Limma nor Vash')
+        print("Using neither Limma nor Vash")
         pass
-    
-    fn_out,fn_out_pkl,header = BooteJTK.main(args)
 
-    #args.output = fn_out.replace('boot','NULL1000-boot')
-    #args.pickle = fn_out_pkl.replace('boot','NULL1000-boot')
+    fn_out, fn_out_pkl, header = BooteJTK.main(args)
 
-    #print args.pickle
-    #print args.output
+    # args.output = fn_out.replace('boot','NULL1000-boot')
+    # args.pickle = fn_out_pkl.replace('boot','NULL1000-boot')
+
+    # print args.pickle
+    # print args.output
     null_key = _null_cache_key(
         header,
-        fn_period, fn_phase, fn_width, fn_waveform,
-        reps, size,
-        args.limma, args.vash, args.noreps,
+        fn_period,
+        fn_phase,
+        fn_width,
+        fn_waveform,
+        reps,
+        size,
+        args.limma,
+        args.vash,
+        args.noreps,
     )
     fn_null_out = _load_null_cache(null_key)
 
     if fn_null_out is not None:
-        print(f'Null distribution cache hit (key={null_key[:8]}...) — skipping null BooteJTK run.')
+        print(
+            f"Null distribution cache hit (key={null_key[:8]}...) — skipping null BooteJTK run."
+        )
     else:
-        fn_null = fn.replace('.txt','_NULL1000.txt')
+        fn_null = fn.replace(".txt", "_NULL1000.txt")
 
         sims = 1000
-        with open(fn_null,'w') as g:
-            g.write('\t'.join(['#']+header)+'\n')
+        with open(fn_null, "w") as g:
+            g.write("\t".join(["#"] + header) + "\n")
             for i in range(sims):
-                line = ['wnoise_'+str(i)] + [str(v) for v in np.random.normal(0,1,len(header))]
-                g.write('\t'.join(line)+'\n')
+                line = ["wnoise_" + str(i)] + [
+                    str(v) for v in np.random.normal(0, 1, len(header))
+                ]
+                g.write("\t".join(line) + "\n")
 
         args.filename = fn_null
 
-        if args.noreps==True:
-            print('No replicates, skipping Limma procedure')
-            print('Estimating time point variance from arrhythmic genes')
+        if args.noreps:
+            print("No replicates, skipping Limma procedure")
+            print("Estimating time point variance from arrhythmic genes")
             try:
-                df = pd.read_table(fn,index_col='ID')
+                df = pd.read_table(fn, index_col="ID")
             except ValueError:
-                df = pd.read_table(fn,index_col='#')
+                df = pd.read_table(fn, index_col="#")
             except ValueError:
                 print('Header needs to begin with "ID" or with "#"')
 
-            j = pd.read_table(args.jtk,index_col='ID')
-            mean = df.loc[j[j.GammaP>0.8].index].std(axis=1).dropna().mean()
+            j = pd.read_table(args.jtk, index_col="ID")
+            mean = df.loc[j[j.GammaP > 0.8].index].std(axis=1).dropna().mean()
 
-            df_sds = pd.DataFrame(np.ones(df.shape)*mean,index=df.index,columns=df.columns)
-            df_ns =  pd.DataFrame(np.ones(df.shape),index=df.index,columns=df.columns)
-            fn_sds = fn_null.replace('.txt','_Sds_noRepsEst.txt')
-            df_sds.to_csv(fn_sds,na_rep=np.nan,sep='\t')
-            fn_ns = fn_null.replace('.txt','_Ns_noRepsEst.txt')
-            df_sds.to_csv(fn_ns,na_rep=np.nan,sep='\t')
+            df_sds = pd.DataFrame(
+                np.ones(df.shape) * mean, index=df.index, columns=df.columns
+            )
+            df_ns = pd.DataFrame(np.ones(df.shape), index=df.index, columns=df.columns)
+            fn_sds = fn_null.replace(".txt", "_Sds_noRepsEst.txt")
+            df_sds.to_csv(fn_sds, na_rep=np.nan, sep="\t")
+            fn_ns = fn_null.replace(".txt", "_Ns_noRepsEst.txt")
+            df_sds.to_csv(fn_ns, na_rep=np.nan, sep="\t")
 
             args.means = fn_null
             args.sds = fn_sds
             args.ns = fn_ns
-        elif args.limma==True:
-            pref_null = fn_null.replace('.txt', '')
-            if args.vash==False:
-                suffix_null = 'postLimma'
-                args.means = fn_null.replace('.txt', '_Means_postLimma.txt')
-                args.sds   = fn_null.replace('.txt', '_Sds_postLimma.txt')
-                args.ns    = fn_null.replace('.txt', '_Ns_postLimma.txt')
+        elif args.limma:
+            pref_null = fn_null.replace(".txt", "")
+            if not args.vash:
+                suffix_null = "postLimma"
+                args.means = fn_null.replace(".txt", "_Means_postLimma.txt")
+                args.sds = fn_null.replace(".txt", "_Sds_postLimma.txt")
+                args.ns = fn_null.replace(".txt", "_Ns_postLimma.txt")
             else:
-                suffix_null = 'postVash'
-                args.means = fn_null.replace('.txt', '_Means_postVash.txt')
-                args.sds   = fn_null.replace('.txt', '_Sds_postVash.txt')
-                args.ns    = fn_null.replace('.txt', '_Ns_postVash.txt')
+                suffix_null = "postVash"
+                args.means = fn_null.replace(".txt", "_Means_postVash.txt")
+                args.sds = fn_null.replace(".txt", "_Sds_postVash.txt")
+                args.ns = fn_null.replace(".txt", "_Ns_postVash.txt")
 
             df_null_clean, _ = prepare_timeseries(fn_null, period_val)
             preprocessor = run_vooma_vash if args.vash else run_vooma_ebayes
@@ -248,235 +272,301 @@ def main(args):
         else:
             pass
 
-        fn_null_out,_,_ = BooteJTK.main(args)
+        fn_null_out, _, _ = BooteJTK.main(args)
         _save_null_cache(null_key, fn_null_out)
-        print(f'Null distribution cached (key={null_key[:8]}...).')
+        print(f"Null distribution cached (key={null_key[:8]}...).")
 
     args.filename = fn_out
     args.null = fn_null_out
-    args.fit = ''
+    args.fit = ""
     CalcP.main(args)
 
 
 def __create_parser__():
     p = argparse.ArgumentParser(
         description="Bootstrap empirical JTK_CYCLE (eJTK) for circadian rhythm detection. "
-                    "See Hutchison et al. PLoS Comput Biol 2015 11(3):e1004094.",
+        "See Hutchison et al. PLoS Comput Biol 2015 11(3):e1004094.",
         epilog="Please contact the corresponding author if you have any questions.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        )
-    p.add_argument('--version', '-V', action='version', version='%(prog)s ' + VERSION)
+    )
+    p.add_argument("--version", "-V", action="version", version="%(prog)s " + VERSION)
 
-                   
-    #p.add_argument("-t", "--test",
+    # p.add_argument("-t", "--test",
     #               action='store_true',
     #               default=False,
     #               help="run the Python unittest testing suite")
-    p.add_argument("-o", "--output",
-                   dest="output",
-                   action='store',
-                   metavar="filename string",
-                   type=str,
-                   default = "DEFAULT",
-                   help="You want to output something. If you leave this blank, _jtkout.txt will be appended to your filename")
+    p.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        action="store",
+        metavar="filename string",
+        type=str,
+        default="DEFAULT",
+        help="You want to output something. If you leave this blank, _jtkout.txt will be appended to your filename",
+    )
 
-    p.add_argument("-k","--pickle",
-                          dest="pickle",
-                          metavar="filename string",
-                          type=str,
-                          action='store',
-                          default="DEFAULT",
-                          help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
-                          Provided file is "period_24.txt"')
+    p.add_argument(
+        "-k",
+        "--pickle",
+        dest="pickle",
+        metavar="filename string",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
+                          Provided file is "period_24.txt"',
+    )
 
+    p.add_argument(
+        "-l",
+        "--list",
+        dest="id_list",
+        metavar="filename string",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help="A filename of the ids to be run in this time series. If time is running out on your job, this will be compared to the ids that have already been completed and a file will be created stating what ids remain to be analyzed.",
+    )
 
-    p.add_argument("-l","--list",
-                          dest="id_list",
-                          metavar="filename string",
-                          type=str,
-                          action='store',
-                          default="DEFAULT",
-                          help='A filename of the ids to be run in this time series. If time is running out on your job, this will be compared to the ids that have already been completed and a file will be created stating what ids remain to be analyzed.')
-
-
-    p.add_argument("-n","--null",
-                          dest="null_list",
-                          metavar="filename string",
-                          type=str,
-                          action='store',
-                          default="DEFAULT",
-                          help='A filename of the ids upon which to calculate the standard deviation. These ids are non-cycling, so the standard deviation can be taken across the entire time series. Using this argument is useless if the bootstraps have already been performed.')
-    
+    p.add_argument(
+        "-n",
+        "--null",
+        dest="null_list",
+        metavar="filename string",
+        type=str,
+        action="store",
+        default="DEFAULT",
+        help="A filename of the ids upon which to calculate the standard deviation. These ids are non-cycling, so the standard deviation can be taken across the entire time series. Using this argument is useless if the bootstraps have already been performed.",
+    )
 
     analysis = p.add_argument_group(title="JTK_CYCLE analysis options")
 
-    analysis.add_argument("-f", "--filename",
-                   dest="filename",
-                   action='store',
-                   metavar="filename string",
-                   type=str,
-                    default='DEFAULT',
-                   help='This is the filename of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it\'s place.')
-    analysis.add_argument("-F", "--means",
-                   dest="means",
-                   action='store',
-                   metavar="filename string",
-                    default='DEFAULT',                          
-                   type=str,
-                   help='This is the filename of the time point means of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it\'s place.')
+    analysis.add_argument(
+        "-f",
+        "--filename",
+        dest="filename",
+        action="store",
+        metavar="filename string",
+        type=str,
+        default="DEFAULT",
+        help="This is the filename of the data series you wish to analyze.\
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+    )
+    analysis.add_argument(
+        "-F",
+        "--means",
+        dest="means",
+        action="store",
+        metavar="filename string",
+        default="DEFAULT",
+        type=str,
+        help="This is the filename of the time point means of the data series you wish to analyze.\
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+    )
 
-    analysis.add_argument("-S", "--sds",
-                   dest="sds",
-                   action='store',
-                   metavar="filename string",
-                    default='DEFAULT',                          
-                   type=str,
-                   help='This is the filename of the time point standard devations of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it\'s place.')
+    analysis.add_argument(
+        "-S",
+        "--sds",
+        dest="sds",
+        action="store",
+        metavar="filename string",
+        default="DEFAULT",
+        type=str,
+        help="This is the filename of the time point standard devations of the data series you wish to analyze.\
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+    )
 
-    analysis.add_argument("-N", "--ns",
-                   dest="ns",
-                   action='store',
-                   metavar="filename string",
-                    default='DEFAULT',
-                   type=str,
-                   help='This is the filename of the time point replicate numbers of the data series you wish to analyze.                         \
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it\'s place.')
+    analysis.add_argument(
+        "-N",
+        "--ns",
+        dest="ns",
+        action="store",
+        metavar="filename string",
+        default="DEFAULT",
+        type=str,
+        help="This is the filename of the time point replicate numbers of the data series you wish to analyze.                         \
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+    )
 
+    analysis.add_argument(
+        "-x",
+        "--prefix",
+        dest="prefix",
+        type=str,
+        metavar="string",
+        action="store",
+        default="",
+        help="string to be inserted in the output filename for this run",
+    )
 
-    analysis.add_argument('-x',"--prefix",
-                          dest="prefix",
-                          type=str,
-                          metavar="string",
-                          action='store',
-                          default="",
-                          help="string to be inserted in the output filename for this run")
+    analysis.add_argument(
+        "-r",
+        "--reps",
+        dest="reps",
+        type=int,
+        metavar="int",
+        action="store",
+        default=2,
+        help="# of reps of each time point to bootstrap (1 or 2, generally)",
+    )
 
+    analysis.add_argument(
+        "-z",
+        "--size",
+        dest="size",
+        type=int,
+        metavar="N",
+        action="store",
+        default=50,
+        help="Number of bootstrap resamples per gene.",
+    )
 
-    analysis.add_argument('-r',"--reps",
-                          dest="reps",
-                          type=int,
-                          metavar="int",
-                          action='store',
-                          default=2,
-                          help="# of reps of each time point to bootstrap (1 or 2, generally)")
+    analysis.add_argument(
+        "-j",
+        "--workers",
+        dest="workers",
+        type=int,
+        metavar="N",
+        action="store",
+        default=1,
+        help="Parallel worker processes. 0 = all available CPUs.",
+    )
 
-    analysis.add_argument('-z',"--size",
-                          dest="size",
-                          type=int,
-                          metavar="N",
-                          action='store',
-                          default=50,
-                          help="Number of bootstrap resamples per gene.")
+    analysis.add_argument(
+        "-w",
+        "--waveform",
+        dest="waveform",
+        type=str,
+        metavar="filename string",
+        action="store",
+        default="cosine",
+        # choices=["waveform_cosine.txt","waveform_rampup.txt","waveform_rampdown.txt","waveform_step.txt","waveform_impulse.txt","waveform_trough.txt"],
+        help="Should be a file with waveforms  you wish to search for listed in a single column separated by newlines.\
+                          Options include cosine (dflt), trough",
+    )
 
-    analysis.add_argument('-j', '--workers',
-                          dest='workers',
-                          type=int,
-                          metavar='N',
-                          action='store',
-                          default=1,
-                          help='Parallel worker processes. 0 = all available CPUs.')
+    analysis.add_argument(
+        "--width",
+        "-a",
+        "--asymmetry",
+        dest="width",
+        type=str,
+        metavar="filename string",
+        action="store",
+        default="widths_02-22.txt",
+        # choices=["widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"]
+        help='Should be a file with asymmetries (widths) you wish to search for listed in a single column separated by newlines.\
+                          Provided files include files like "widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"\nasymmetries=widths',
+    )
+    analysis.add_argument(
+        "-s",
+        "-ph",
+        "--phase",
+        dest="phase",
+        metavar="filename string",
+        type=str,
+        default="phases_00-22_by2.txt",
+        help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
+                          Example files include "phases_00-22_by2.txt" or "phases_00-22_by4.txt" or "phases_00-20_by4.txt"',
+    )
 
-    analysis.add_argument('-w',"--waveform",
-                          dest="waveform",
-                          type=str,
-                          metavar="filename string",
-                          action='store',
-                          default="cosine",
-                          #choices=["waveform_cosine.txt","waveform_rampup.txt","waveform_rampdown.txt","waveform_step.txt","waveform_impulse.txt","waveform_trough.txt"],
-                          help='Should be a file with waveforms  you wish to search for listed in a single column separated by newlines.\
-                          Options include cosine (dflt), trough')
+    analysis.add_argument(
+        "-p",
+        "--period",
+        dest="period",
+        metavar="filename string",
+        type=str,
+        action="store",
+        default="period_24.txt",
+        help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
+                          Provided file is "period_24.txt"',
+    )
 
-    analysis.add_argument("--width", "-a", "--asymmetry",
-                          dest="width",
-                          type=str,
-                          metavar="filename string",
-                          action='store',
-                          default="widths_02-22.txt",
-                          #choices=["widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"]
-                          help='Should be a file with asymmetries (widths) you wish to search for listed in a single column separated by newlines.\
-                          Provided files include files like "widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"\nasymmetries=widths')
-    analysis.add_argument('-s', "-ph", "--phase",
-                          dest="phase",
-                          metavar="filename string",
-                          type=str,
-                          default="phases_00-22_by2.txt",
-                          help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
-                          Example files include "phases_00-22_by2.txt" or "phases_00-22_by4.txt" or "phases_00-20_by4.txt"')
+    analysis.add_argument(
+        "--vash",
+        dest="vash",
+        action="store_true",
+        default=False,
+        help="Determine if you would like to use limma or Vash",
+    )
 
-    analysis.add_argument("-p","--period",
-                          dest="period",
-                          metavar="filename string",
-                          type=str,
-                          action='store',
-                          default="period_24.txt",
-                          help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
-                          Provided file is "period_24.txt"')
+    analysis.add_argument(
+        "-U",
+        "--noreps",
+        "--unique",
+        dest="noreps",
+        action="store_true",
+        default=False,
+        help="Determine if your data has no replicates and therefore the standard deviation should be estimated from the arrhythmic time series",
+    )
 
+    analysis.add_argument(
+        "-R",
+        "--rnaseq",
+        dest="rnaseq",
+        action="store_true",
+        default=False,
+        help="Flag for data that is RNA-Seq and for which voom should be used.",
+    )
 
-    analysis.add_argument("--vash",
-                          dest="vash",
-                          action='store_true',
-                          default=False,
-                          help='Determine if you would like to use limma or Vash')
+    analysis.add_argument(
+        "-L",
+        "--limma",
+        dest="limma",
+        action="store_true",
+        default=False,
+        help="Flag for using the limma variance shrinkage methods",
+    )
 
-    analysis.add_argument("-U","--noreps","--unique",
-                          dest="noreps",
-                          action='store_true',
-                          default=False,
-                          help='Determine if your data has no replicates and therefore the standard deviation should be estimated from the arrhythmic time series')
+    analysis.add_argument(
+        "-J",
+        "--jtk",
+        dest="jtk",
+        metavar="filename string",
+        type=str,
+        action="store",
+        help="The eJTK file to use if you don't have replicates in in your time series. The standard deviation between points will be estimated based on the arrhythmic time series.",
+    )
 
-    analysis.add_argument("-R","--rnaseq",
-                          dest="rnaseq",
-                          action='store_true',
-                          default=False,
-                          help='Flag for data that is RNA-Seq and for which voom should be used.')
-    
-    analysis.add_argument("-L","--limma",
-                          dest="limma",
-                          action='store_true',
-                          default=False,
-                          help='Flag for using the limma variance shrinkage methods')
-    
+    analysis.add_argument(
+        "-B",
+        "--basic",
+        dest="basic",
+        action="store_true",
+        default=False,
+        help="Flag for not using the limma or vash settings",
+    )
 
-    analysis.add_argument("-J","--jtk",
-                          dest="jtk",
-                          metavar="filename string",
-                          type=str,
-                          action='store',
-                          help="The eJTK file to use if you don't have replicates in in your time series. The standard deviation between points will be estimated based on the arrhythmic time series.")
-
-    analysis.add_argument("-B","--basic",
-                          dest="basic",
-                          action='store_true',
-                          default=False,
-                          help='Flag for not using the limma or vash settings')
-
-    analysis.add_argument("-W", "--write",
-                   dest="write",
-                   action='store_true',
-                   default=False,
-                   help='If you want pickle output from BooteJTK, use this flag.')
-    
-    
+    analysis.add_argument(
+        "-W",
+        "--write",
+        dest="write",
+        action="store_true",
+        default=False,
+        help="If you want pickle output from BooteJTK, use this flag.",
+    )
 
     distribution = analysis.add_mutually_exclusive_group(required=False)
-    distribution.add_argument("-e", "--exact",
-                              dest="harding",
-                              action='store_true',
-                              default=False,
-                              help="use Harding's exact null distribution (dflt)")
-    distribution.add_argument("-g", "--gaussian","--normal",
-                              dest="normal",
-                              action='store_true',
-                              default=False,
-                              help="use normal approximation to null distribution")
-    
+    distribution.add_argument(
+        "-e",
+        "--exact",
+        dest="harding",
+        action="store_true",
+        default=False,
+        help="use Harding's exact null distribution (dflt)",
+    )
+    distribution.add_argument(
+        "-g",
+        "--gaussian",
+        "--normal",
+        dest="normal",
+        action="store_true",
+        default=False,
+        help="use normal approximation to null distribution",
+    )
+
     return p
-
-
 
 
 def cli():
@@ -485,5 +575,5 @@ def cli():
     main(args)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     cli()

--- a/circ/cli.py
+++ b/circ/cli.py
@@ -1,4 +1,5 @@
 """Unified command-line interface for CIRC."""
+
 import argparse
 import sys
 
@@ -7,14 +8,19 @@ import sys
 # Subcommand implementations
 # ---------------------------------------------------------------------------
 
-def _run_impute(args):
+
+def _run_impute(args: argparse.Namespace) -> None:
     from circ.limbr.imputation import imputable
-    obj = imputable(args.filename, missingness=args.missingness, neighbors=args.neighbors)
+
+    obj = imputable(
+        args.filename, missingness=args.missingness, neighbors=args.neighbors
+    )
     obj.impute_data(args.output)
 
 
-def _run_normalize(args):
+def _run_normalize(args: argparse.Namespace) -> None:
     from circ.limbr.batch_fx import sva
+
     obj = sva(
         args.filename,
         design=args.design,
@@ -27,15 +33,17 @@ def _run_normalize(args):
     obj.output_default(args.output)
 
 
-def _run_rank(args):
+def _run_rank(args: argparse.Namespace) -> None:
     from circ.pirs.rank import ranker
+
     obj = ranker(args.filename, anova=not args.no_anova)
     sorted_data = obj.pirs_sort(outname=args.output)
     print(f"Ranked {len(sorted_data)} expression profiles → {args.output}")
 
 
-def _run_classify(args):
+def _run_classify(args: argparse.Namespace) -> None:
     from circ.expression_classification.classify import Classifier
+
     clf = Classifier(
         args.filename,
         anova=args.anova,
@@ -44,15 +52,15 @@ def _run_classify(args):
         workers=args.workers,
     )
     result = clf.run_all(
-        pirs_alpha=args.pirs_alpha,
         basic=not args.limma,
         pirs_percentile=args.pirs_percentile,
         tau_threshold=args.tau_threshold,
         emp_p_threshold=args.emp_p_threshold,
     )
     from circ.io import write_expression
+
     write_expression(result, args.output)
-    counts = result['label'].value_counts().to_dict()
+    counts = result["label"].value_counts().to_dict()
     print(f"Classified {len(result)} genes → {args.output}")
     for label, n in sorted(counts.items()):
         print(f"  {label}: {n}")
@@ -62,51 +70,113 @@ def _run_classify(args):
 # Parser builders
 # ---------------------------------------------------------------------------
 
-def _add_impute_parser(subparsers):
+
+def _add_impute_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
     p = subparsers.add_parser(
         "impute",
         help="Impute missing data with KNN (LIMBR)",
         description="Deduplicates peptides, drops high-missingness rows, and imputes remaining "
-                    "missing values using K-nearest neighbours.",
+        "missing values using K-nearest neighbours.",
     )
-    p.add_argument("-f", "--filename", required=True, metavar="FILE",
-                   help="Tab-separated input file (Peptide/Protein index + ZT columns)")
-    p.add_argument("-m", "--missingness", type=float, default=0.3, metavar="FLOAT",
-                   help="Maximum allowable missingness fraction per row (default: 0.3)")
-    p.add_argument("-n", "--neighbors", type=int, default=10, metavar="N",
-                   help="Number of nearest neighbours for KNN imputation (default: 10)")
-    p.add_argument("-o", "--output", required=True, metavar="FILE",
-                   help="Output file path")
+    p.add_argument(
+        "-f",
+        "--filename",
+        required=True,
+        metavar="FILE",
+        help="Tab-separated input file (Peptide/Protein index + ZT columns)",
+    )
+    p.add_argument(
+        "-m",
+        "--missingness",
+        type=float,
+        default=0.3,
+        metavar="FLOAT",
+        help="Maximum allowable missingness fraction per row (default: 0.3)",
+    )
+    p.add_argument(
+        "-n",
+        "--neighbors",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Number of nearest neighbours for KNN imputation (default: 10)",
+    )
+    p.add_argument(
+        "-o", "--output", required=True, metavar="FILE", help="Output file path"
+    )
     return p
 
 
-def _add_normalize_parser(subparsers):
+def _add_normalize_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
     p = subparsers.add_parser(
         "normalize",
         help="Normalize and remove batch effects (LIMBR SVA)",
         description="Applies pool normalization, quantile normalization, and SVA-based batch "
-                    "effect identification and removal.",
+        "effect identification and removal.",
     )
-    p.add_argument("-f", "--filename", required=True, metavar="FILE",
-                   help="Tab-separated input file (imputed proteomics or RNAseq)")
-    p.add_argument("-d", "--design", required=True, choices=["c", "t", "b"],
-                   help="Experimental design: c=circadian, t=timecourse, b=block")
-    p.add_argument("-t", "--data-type", required=True, choices=["p", "r"], dest="data_type",
-                   help="Data type: p=proteomics (Peptide/Protein index), r=RNAseq (# index)")
-    p.add_argument("-b", "--blocks", default=None, metavar="FILE",
-                   help="Parquet file with 'block' column (required when design=b)")
-    p.add_argument("-p", "--pool", default=None, metavar="FILE",
-                   help="Parquet file with 'pool_number' column (proteomics pool controls)")
-    p.add_argument("--nperm", type=int, default=200, metavar="N",
-                   help="Permutation iterations for batch effect significance (default: 200)")
-    p.add_argument("--nproc", type=int, default=1, metavar="N",
-                   help="Parallel worker processes for permutation testing (default: 1)")
-    p.add_argument("-o", "--output", required=True, metavar="FILE",
-                   help="Output file path")
+    p.add_argument(
+        "-f",
+        "--filename",
+        required=True,
+        metavar="FILE",
+        help="Tab-separated input file (imputed proteomics or RNAseq)",
+    )
+    p.add_argument(
+        "-d",
+        "--design",
+        required=True,
+        choices=["c", "t", "b"],
+        help="Experimental design: c=circadian, t=timecourse, b=block",
+    )
+    p.add_argument(
+        "-t",
+        "--data-type",
+        required=True,
+        choices=["p", "r"],
+        dest="data_type",
+        help="Data type: p=proteomics (Peptide/Protein index), r=RNAseq (# index)",
+    )
+    p.add_argument(
+        "-b",
+        "--blocks",
+        default=None,
+        metavar="FILE",
+        help="Parquet file with 'block' column (required when design=b)",
+    )
+    p.add_argument(
+        "-p",
+        "--pool",
+        default=None,
+        metavar="FILE",
+        help="Parquet file with 'pool_number' column (proteomics pool controls)",
+    )
+    p.add_argument(
+        "--nperm",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Permutation iterations for batch effect significance (default: 200)",
+    )
+    p.add_argument(
+        "--nproc",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Parallel worker processes for permutation testing (default: 1)",
+    )
+    p.add_argument(
+        "-o", "--output", required=True, metavar="FILE", help="Output file path"
+    )
     return p
 
 
-def _add_classify_parser(subparsers):
+def _add_classify_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
     p = subparsers.add_parser(
         "classify",
         help="Classify expression profiles using PIRS + BooteJTK",
@@ -115,48 +185,103 @@ def _add_classify_parser(subparsers):
             "then labels each gene as: constitutive, rhythmic, variable, or noisy_rhythmic."
         ),
     )
-    p.add_argument("-f", "--filename", required=True, metavar="FILE",
-                   help="Tab-separated input file (# index + ZT/CT columns)")
-    p.add_argument("-o", "--output", required=True, metavar="FILE",
-                   help="Output TSV with classification results")
-    p.add_argument("--anova", action="store_true",
-                   help="ANOVA-filter differentially expressed genes before PIRS scoring")
-    p.add_argument("--pirs-alpha", type=float, default=0.5, metavar="FLOAT",
-                   dest="pirs_alpha",
-                   help="Prediction interval alpha for PIRS scoring (default: 0.5)")
-    p.add_argument("--pirs-percentile", type=float, default=50, metavar="FLOAT",
-                   dest="pirs_percentile",
-                   help="PIRS percentile cutoff for 'stable' genes (default: 50)")
-    p.add_argument("--tau-threshold", type=float, default=0.5, metavar="FLOAT",
-                   dest="tau_threshold",
-                   help="Minimum TauMean to classify a gene as rhythmic (default: 0.5)")
-    p.add_argument("--emp-p-threshold", type=float, default=0.05, metavar="FLOAT",
-                   dest="emp_p_threshold",
-                   help="Maximum FDR-corrected p-value for rhythmicity (default: 0.05)")
-    p.add_argument("-r", "--reps", type=int, default=2, metavar="N",
-                   help="Replicates per timepoint for BooteJTK (default: 2)")
-    p.add_argument("-z", "--size", type=int, default=50, metavar="N",
-                   help="Bootstrap iterations per gene for BooteJTK (default: 50)")
-    p.add_argument("-j", "--workers", type=int, default=1, metavar="N",
-                   help="Parallel worker processes for BooteJTK (default: 1)")
-    p.add_argument("--limma", action="store_true",
-                   help="Use Limma/Vash variance shrinkage before BooteJTK")
+    p.add_argument(
+        "-f",
+        "--filename",
+        required=True,
+        metavar="FILE",
+        help="Tab-separated input file (# index + ZT/CT columns)",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        metavar="FILE",
+        help="Output TSV with classification results",
+    )
+    p.add_argument(
+        "--anova",
+        action="store_true",
+        help="ANOVA-filter differentially expressed genes before PIRS scoring",
+    )
+    p.add_argument(
+        "--pirs-percentile",
+        type=float,
+        default=50,
+        metavar="FLOAT",
+        dest="pirs_percentile",
+        help="PIRS percentile cutoff for 'stable' genes (default: 50)",
+    )
+    p.add_argument(
+        "--tau-threshold",
+        type=float,
+        default=0.5,
+        metavar="FLOAT",
+        dest="tau_threshold",
+        help="Minimum TauMean to classify a gene as rhythmic (default: 0.5)",
+    )
+    p.add_argument(
+        "--emp-p-threshold",
+        type=float,
+        default=0.05,
+        metavar="FLOAT",
+        dest="emp_p_threshold",
+        help="Maximum FDR-corrected p-value for rhythmicity (default: 0.05)",
+    )
+    p.add_argument(
+        "-r",
+        "--reps",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Replicates per timepoint for BooteJTK (default: 2)",
+    )
+    p.add_argument(
+        "-z",
+        "--size",
+        type=int,
+        default=50,
+        metavar="N",
+        help="Bootstrap iterations per gene for BooteJTK (default: 50)",
+    )
+    p.add_argument(
+        "-j",
+        "--workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Parallel worker processes for BooteJTK (default: 1)",
+    )
+    p.add_argument(
+        "--limma",
+        action="store_true",
+        help="Use Limma/Vash variance shrinkage before BooteJTK",
+    )
     return p
 
 
-def _add_rank_parser(subparsers):
+def _add_rank_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p = subparsers.add_parser(
         "rank",
         help="Rank expression profiles by constitutiveness (PIRS)",
         description="Sorts expression profiles from most to least constitutive using "
-                    "prediction interval ranking scores.",
+        "prediction interval ranking scores.",
     )
-    p.add_argument("-f", "--filename", required=True, metavar="FILE",
-                   help="Tab-separated input file (# index + ZT columns)")
-    p.add_argument("--no-anova", action="store_true",
-                   help="Skip ANOVA pre-filtering of differentially expressed profiles")
-    p.add_argument("-o", "--output", required=True, metavar="FILE",
-                   help="Output scores file path")
+    p.add_argument(
+        "-f",
+        "--filename",
+        required=True,
+        metavar="FILE",
+        help="Tab-separated input file (# index + ZT columns)",
+    )
+    p.add_argument(
+        "--no-anova",
+        action="store_true",
+        help="Skip ANOVA pre-filtering of differentially expressed profiles",
+    )
+    p.add_argument(
+        "-o", "--output", required=True, metavar="FILE", help="Output scores file path"
+    )
     return p
 
 
@@ -164,7 +289,8 @@ def _add_rank_parser(subparsers):
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def main():
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="circ",
         description="Circadian Integrated Research Core — unified analysis toolkit",
@@ -173,8 +299,9 @@ def main():
             "Run 'circ rhythm --help' or 'circ rhythm-calcp --help' for details."
         ),
     )
-    parser.add_argument("--version", "-V", action="version",
-                        version="%(prog)s " + _get_version())
+    parser.add_argument(
+        "--version", "-V", action="version", version="%(prog)s " + _get_version()
+    )
 
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
 
@@ -215,17 +342,20 @@ def main():
     elif args.command == "rhythm":
         sys.argv = [sys.argv[0]] + (args.bootejtk_args or [])
         from circ.bootjtk.BooteJTK import cli
+
         cli()
     elif args.command == "rhythm-calcp":
         sys.argv = [sys.argv[0]] + (args.bootejtk_args or [])
         from circ.bootjtk.pipeline import cli
+
         cli()
     else:
         parser.print_help()
 
 
-def _get_version():
+def _get_version() -> str:
     from importlib.metadata import version, PackageNotFoundError
+
     try:
         return version("circ")
     except PackageNotFoundError:

--- a/circ/compare.py
+++ b/circ/compare.py
@@ -30,6 +30,7 @@ Statistical methods
 
 Both tests apply Benjamini–Hochberg FDR correction across all tested genes.
 """
+
 import numpy as np
 import pandas as pd
 from scipy import stats
@@ -38,6 +39,7 @@ from scipy import stats
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def aggregate_to_protein(result):
     """Aggregate peptide-level classifier results to the protein level.
@@ -68,29 +70,33 @@ def aggregate_to_protein(result):
     if not isinstance(result.index, pd.MultiIndex):
         return result.copy()
 
-    protein = result.index.get_level_values('Protein')
+    protein = result.index.get_level_values("Protein")
     df = result.copy()
-    df.index = pd.Index(protein, name='Protein')
+    df.index = pd.Index(protein, name="Protein")
 
-    numeric_cols = set(df.select_dtypes(include='number').columns)
+    numeric_cols = set(df.select_dtypes(include="number").columns)
     agg = {}
     for col in df.columns:
-        if col == 'phase_mean':
+        if col == "phase_mean":
             continue
-        elif col == 'label':
+        elif col == "label":
             agg[col] = _majority_label
         elif col in numeric_cols:
-            agg[col] = 'mean'
+            agg[col] = "mean"
 
-    out = df.groupby(df.index, sort=False).agg(agg) if agg else pd.DataFrame(index=df.index.unique())
+    out = (
+        df.groupby(df.index, sort=False).agg(agg)
+        if agg
+        else pd.DataFrame(index=df.index.unique())
+    )
 
-    if 'phase_mean' in df.columns:
-        angles = 2 * np.pi * df['phase_mean'].values / 24.0
+    if "phase_mean" in df.columns:
+        angles = 2 * np.pi * df["phase_mean"].values / 24.0
         sin_s = pd.Series(np.sin(angles), index=df.index)
         cos_s = pd.Series(np.cos(angles), index=df.index)
         sin_mean = sin_s.groupby(df.index, sort=False).mean()
         cos_mean = cos_s.groupby(df.index, sort=False).mean()
-        out['phase_mean'] = (np.arctan2(sin_mean, cos_mean) * 24 / (2 * np.pi)) % 24
+        out["phase_mean"] = (np.arctan2(sin_mean, cos_mean) * 24 / (2 * np.pi)) % 24
 
     return out.reindex(columns=[c for c in result.columns if c in out.columns])
 
@@ -140,7 +146,7 @@ def compare_conditions(
         * ``phase_pval``, ``phase_padj`` — z-test on phase shift
           (only for genes rhythmic in both conditions)
     """
-    for _name, _res in (('result_A', result_A), ('result_B', result_B)):
+    for _name, _res in (("result_A", result_A), ("result_B", result_B)):
         if isinstance(_res.index, pd.MultiIndex):
             raise ValueError(
                 f"{_name} has a MultiIndex (peptide-level proteomics data). "
@@ -162,45 +168,48 @@ def compare_conditions(
 
     out = pd.DataFrame(index=shared)
     out.index.name = A.index.name
-    out['label_A'] = A['label']
-    out['label_B'] = B['label']
+    out["label_A"] = A["label"]
+    out["label_B"] = B["label"]
 
     rhythmic_A = _is_rhythmic(A, emp_p_threshold, tau_threshold)
     rhythmic_B = _is_rhythmic(B, emp_p_threshold, tau_threshold)
-    out['rhythmicity_status'] = _rhythmicity_status(rhythmic_A, rhythmic_B)
+    out["rhythmicity_status"] = _rhythmicity_status(rhythmic_A, rhythmic_B)
 
     # TauMean effect size
-    out['tau_mean_A'] = A['tau_mean']
-    out['tau_mean_B'] = B['tau_mean']
-    out['delta_tau'] = B['tau_mean'].values - A['tau_mean'].values
+    out["tau_mean_A"] = A["tau_mean"]
+    out["tau_mean_B"] = B["tau_mean"]
+    out["delta_tau"] = B["tau_mean"].values - A["tau_mean"].values
 
     # PIRS effect size
-    out['pirs_score_A'] = A['pirs_score']
-    out['pirs_score_B'] = B['pirs_score']
-    out['delta_pirs'] = B['pirs_score'].values - A['pirs_score'].values
+    out["pirs_score_A"] = A["pirs_score"]
+    out["pirs_score_B"] = B["pirs_score"]
+    out["delta_pirs"] = B["pirs_score"].values - A["pirs_score"].values
 
     # Empirical p-values (pass through for reference)
-    for suffix, df in [('_A', A), ('_B', B)]:
-        if 'emp_p' in df.columns:
-            out[f'emp_p{suffix}'] = df['emp_p']
+    for suffix, df in [("_A", A), ("_B", B)]:
+        if "emp_p" in df.columns:
+            out[f"emp_p{suffix}"] = df["emp_p"]
 
     # Phase effect size (circular)
-    if 'phase_mean' in A.columns and 'phase_mean' in B.columns:
-        out['phase_A'] = A['phase_mean']
-        out['phase_B'] = B['phase_mean']
-        raw_diff = _circular_diff(A['phase_mean'].values, B['phase_mean'].values)
-        out['delta_phase'] = raw_diff
+    if "phase_mean" in A.columns and "phase_mean" in B.columns:
+        out["phase_A"] = A["phase_mean"]
+        out["phase_B"] = B["phase_mean"]
+        raw_diff = _circular_diff(A["phase_mean"].values, B["phase_mean"].values)
+        out["delta_phase"] = raw_diff
         # Phase difference is only meaningful when rhythmic in both conditions
-        out.loc[~(rhythmic_A & rhythmic_B), 'delta_phase'] = np.nan
+        out.loc[~(rhythmic_A & rhythmic_B), "delta_phase"] = np.nan
 
     # Significance tests (requires uncertainty columns from BooteJTK)
-    has_uncertainty = (
-        all(c in A.columns for c in ('tau_std', 'n_boots')) and
-        all(c in B.columns for c in ('tau_std', 'n_boots'))
+    has_uncertainty = all(c in A.columns for c in ("tau_std", "n_boots")) and all(
+        c in B.columns for c in ("tau_std", "n_boots")
     )
     if has_uncertainty:
         _tau_test(out, A, B)
-        if 'delta_phase' in out.columns and 'phase_std' in A.columns and 'phase_std' in B.columns:
+        if (
+            "delta_phase" in out.columns
+            and "phase_std" in A.columns
+            and "phase_std" in B.columns
+        ):
             _phase_test(out, A, B)
 
     return out
@@ -221,16 +230,25 @@ def label_change_table(comparison):
         values = gene count.  Labels are ordered by ``_LABEL_ORDER``.
     """
     from circ.visualization.classify import _LABEL_ORDER
-    all_labels = list(dict.fromkeys(
-        [l for l in _LABEL_ORDER if l in comparison['label_A'].values or l in comparison['label_B'].values]
-    ))
-    ct = pd.crosstab(comparison['label_A'], comparison['label_B'])
+
+    all_labels = list(
+        dict.fromkeys(
+            [
+                l
+                for l in _LABEL_ORDER
+                if l in comparison["label_A"].values
+                or l in comparison["label_B"].values
+            ]
+        )
+    )
+    ct = pd.crosstab(comparison["label_A"], comparison["label_B"])
     return ct.reindex(index=all_labels, columns=all_labels, fill_value=0)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _majority_label(series):
     """Return the most common label; ties broken alphabetically."""
@@ -267,31 +285,33 @@ def _bh_correct(pvals):
 
 def _is_rhythmic(result, emp_p_threshold, tau_threshold):
     """Boolean Series: True if the gene passes rhythmicity thresholds."""
-    has_emp_p = 'emp_p' in result.columns and result['emp_p'].notna().any()
-    has_tau   = 'tau_mean' in result.columns and result['tau_mean'].notna().any()
+    has_emp_p = "emp_p" in result.columns and result["emp_p"].notna().any()
+    has_tau = "tau_mean" in result.columns and result["tau_mean"].notna().any()
     if has_emp_p and has_tau:
-        return (result['emp_p'] < emp_p_threshold) & (result['tau_mean'] >= tau_threshold)
+        return (result["emp_p"] < emp_p_threshold) & (
+            result["tau_mean"] >= tau_threshold
+        )
     elif has_tau:
-        return result['tau_mean'] >= tau_threshold
-    return result['label'].isin(['rhythmic', 'noisy_rhythmic'])
+        return result["tau_mean"] >= tau_threshold
+    return result["label"].isin(["rhythmic", "noisy_rhythmic"])
 
 
 def _rhythmicity_status(rhythmic_A, rhythmic_B):
-    status = pd.Series('maintained_nonrhythmic', index=rhythmic_A.index, dtype=object)
-    status[rhythmic_A  & rhythmic_B]  = 'maintained_rhythmic'
-    status[~rhythmic_A & rhythmic_B]  = 'gained'
-    status[rhythmic_A  & ~rhythmic_B] = 'lost'
+    status = pd.Series("maintained_nonrhythmic", index=rhythmic_A.index, dtype=object)
+    status[rhythmic_A & rhythmic_B] = "maintained_rhythmic"
+    status[~rhythmic_A & rhythmic_B] = "gained"
+    status[rhythmic_A & ~rhythmic_B] = "lost"
     return status
 
 
 def _tau_test(out, A, B):
     """Vectorised Welch's t-test on bootstrap TauMean distributions."""
-    ta = A['tau_mean'].values.astype(float)
-    sa = A['tau_std'].values.astype(float)
-    na = A['n_boots'].values.astype(float)
-    tb = B['tau_mean'].values.astype(float)
-    sb = B['tau_std'].values.astype(float)
-    nb = B['n_boots'].values.astype(float)
+    ta = A["tau_mean"].values.astype(float)
+    sa = A["tau_std"].values.astype(float)
+    na = A["n_boots"].values.astype(float)
+    tb = B["tau_mean"].values.astype(float)
+    sb = B["tau_std"].values.astype(float)
+    nb = B["n_boots"].values.astype(float)
 
     se_a_sq = np.where(na > 1, sa**2 / na, np.nan)
     se_b_sq = np.where(nb > 1, sb**2 / nb, np.nan)
@@ -299,28 +319,28 @@ def _tau_test(out, A, B):
     t = (tb - ta) / se
 
     # Welch–Satterthwaite degrees of freedom
-    df_ws = (se_a_sq + se_b_sq)**2 / (
+    df_ws = (se_a_sq + se_b_sq) ** 2 / (
         se_a_sq**2 / np.maximum(na - 1, 1) + se_b_sq**2 / np.maximum(nb - 1, 1)
     )
     pvals = 2 * stats.t.sf(np.abs(t), df_ws)
     pvals[~np.isfinite(t)] = np.nan
 
-    out['tau_pval'] = pvals
-    out['tau_padj'] = _bh_correct(pvals)
+    out["tau_pval"] = pvals
+    out["tau_padj"] = _bh_correct(pvals)
 
 
 def _phase_test(out, A, B):
     """Vectorised z-test on circular phase shift (genes rhythmic in both)."""
-    delta = out['delta_phase'].values.astype(float)   # NaN where not both rhythmic
-    sa = A['phase_std'].values.astype(float)
-    na = A['n_boots'].values.astype(float)
-    sb = B['phase_std'].values.astype(float)
-    nb = B['n_boots'].values.astype(float)
+    delta = out["delta_phase"].values.astype(float)  # NaN where not both rhythmic
+    sa = A["phase_std"].values.astype(float)
+    na = A["n_boots"].values.astype(float)
+    sb = B["phase_std"].values.astype(float)
+    nb = B["n_boots"].values.astype(float)
 
     se = np.sqrt(sa**2 / np.maximum(na, 1) + sb**2 / np.maximum(nb, 1))
-    z = delta / se                                     # NaN propagates from delta
+    z = delta / se  # NaN propagates from delta
     pvals = 2 * stats.norm.sf(np.abs(z))
     pvals[~np.isfinite(z)] = np.nan
 
-    out['phase_pval'] = pvals
-    out['phase_padj'] = _bh_correct(pvals)
+    out["phase_pval"] = pvals
+    out["phase_padj"] = _bh_correct(pvals)

--- a/circ/evaluation.py
+++ b/circ/evaluation.py
@@ -7,12 +7,14 @@ matplotlib so they can be used in automated pipelines without a display.
 Plotting wrappers that visualise these metrics live in
 ``circ.visualization.benchmarks``.
 """
+
 from sklearn.metrics import average_precision_score, roc_curve, auc
 
 
 # ---------------------------------------------------------------------------
 # Legacy-format ROC (merged_dict interface used by circ.limbr.simulations)
 # ---------------------------------------------------------------------------
+
 
 def roc_auc(merged_dict):
     """Compute area under the ROC curve for each method.
@@ -31,9 +33,11 @@ def roc_auc(merged_dict):
     """
     out = {}
     for tag, df in merged_dict.items():
-        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
-        score_col = 'score' if 'score' in df.columns else 'GammaBH'
-        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
+        truth_col = "truth" if "truth" in df.columns else "Circadian"
+        score_col = "score" if "score" in df.columns else "GammaBH"
+        fpr, tpr, _ = roc_curve(
+            df[truth_col].values, 1 - df[score_col].values, pos_label=1
+        )
         out[tag] = auc(fpr, tpr)
     return out
 
@@ -42,19 +46,20 @@ def roc_auc(merged_dict):
 # Classifier-output evaluation (Classifier + simulate ground-truth interface)
 # ---------------------------------------------------------------------------
 
+
 def _default_tasks(classifications, true_classes):
     """Return the default (score_col, truth_col, invert) task list."""
     tasks = []
-    if 'pirs_score' in classifications.columns and 'Const' in true_classes.columns:
-        tasks.append(('pirs_score', 'Const', True))
-    if 'tau_mean' in classifications.columns and 'Circadian' in true_classes.columns:
-        tasks.append(('tau_mean', 'Circadian', False))
-    if 'emp_p' in classifications.columns and 'Circadian' in true_classes.columns:
-        tasks.append(('emp_p', 'Circadian', True))
-    if 'pval' in classifications.columns and 'Const' in true_classes.columns:
-        tasks.append(('pval', 'Const', True))
-    if 'slope_pval' in classifications.columns and 'Linear' in true_classes.columns:
-        tasks.append(('slope_pval', 'Linear', True))
+    if "pirs_score" in classifications.columns and "Const" in true_classes.columns:
+        tasks.append(("pirs_score", "Const", True))
+    if "tau_mean" in classifications.columns and "Circadian" in true_classes.columns:
+        tasks.append(("tau_mean", "Circadian", False))
+    if "emp_p" in classifications.columns and "Circadian" in true_classes.columns:
+        tasks.append(("emp_p", "Circadian", True))
+    if "pval" in classifications.columns and "Const" in true_classes.columns:
+        tasks.append(("pval", "Const", True))
+    if "slope_pval" in classifications.columns and "Linear" in true_classes.columns:
+        tasks.append(("slope_pval", "Linear", True))
     return tasks
 
 
@@ -87,7 +92,7 @@ def classification_auc(classifications, true_classes, tasks=None):
     for score_col, truth_col, invert in tasks:
         merged = (
             classifications[[score_col]]
-            .join(true_classes[[truth_col]], how='inner')
+            .join(true_classes[[truth_col]], how="inner")
             .dropna()
         )
         if merged.empty or merged[truth_col].nunique() < 2:
@@ -101,8 +106,8 @@ def classification_auc(classifications, true_classes, tasks=None):
 def classification_ap(
     classifications,
     true_classes,
-    ground_truth_col='Const',
-    score_col='pirs_score',
+    ground_truth_col="Const",
+    score_col="pirs_score",
     invert_score=True,
 ):
     """Compute average precision (PR AUC) for a single classification task.
@@ -129,7 +134,7 @@ def classification_ap(
     """
     merged = (
         classifications[[score_col]]
-        .join(true_classes[[ground_truth_col]], how='inner')
+        .join(true_classes[[ground_truth_col]], how="inner")
         .dropna()
     )
     if merged.empty or merged[ground_truth_col].nunique() < 2:

--- a/circ/expression_classification/classify.py
+++ b/circ/expression_classification/classify.py
@@ -1,34 +1,38 @@
 """Expression classification integrating PIRS constitutiveness scores and BooteJTK rhythmicity."""
+
 import os
 import shutil
 import tempfile
 import types
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 _REF_DIR = os.path.normpath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'bootjtk', 'ref_files')
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "bootjtk", "ref_files"
+    )
 )
 
 # (pirs_stable, rhythmic) -> label  — used when slope p-values are not available
 _LABEL_MAP = {
-    (True,  True):  'rhythmic',
-    (True,  False): 'constitutive',
-    (False, True):  'noisy_rhythmic',
-    (False, False): 'variable',
+    (True, True): "rhythmic",
+    (True, False): "constitutive",
+    (False, True): "noisy_rhythmic",
+    (False, False): "variable",
 }
 
 # (pirs_stable, sloped, rhythmic) -> label  — used when slope p-values are available
 _LABEL_MAP_SLOPE = {
-    (True,  False, True):  'rhythmic',
-    (True,  False, False): 'constitutive',
-    (True,  True,  True):  'rhythmic',
-    (True,  True,  False): 'linear',
-    (False, False, True):  'noisy_rhythmic',
-    (False, False, False): 'variable',
-    (False, True,  True):  'noisy_rhythmic',
-    (False, True,  False): 'linear',
+    (True, False, True): "rhythmic",
+    (True, False, False): "constitutive",
+    (True, True, True): "rhythmic",
+    (True, True, False): "linear",
+    (False, False, True): "noisy_rhythmic",
+    (False, False, False): "variable",
+    (False, True, True): "noisy_rhythmic",
+    (False, True, False): "linear",
 }
 
 
@@ -63,10 +67,18 @@ class Classifier:
         Parallel worker processes for BooteJTK.  0 = all CPUs (default 1).
     """
 
-    def __init__(self, source, *, anova=False, reps=2, size=50, workers=1):
+    def __init__(
+        self,
+        source: str | Path | pd.DataFrame,
+        *,
+        anova: bool = False,
+        reps: int = 2,
+        size: int = 50,
+        workers: int = 1,
+    ) -> None:
         if isinstance(source, pd.DataFrame):
             self._source = source
-            self.filename = None
+            self.filename: str | None = None
         else:
             self._source = os.path.abspath(str(source))
             self.filename = self._source
@@ -146,16 +158,16 @@ class Classifier:
         """
         from circ.bootjtk.pipeline import main as _pipeline_main
 
-        workdir = tempfile.mkdtemp(prefix='circ_classify_')
+        workdir = tempfile.mkdtemp(prefix="circ_classify_")
         try:
             if isinstance(self._source, pd.DataFrame):
-                fn_copy = os.path.join(workdir, 'input.txt')
-                self._source.to_csv(fn_copy, sep='\t')
+                fn_copy = os.path.join(workdir, "input.txt")
+                self._source.to_csv(fn_copy, sep="\t")
             else:
                 src = str(self._source)
-                if src.endswith('.parquet'):
-                    fn_copy = os.path.join(workdir, 'input.txt')
-                    pd.read_parquet(src).to_csv(fn_copy, sep='\t')
+                if src.endswith(".parquet"):
+                    fn_copy = os.path.join(workdir, "input.txt")
+                    pd.read_parquet(src).to_csv(fn_copy, sep="\t")
                 else:
                     fn_copy = os.path.join(workdir, os.path.basename(src))
                     shutil.copy2(src, fn_copy)
@@ -171,16 +183,14 @@ class Classifier:
 
             _pipeline_main(args)
 
-            calcp_files = [
-                f for f in os.listdir(workdir) if f.endswith('_GammaP.txt')
-            ]
+            calcp_files = [f for f in os.listdir(workdir) if f.endswith("_GammaP.txt")]
             if not calcp_files:
                 raise FileNotFoundError(
-                    'BooteJTK/CalcP produced no *_GammaP.txt output in the '
-                    f'working directory: {workdir}'
+                    "BooteJTK/CalcP produced no *_GammaP.txt output in the "
+                    f"working directory: {workdir}"
                 )
             result_path = os.path.join(workdir, calcp_files[0])
-            self.rhythm_results = pd.read_csv(result_path, sep='\t', index_col='ID')
+            self.rhythm_results = pd.read_csv(result_path, sep="\t", index_col="ID")
         finally:
             shutil.rmtree(workdir, ignore_errors=True)
 
@@ -244,47 +254,47 @@ class Classifier:
         if self.rhythm_results is None:
             raise RuntimeError("Call run_bootjtk() before classify().")
 
-        tau_col = 'TauMean' if 'TauMean' in self.rhythm_results.columns else 'Tau'
+        tau_col = "TauMean" if "TauMean" in self.rhythm_results.columns else "Tau"
 
         all_ids = self.pirs_scores.index.union(self.rhythm_results.index)
         result = pd.DataFrame(index=all_ids)
         result.index.name = self.pirs_scores.index.name
 
-        result['pirs_score'] = self.pirs_scores['score']
+        result["pirs_score"] = self.pirs_scores["score"]
 
-        for col in ('pval', 'pval_bh', 'slope_pval', 'slope_pval_bh'):
+        for col in ("pval", "pval_bh", "slope_pval", "slope_pval_bh"):
             if col in self.pirs_scores.columns:
                 result[col] = self.pirs_scores[col]
 
-        result['tau_mean'] = self.rhythm_results[tau_col]
+        result["tau_mean"] = self.rhythm_results[tau_col]
 
         for src_col, dst_col in [
-            ('GammaBH',     'emp_p'),
-            ('PeriodMean',  'period_mean'),
-            ('PhaseMean',   'phase_mean'),
-            ('TauStdDev',   'tau_std'),
-            ('PhaseStdDev', 'phase_std'),
-            ('NumBoots',    'n_boots'),
+            ("GammaBH", "emp_p"),
+            ("PeriodMean", "period_mean"),
+            ("PhaseMean", "phase_mean"),
+            ("TauStdDev", "tau_std"),
+            ("PhaseStdDev", "phase_std"),
+            ("NumBoots", "n_boots"),
         ]:
             if src_col in self.rhythm_results.columns:
                 result[dst_col] = self.rhythm_results[src_col]
 
-        pirs_cutoff = np.percentile(result['pirs_score'].dropna(), pirs_percentile)
-        stable = result['pirs_score'] <= pirs_cutoff
+        pirs_cutoff = np.percentile(result["pirs_score"].dropna(), pirs_percentile)
+        stable = result["pirs_score"] <= pirs_cutoff
 
-        rhythmic = result['tau_mean'] >= tau_threshold
-        if 'emp_p' in result.columns:
-            rhythmic = rhythmic & (result['emp_p'] <= emp_p_threshold)
+        rhythmic = result["tau_mean"] >= tau_threshold
+        if "emp_p" in result.columns:
+            rhythmic = rhythmic & (result["emp_p"] <= emp_p_threshold)
 
-        if 'slope_pval' in result.columns:
-            sloped = result['slope_pval'] <= slope_pval_threshold
-            result['label'] = [
-                _LABEL_MAP_SLOPE.get((bool(s), bool(sl), bool(r)), 'unclassified')
+        if "slope_pval" in result.columns:
+            sloped = result["slope_pval"] <= slope_pval_threshold
+            result["label"] = [
+                _LABEL_MAP_SLOPE.get((bool(s), bool(sl), bool(r)), "unclassified")
                 for s, sl, r in zip(stable, sloped, rhythmic)
             ]
         else:
-            result['label'] = [
-                _LABEL_MAP.get((bool(s), bool(r)), 'unclassified')
+            result["label"] = [
+                _LABEL_MAP.get((bool(s), bool(r)), "unclassified")
                 for s, r in zip(stable, rhythmic)
             ]
 
@@ -336,6 +346,7 @@ class Classifier:
 # Internal helpers
 # ------------------------------------------------------------------
 
+
 def _make_pipeline_args(
     *,
     filename: str,
@@ -348,18 +359,18 @@ def _make_pipeline_args(
     """Build the argparse-compatible namespace that pipeline.main() expects."""
     return types.SimpleNamespace(
         filename=filename,
-        means='DEFAULT',
-        sds='DEFAULT',
-        ns='DEFAULT',
-        prefix='classify',
-        waveform='cosine',
-        period=os.path.join(ref_dir, 'period24.txt'),
-        phase=os.path.join(ref_dir, 'phases_00-22_by2.txt'),
-        width=os.path.join(ref_dir, 'asymmetries_02-22_by2.txt'),
-        output='DEFAULT',
-        pickle='DEFAULT',
-        id_list='DEFAULT',
-        null_list='DEFAULT',
+        means="DEFAULT",
+        sds="DEFAULT",
+        ns="DEFAULT",
+        prefix="classify",
+        waveform="cosine",
+        period=os.path.join(ref_dir, "period24.txt"),
+        phase=os.path.join(ref_dir, "phases_00-22_by2.txt"),
+        width=os.path.join(ref_dir, "asymmetries_02-22_by2.txt"),
+        output="DEFAULT",
+        pickle="DEFAULT",
+        id_list="DEFAULT",
+        null_list="DEFAULT",
         size=size,
         reps=reps,
         workers=workers,
@@ -371,7 +382,7 @@ def _make_pipeline_args(
         rnaseq=False,
         harding=False,
         normal=False,
-        jtk='DEFAULT',
+        jtk="DEFAULT",
         fit=False,
-        null='DEFAULT',
+        null="DEFAULT",
     )

--- a/circ/io.py
+++ b/circ/io.py
@@ -1,10 +1,13 @@
 """Shared I/O utilities for reading and writing expression data."""
+
 from pathlib import Path
 
 import pandas as pd
 
 
-def read_expression(source, data_type='r'):
+def read_expression(
+    source: str | Path | pd.DataFrame, data_type: str = "r"
+) -> pd.DataFrame:
     """Read an expression DataFrame from a file path, or return one unchanged.
 
     Parquet files (detected by ``.parquet`` extension) carry their own index
@@ -24,14 +27,14 @@ def read_expression(source, data_type='r'):
     if isinstance(source, pd.DataFrame):
         return source.copy()
     path = str(source)
-    if path.endswith('.parquet'):
+    if path.endswith(".parquet"):
         return pd.read_parquet(path)
-    if data_type == 'p':
-        return pd.read_csv(path, sep='\t').set_index(['Peptide', 'Protein'])
-    return pd.read_csv(path, sep='\t', header=0, index_col=0)
+    if data_type == "p":
+        return pd.read_csv(path, sep="\t").set_index(["Peptide", "Protein"])
+    return pd.read_csv(path, sep="\t", header=0, index_col=0)
 
 
-def write_expression(df, path):
+def write_expression(df: pd.DataFrame, path: str | Path) -> None:
     """Write an expression DataFrame to disk.
 
     Writes Apache Parquet when *path* ends with ``.parquet``; tab-separated
@@ -43,13 +46,13 @@ def write_expression(df, path):
     path : str | Path
     """
     path = str(path)
-    if path.endswith('.parquet'):
+    if path.endswith(".parquet"):
         df.to_parquet(path)
     else:
-        df.to_csv(path, sep='\t')
+        df.to_csv(path, sep="\t")
 
 
-def sidecar_path(main_path, suffix):
+def sidecar_path(main_path: str | Path, suffix: str) -> str:
     """Derive a sidecar file path that inherits the extension of the main output.
 
     Parameters

--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -1,9 +1,11 @@
 import itertools
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import multiprocess as _mp
-_forkserver_pool = _mp.get_context('forkserver').Pool
+
+_forkserver_pool = _mp.get_context("forkserver").Pool
 from sklearn import preprocessing
 from sklearn.decomposition import PCA
 from scipy.stats import linregress, f_oneway
@@ -17,10 +19,20 @@ from tqdm import tqdm
 
 # Per-worker globals populated once by _init_perm_worker (Pool initializer).
 # This avoids re-serialising the large residual matrix for every task.
-_perm_res = _perm_tks = _perm_designtype = _perm_tpoints = _perm_block_design = None
+_perm_res: np.ndarray | None = None
+_perm_tks: np.ndarray | None = None
+_perm_designtype: str | None = None
+_perm_tpoints: np.ndarray | None = None
+_perm_block_design: list[int] | None = None
 
 
-def _init_perm_worker(res, tks, designtype, tpoints, block_design):
+def _init_perm_worker(
+    res: np.ndarray,
+    tks: np.ndarray,
+    designtype: str,
+    tpoints: np.ndarray | None,
+    block_design: list[int] | None,
+) -> None:
     """Pool initializer: stores shared read-only data in each worker once."""
     global _perm_res, _perm_tks, _perm_designtype, _perm_tpoints, _perm_block_design
     _perm_res = res
@@ -30,13 +42,16 @@ def _init_perm_worker(res, tks, designtype, tpoints, block_design):
     _perm_block_design = block_design
 
 
-def _perm_worker(rseed):
+def _perm_worker(rseed: int) -> np.ndarray:
     """Single permutation iteration executed inside a pool worker."""
+    assert _perm_res is not None and _perm_tks is not None
     rng = np.random.default_rng(rseed * 100)
     rstar = rng.permuted(_perm_res.copy(), axis=1)
 
-    if _perm_designtype in ('c', 't'):
-        resstar = np.array([row - lowess(row, _perm_tpoints, it=1)[:, 1] for row in rstar])
+    if _perm_designtype in ("c", "t"):
+        resstar = np.array(
+            [row - lowess(row, _perm_tpoints, it=1)[:, 1] for row in rstar]
+        )
     else:
         blocks = np.asarray(_perm_block_design)
         ma = np.empty_like(rstar)
@@ -45,7 +60,7 @@ def _perm_worker(rseed):
             ma[:, idx] = rstar[:, idx].mean(axis=1, keepdims=True)
         resstar = rstar - ma
 
-    pca = PCA(svd_solver='randomized', random_state=rseed * 100)
+    pca = PCA(svd_solver="randomized", random_state=rseed * 100)
     pca.fit(resstar)
     tkstar = pca.explained_variance_ratio_
 
@@ -53,6 +68,7 @@ def _perm_worker(rseed):
     out = np.zeros(len(_perm_tks))
     out[:n] = tkstar[:n] > _perm_tks[:n]
     return out
+
 
 class sva:
     """
@@ -91,7 +107,14 @@ class sva:
 
     """
 
-    def __init__(self, source, design, data_type, blocks=None, pool=None):
+    def __init__(
+        self,
+        source: str | Path | pd.DataFrame,
+        design: str,
+        data_type: str,
+        blocks: str | None = None,
+        pool: str | None = None,
+    ) -> None:
         """
         Imports data and initializes an sva object.
 
@@ -100,19 +123,20 @@ class sva:
 
         """
         from circ.io import read_expression
+
         np.random.seed(4574)
         self.data_type = str(data_type)
         self.raw_data = read_expression(source, data_type=data_type)
         self.designtype = str(design)
-        if self.designtype == 'b':
-            self.block_design = pd.read_parquet(blocks)['block'].tolist()
+        if self.designtype == "b":
+            self.block_design = pd.read_parquet(blocks)["block"].tolist()
         if pool is not None:
-            self.norm_map = pd.read_parquet(pool)['pool_number'].to_dict()
+            self.norm_map = pd.read_parquet(pool)["pool_number"].to_dict()
         else:
             self.norm_map = None
         self.notdone = True
 
-    def pool_normalize(self):
+    def pool_normalize(self) -> None:
         """
         Preprocessing normalization.
 
@@ -129,7 +153,7 @@ class sva:
 
         """
 
-        def pool_norm(df,dmap):
+        def pool_norm(df, dmap):
             """
             Pool normalizes samples in a proteomics experiment.
 
@@ -154,9 +178,11 @@ class sva:
 
             newdf = pd.DataFrame(index=df.index)
             for column in df.columns.values:
-                if 'pool' not in column:
-                    newdf[column] = df[column].div(df['pool_'+'%02d' % dmap[column]],axis='index')
-            nonpool = [i for i in newdf.columns if 'pool' not in i]
+                if "pool" not in column:
+                    newdf[column] = df[column].div(
+                        df["pool_" + "%02d" % dmap[column]], axis="index"
+                    )
+            nonpool = [i for i in newdf.columns if "pool" not in i]
             newdf = newdf[nonpool]
             return newdf
 
@@ -181,28 +207,43 @@ class sva:
 
             """
 
-            ref = pd.concat([df[col].sort_values().reset_index(drop=True) for col in df], axis=1, ignore_index=True).mean(axis=1).values
-            for i in range(0,len(df.columns)):
+            ref = (
+                pd.concat(
+                    [df[col].sort_values().reset_index(drop=True) for col in df],
+                    axis=1,
+                    ignore_index=True,
+                )
+                .mean(axis=1)
+                .values
+            )
+            for i in range(0, len(df.columns)):
                 df = df.sort_values(df.columns[i])
                 df[df.columns[i]] = ref
             newdf = df.sort_index()
             return newdf
 
-        if (self.data_type == 'r') or (self.norm_map is None):
+        if (self.data_type == "r") or (self.norm_map is None):
             self.data = qnorm(self.raw_data)
             self.scaler = preprocessing.StandardScaler().fit(self.data.values.T)
-            self.data = pd.DataFrame(self.scaler.transform(self.data.values.T).T,columns=self.data.columns,index=self.data.index)
+            self.data = pd.DataFrame(
+                self.scaler.transform(self.data.values.T).T,
+                columns=self.data.columns,
+                index=self.data.index,
+            )
         else:
-            self.data_pnorm = pool_norm(self.raw_data,self.norm_map)
+            self.data_pnorm = pool_norm(self.raw_data, self.norm_map)
             self.data_pnorm = self.data_pnorm.replace([np.inf, -np.inf], np.nan)
             self.data_pnorm = self.data_pnorm.dropna()
             self.data_pnorm = self.data_pnorm.sort_index(axis=1)
             self.data_pnorm = qnorm(self.data_pnorm)
             self.scaler = preprocessing.StandardScaler().fit(self.data_pnorm.values.T)
-            self.data = pd.DataFrame(self.scaler.transform(self.data_pnorm.values.T).T,columns=self.data_pnorm.columns,index=self.data_pnorm.index)
+            self.data = pd.DataFrame(
+                self.scaler.transform(self.data_pnorm.values.T).T,
+                columns=self.data_pnorm.columns,
+                index=self.data_pnorm.index,
+            )
 
-
-    def get_tpoints(self):
+    def get_tpoints(self) -> None:
         """
         Extracts timepoints from header of data.
 
@@ -217,13 +258,15 @@ class sva:
 
         """
 
-        tpoints = [i.replace('ZT', '').replace('CT','') for i in self.data.columns.values]
-        tpoints = [int(i.split('_')[0]) for i in tpoints]
-        #deprecated splitting for alternative header syntax
-        #tpoints = [int(i.split('.')[0]) for i in tpoints]
+        tpoints = [
+            i.replace("ZT", "").replace("CT", "") for i in self.data.columns.values
+        ]
+        tpoints = [int(i.split("_")[0]) for i in tpoints]
+        # deprecated splitting for alternative header syntax
+        # tpoints = [int(i.split('.')[0]) for i in tpoints]
         self.tpoints = np.asarray(tpoints)
 
-    def prim_cor(self):
+    def prim_cor(self) -> None:
         """
         calculates correlation for each row against the primary variable of interest.
 
@@ -237,6 +280,7 @@ class sva:
             Array of correlations with primary variable of interest.  The calculation of this variable is determined by the designtype as specified above and the procedure described in the corresponding function.
 
         """
+
         def circ_cor():
             """
             Calculates rough estimate of circadianness based on autocorrelation differences.
@@ -245,10 +289,11 @@ class sva:
             Autocorrelation is calculated at one full period and one half period (in unique-timepoint space) and the difference indicates the degree of circadian signal.
 
             """
+
             def autocorr_vec(m, shift):
                 """Row-wise autocorrelation of a 2-D array at a given shift."""
                 shifted = np.roll(m, shift, axis=1)
-                return np.einsum('ij,ij->i', m, shifted) / np.einsum('ij,ij->i', m, m)
+                return np.einsum("ij,ij->i", m, shifted) / np.einsum("ij,ij->i", m, m)
 
             tps = np.asarray(self.tpoints)
             unique_tps = np.unique(tps)
@@ -256,10 +301,9 @@ class sva:
             per = 24 // max(spacing, 1)
             data = self.data.values
             # Build (nrows, n_unique_tpoints) matrix of per-timepoint means
-            ave = np.column_stack([
-                data[:, tps == tp].mean(axis=1) * 1e6
-                for tp in np.unique(tps)
-            ])
+            ave = np.column_stack(
+                [data[:, tps == tp].mean(axis=1) * 1e6 for tp in np.unique(tps)]
+            )
             self.cors = autocorr_vec(ave, per) - autocorr_vec(ave, per // 2)
 
         def l_cor():
@@ -270,8 +314,10 @@ class sva:
             In a timecourse, rows least affected by batch effects should be those with the best fit from a lowess model.  Goodness of fit in this case is defined as the sum of squared errors for the lowess fit.
 
             """
-            cors = [-np.sum((row - lowess(row, self.tpoints, it=1)[:, 1]) ** 2)
-                    for row in tqdm(self.data.values)]
+            cors = [
+                -np.sum((row - lowess(row, self.tpoints, it=1)[:, 1]) ** 2)
+                for row in tqdm(self.data.values)
+            ]
             self.cors = np.asarray(cors)
 
         def block_cor():
@@ -285,19 +331,20 @@ class sva:
             blocks = np.asarray(self.block_design)
             # Pre-compute block indices once rather than rebuilding per row
             block_indices = [np.where(blocks == b)[0] for b in np.unique(blocks)]
-            cors = [f_oneway(*[row[idx] for idx in block_indices])[0]
-                    for row in tqdm(self.data.values)]
+            cors = [
+                f_oneway(*[row[idx] for idx in block_indices])[0]
+                for row in tqdm(self.data.values)
+            ]
             self.cors = np.asarray(cors)
 
-        if self.designtype == 'c':
+        if self.designtype == "c":
             circ_cor()
-        elif self.designtype == 'b':
+        elif self.designtype == "b":
             block_cor()
-        elif self.designtype == 't':
+        elif self.designtype == "t":
             l_cor()
 
-
-    def reduce(self,perc_red=25):
+    def reduce(self, perc_red: float = 25) -> None:
         """
         Reduces the data based on the correlation to primary variable of interest calculated in prim_cor.
 
@@ -317,10 +364,11 @@ class sva:
             Reduced dataset.
 
         """
-        self.data_reduced = self.data[self.cors < np.percentile(self.cors, float(perc_red))]
+        self.data_reduced = self.data[
+            self.cors < np.percentile(self.cors, float(perc_red))
+        ]
 
-
-    def get_res(self,in_arr):
+    def get_res(self, in_arr: np.ndarray) -> np.ndarray:
         """
         Calculates model residuals from which to learn batch effects.
 
@@ -340,9 +388,12 @@ class sva:
             Residual matrix.
 
         """
+
         def get_l_res(arr):
             """calculates residuals from a lowess model for timecourse designs"""
-            return np.array([row - lowess(row, self.tpoints, it=1)[:, 1] for row in arr])
+            return np.array(
+                [row - lowess(row, self.tpoints, it=1)[:, 1] for row in arr]
+            )
 
         def get_b_res(arr):
             """calculates residuals from the block mean for block based designs"""
@@ -353,16 +404,16 @@ class sva:
                 ma[:, idx] = arr[:, idx].mean(axis=1, keepdims=True)
             return arr - ma
 
-        if self.designtype == 'c':
+        if self.designtype == "c":
             res_mat = get_l_res(in_arr)
-        elif self.designtype == 'b':
+        elif self.designtype == "b":
             res_mat = get_b_res(in_arr)
-        elif self.designtype == 't':
+        elif self.designtype == "t":
             res_mat = get_l_res(in_arr)
         return res_mat
 
-    #defined seperately for reuse in perm_test
-    def set_res(self):
+    # defined seperately for reuse in perm_test
+    def set_res(self) -> None:
         """
         Calls get_res()
 
@@ -376,14 +427,14 @@ class sva:
 
         self.res = self.get_res(self.data_reduced.values)
 
-    def get_tks(self,arr):
+    def get_tks(self, arr: np.ndarray) -> np.ndarray:
         """calculates the fraction of variance for each row of the residual matrix explained by each principle component with PCA"""
-        pca = PCA(svd_solver='randomized',random_state=4574)
+        pca = PCA(svd_solver="randomized", random_state=4574)
         pca.fit(arr)
         return pca.explained_variance_ratio_
 
-    #defined seperately for reuse in perm_test
-    def set_tks(self):
+    # defined seperately for reuse in perm_test
+    def set_tks(self) -> None:
         """
         Calls get_tks().
 
@@ -397,12 +448,12 @@ class sva:
 
         self.tks = self.get_tks(self.res)
 
-    def perm_test(self,nperm,npr=1):
+    def perm_test(self, nperm: int, npr: int = 1) -> None:
         """
         Performs permutation testing on residual matrix SVD.
 
         The rows of the residual matrix are first permuted.  Then get_tks is called to calculate explained variance ratios and these tks are compared to the values from the actual residual matrix.  A running total is kept for the number of times the explained variance from the permuted matrix exceeds that from the original matrix. Significance is estimated by dividing these totals by the number of permutations.  When npr > 1 a multiprocess Pool is used to parallelise the permutations.
-        
+
         Parameters
         ----------
         nperm : int
@@ -416,6 +467,7 @@ class sva:
             Estimated significances for each batch effect.
 
         """
+
         def single_it(rseed):
             rng = np.random.default_rng(rseed * 100)
             rstar = rng.permuted(self.res.copy(), axis=1)
@@ -428,20 +480,26 @@ class sva:
 
         seeds = range(int(nperm))
         if int(npr) > 1:
-            tpoints = getattr(self, 'tpoints', None)
-            block_design = getattr(self, 'block_design', None)
+            tpoints = getattr(self, "tpoints", None)
+            block_design = getattr(self, "block_design", None)
             chunksize = max(1, int(nperm) // (int(npr) * 4))
             init_args = (self.res, self.tks, self.designtype, tpoints, block_design)
-            with _forkserver_pool(int(npr), initializer=_init_perm_worker, initargs=init_args) as pool:
-                output = list(tqdm(
-                    pool.imap_unordered(_perm_worker, seeds, chunksize=chunksize),
-                    total=int(nperm), desc='permuting', smoothing=0,
-                ))
+            with _forkserver_pool(
+                int(npr), initializer=_init_perm_worker, initargs=init_args
+            ) as pool:
+                output = list(
+                    tqdm(
+                        pool.imap_unordered(_perm_worker, seeds, chunksize=chunksize),
+                        total=int(nperm),
+                        desc="permuting",
+                        smoothing=0,
+                    )
+                )
         else:
-            output = [single_it(s) for s in tqdm(seeds, desc='permuting', smoothing=0)]
+            output = [single_it(s) for s in tqdm(seeds, desc="permuting", smoothing=0)]
         self.sigs = np.sum(np.asarray(output), axis=0) / float(nperm)
 
-    def eig_reg(self,alpha=0.05):
+    def eig_reg(self, alpha: float = 0.05) -> None:
         """
         Regresses eigentrends (batch effects) against the reduced dataset calculating p values for each row being associated with that trend.
 
@@ -464,20 +522,25 @@ class sva:
 
         alpha = float(alpha)
         U, s, V = np.linalg.svd(self.res)
-        sig = V.T[:,:len([i for i in itertools.takewhile(lambda x: x < alpha, self.sigs.copy())])]
+        sig = V.T[
+            :,
+            : len(
+                [i for i in itertools.takewhile(lambda x: x < alpha, self.sigs.copy())]
+            ),
+        ]
         pvals = []
-        if len(sig)>0:
+        if len(sig) > 0:
             for trend in tqdm(sig.T.copy()):
                 temp = []
                 for row in self.data_reduced.values.copy():
-                    slope, intercept, r_value, p_value, std_err = linregress(row,trend)
+                    slope, intercept, r_value, p_value, std_err = linregress(row, trend)
                     temp.append(p_value)
                 pvals.append(temp)
-            self.ps =  pvals
+            self.ps = pvals
         else:
-            print('No Significant Trends')
+            print("No Significant Trends")
 
-    def subset_svd(self,lam=0.5):
+    def subset_svd(self, lam: float = 0.5) -> None:
         """
         Performs SVD on the subset of rows associated with each batch effect.
 
@@ -500,7 +563,7 @@ class sva:
 
         """
 
-        def est_pi_naught(probs_naught,lam):
+        def est_pi_naught(probs_naught, lam):
             """
             Estimates background distribution of p values.
 
@@ -523,10 +586,12 @@ class sva:
 
             """
 
-            pi_naught = len([i for i in probs_naught if i > lam])/(len(probs_naught)*(1-lam))
+            pi_naught = len([i for i in probs_naught if i > lam]) / (
+                len(probs_naught) * (1 - lam)
+            )
             return pi_naught
 
-        def est_pi_sig(probs_sig,l):
+        def est_pi_sig(probs_sig, l):
             """
             Finds p value pi_sig as cutoff for rows associated with batch effect.
 
@@ -549,22 +614,22 @@ class sva:
 
             """
 
-            pi_0 = est_pi_naught(probs_sig,l)
+            pi_0 = est_pi_naught(probs_sig, l)
             if pi_0 > 1:
-                return 'nan'
+                return "nan"
             sp = np.sort(probs_sig)
-            pi_sig = sp[int(np.floor((1-pi_0)*len(probs_sig))-1)]
+            pi_sig = sp[int(np.floor((1 - pi_0) * len(probs_sig)) - 1)]
             return pi_sig
 
         pt, _, bt = np.linalg.svd(self.res)
-        trends = []
-        pep_trends = []
+        trends: list[np.ndarray] = []
+        pep_trends: list[np.ndarray] = []
         for j, entry in enumerate(tqdm(self.ps)):
             sub = []
-            thresh = est_pi_sig(entry,lam)
-            if thresh == 'nan':
-                self.ts = trends
-                self.pepts = pep_trends
+            thresh = est_pi_sig(entry, lam)
+            if thresh == "nan":
+                self.ts: list[np.ndarray] = trends
+                self.pepts: list[np.ndarray] = pep_trends
                 return
             for i in range(len(entry)):
                 if entry[i] < thresh:
@@ -573,15 +638,14 @@ class sva:
                 U, s, V = np.linalg.svd(sub)
                 temp = []
                 for trend in V:
-                    _, _, _, p_value, _ = linregress(bt[j],trend)
+                    _, _, _, p_value, _ = linregress(bt[j], trend)
                     temp.append(p_value)
-                trends.append(V.T[:,np.argmin(temp)])
-                pep_trends.append(pt[:,j])
+                trends.append(V.T[:, np.argmin(temp)])
+                pep_trends.append(pt[:, j])
         self.pepts = pep_trends
         self.ts = trends
 
-
-    def normalize(self,outname):
+    def normalize(self, outname: str) -> None:
         """
         Creates diagnostic files, normalizes data based on calculated batch effects, groups peptides by protein and outputs final processed dataset.
 
@@ -603,26 +667,40 @@ class sva:
         """
 
         from circ.io import write_expression, sidecar_path
-        write_expression(pd.DataFrame(self.ts, columns=self.data.columns), sidecar_path(outname, '_trends'))
-        write_expression(pd.DataFrame(self.sigs), sidecar_path(outname, '_perms'))
-        write_expression(pd.DataFrame(self.tks), sidecar_path(outname, '_tks'))
+
+        write_expression(
+            pd.DataFrame(self.ts, columns=self.data.columns),
+            sidecar_path(outname, "_trends"),
+        )
+        write_expression(pd.DataFrame(self.sigs), sidecar_path(outname, "_perms"))
+        write_expression(pd.DataFrame(self.tks), sidecar_path(outname, "_tks"))
         if len(self.pepts) > 0:
             write_expression(
                 pd.DataFrame(np.asarray(self.pepts).T, index=self.data_reduced.index),
-                sidecar_path(outname, '_pep_bias'),
+                sidecar_path(outname, "_pep_bias"),
             )
         if len(self.ts) > 0:
-            fin_res = np.dot(np.dot(self.data.values,np.linalg.lstsq(self.ts,np.identity(np.shape(self.ts)[0]),rcond=None)[0]),self.ts)
+            fin_res = np.dot(
+                np.dot(
+                    self.data.values,
+                    np.linalg.lstsq(
+                        self.ts, np.identity(np.shape(self.ts)[0]), rcond=None
+                    )[0],
+                ),
+                self.ts,
+            )
         else:
             fin_res = 0
         self.svd_norm = self.scaler.inverse_transform((self.data.values - fin_res).T).T
-        self.svd_norm = pd.DataFrame(self.svd_norm,index=self.data.index,columns=self.data.columns)
-        if self.data_type == 'p':
-            self.svd_norm = self.svd_norm.groupby(level='Protein').mean()
-        self.svd_norm.index.names = ['#']
+        self.svd_norm = pd.DataFrame(
+            self.svd_norm, index=self.data.index, columns=self.data.columns
+        )
+        if self.data_type == "p":
+            self.svd_norm = self.svd_norm.groupby(level="Protein").mean()
+        self.svd_norm.index.names = ["#"]
         write_expression(self.svd_norm, outname)
 
-    def preprocess_default(self):
+    def preprocess_default(self) -> None:
         self.pool_normalize()
         self.get_tpoints()
         self.prim_cor()
@@ -630,7 +708,7 @@ class sva:
         self.set_res()
         self.set_tks()
 
-    def output_default(self,out_file):
+    def output_default(self, out_file: str) -> None:
         self.eig_reg()
         self.subset_svd()
         self.normalize(out_file)

--- a/circ/limbr/imputation.py
+++ b/circ/limbr/imputation.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
+
 
 class imputable:
     """Imputes missing data with K Nearest Neighbors based on user specified parameters.
@@ -29,7 +32,12 @@ class imputable:
 
     """
 
-    def __init__(self, source, missingness, neighbors=10):
+    def __init__(
+        self,
+        source: str | Path | pd.DataFrame,
+        missingness: float,
+        neighbors: int = 10,
+    ) -> None:
         """
         Constructor, takes input data and missingness threshold and initializes imputable object.
 
@@ -40,20 +48,20 @@ class imputable:
             df = source.copy()
         else:
             path = str(source)
-            if path.endswith('.parquet'):
+            if path.endswith(".parquet"):
                 df = pd.read_parquet(path)
             else:
-                df = pd.read_csv(path, sep='\t')
+                df = pd.read_csv(path, sep="\t")
         # deduplicate() expects flat columns, not a MultiIndex
         if isinstance(df.index, pd.MultiIndex):
             df = df.reset_index()
         self.data = df
         self.miss = float(missingness)
-        self.pats = {}
+        self.pats: dict[str, list[int]] = {}
         self.notdone = True
         self.NN = neighbors
 
-    def deduplicate(self):
+    def deduplicate(self) -> None:
         """
         Removes duplicate peptides.
 
@@ -61,22 +69,26 @@ class imputable:
         Groups rows by peptide, if a peptide appears in more than one row it is removed.
 
         """
-        if (self.data[self.data.columns.values[1]][0][-2] == "T") & (self.data[self.data.columns.values[1]][0][-1].isdigit()):
-            self.data[self.data.columns.values[1]] = self.data[self.data.columns.values[1]].apply(lambda x: x.split('T')[0])
-        
-        self.data = self.data.groupby(['Peptide','Protein']).mean()
+        if (self.data[self.data.columns.values[1]][0][-2] == "T") & (
+            self.data[self.data.columns.values[1]][0][-1].isdigit()
+        ):
+            self.data[self.data.columns.values[1]] = self.data[
+                self.data.columns.values[1]
+            ].apply(lambda x: x.split("T")[0])
+
+        self.data = self.data.groupby(["Peptide", "Protein"]).mean()
         todrop = []
-        for name, group in tqdm(self.data.groupby(level='Peptide')):
+        for name, group in tqdm(self.data.groupby(level="Peptide")):
             if len(group) > 1:
                 todrop.append(name)
         self.data = self.data.drop(todrop)
 
-    def drop_missing(self):
+    def drop_missing(self) -> None:
         """Removes rows which are missing more data than the user specified missingness threshold."""
-        self.miss = np.rint(len(self.data.columns)*self.miss)
-        self.data = self.data[self.data.isnull().sum(axis=1)<=self.miss]
+        self.miss = np.rint(len(self.data.columns) * self.miss)
+        self.data = self.data[self.data.isnull().sum(axis=1) <= self.miss]
 
-    def impute(self,outname):
+    def impute(self, outname: str) -> None:
         """
         Imputes missing data with KNN and outputs the results to the specified file.
 
@@ -91,7 +103,7 @@ class imputable:
 
         """
 
-        def match_pat(l,i):
+        def match_pat(l, i):
             """
             finds all missingness patterns present in the dataset
 
@@ -117,49 +129,57 @@ class imputable:
         def get_patterns(arr):
             """Calls match_pat on all rows of data"""
             for ind, val in enumerate(arr):
-                match_pat(val,ind)
+                match_pat(val, ind)
 
-        def sub_imputer(inds,pattern,origarr,comparr):
+        def sub_imputer(inds, pattern, origarr, comparr):
             """
-            single imputation process for a missingness pattern.
+                        single imputation process for a missingness pattern.
 
 
-            Drops columns missing in a given missingness pattern. Then finds nearest neighbors.  Iterates over rows matching missingness pattern, getting indexes of nearest neighbors, averaging nearest neighbrs and replacing 
-missing values with corresponding averages.
+                        Drops columns missing in a given missingness pattern. Then finds nearest neighbors.  Iterates over rows matching missingness pattern, getting indexes of nearest neighbors, averaging nearest neighbrs and replacing
+            missing values with corresponding averages.
 
 
-            Parameters
-            ----------
-            inds : list
-                indexes of rows sharing the missingness pattern.
-            pattern : str
-                Binary representation of missingness pattern.
-            origarr : arr
-                original array of data with missing values
-            comparr : arr
-                Complete array of only rows with no missing values (complete cases).
+                        Parameters
+                        ----------
+                        inds : list
+                            indexes of rows sharing the missingness pattern.
+                        pattern : str
+                            Binary representation of missingness pattern.
+                        origarr : arr
+                            original array of data with missing values
+                        comparr : arr
+                            Complete array of only rows with no missing values (complete cases).
 
 
-            Returns
-            -------
-            outa : arr
-                Imputed array for missingness pattern.
+                        Returns
+                        -------
+                        outa : arr
+                            Imputed array for missingness pattern.
 
             """
 
-            #drop missing columns given missingness pattern
-            newarr = comparr[:,~np.array(list(pattern)).astype(int).astype(bool)]
-            #fit nearest neighbors
+            # drop missing columns given missingness pattern
+            newarr = comparr[:, ~np.array(list(pattern)).astype(int).astype(bool)]
+            # fit nearest neighbors
             nbrs = NearestNeighbors(n_neighbors=self.NN).fit(newarr)
             outa = []
-            #iterate over rows matching missingness pattern
+            # iterate over rows matching missingness pattern
             for rowind, row in enumerate(origarr[inds]):
                 outl = []
-                #get indexes of given rows nearest neighbors
-                indexes = nbrs.kneighbors([origarr[inds[rowind],~np.array(list(pattern)).astype(int).astype(bool)]],return_distance=False)
-                #get array of nearest neighbors
+                # get indexes of given rows nearest neighbors
+                indexes = nbrs.kneighbors(
+                    [
+                        origarr[
+                            inds[rowind],
+                            ~np.array(list(pattern)).astype(int).astype(bool),
+                        ]
+                    ],
+                    return_distance=False,
+                )
+                # get array of nearest neighbors
                 means = np.mean(comparr[indexes[0][1:]], axis=0)
-                #iterate over entries in each row
+                # iterate over entries in each row
                 for ind, v in enumerate(row):
                     if not np.isnan(v):
                         outl.append(v)
@@ -190,32 +210,35 @@ missing values with corresponding averages.
 
             outdict = {}
             for k in tqdm(self.pats.keys()):
-                temparr = sub_imputer(self.pats[k],k, origarr,comparr)
+                temparr = sub_imputer(self.pats[k], k, origarr, comparr)
                 for ind, v in enumerate(temparr):
                     outdict[self.pats[k][ind]] = v
             return outdict
 
         datavals = self.data.values
-        #generate array of complete cases
+        # generate array of complete cases
         comparr = datavals[~np.isnan(datavals).any(axis=1)]
 
-        #find missingness patterns
+        # find missingness patterns
         get_patterns(datavals)
 
-        #impute
+        # impute
         out = imputer(datavals, comparr)
 
-        #reform dataframe with imputed values from outdict
-        meld = pd.DataFrame.from_dict(out,orient='index')
+        # reform dataframe with imputed values from outdict
+        meld = pd.DataFrame.from_dict(out, orient="index")
         meld.index = meld.index.astype(float)
         meld.sort_index(inplace=True)
-        meld.set_index([self.data.index.get_level_values(0),self.data.index.get_level_values(1)], inplace=True)
+        meld.set_index(
+            [self.data.index.get_level_values(0), self.data.index.get_level_values(1)],
+            inplace=True,
+        )
         meld.columns = self.data.columns
         from circ.io import write_expression
+
         write_expression(meld, outname)
 
-    def impute_data(self,out_file):
+    def impute_data(self, out_file: str) -> None:
         self.deduplicate()
         self.drop_missing()
         self.impute(out_file)
-

--- a/circ/limbr/old_fashioned.py
+++ b/circ/limbr/old_fashioned.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from sklearn import preprocessing
+
 
 class old_fashioned:
     """
@@ -31,7 +34,9 @@ class old_fashioned:
 
     """
 
-    def __init__(self, filename,data_type,pool=None):
+    def __init__(
+        self, filename: str | Path, data_type: str, pool: str | Path | None = None
+    ) -> None:
         """
         Imports data and initializes an old_fashioned object.
 
@@ -42,15 +47,17 @@ class old_fashioned:
 
         np.random.seed(4574)
         self.data_type = str(data_type)
-        if self.data_type == 'p':
-            self.raw_data = pd.read_csv(filename,sep='\t').set_index(['Peptide','Protein'])
-        if self.data_type == 'r':
-            self.raw_data = pd.read_csv(filename,sep='\t').set_index('#')
+        if self.data_type == "p":
+            self.raw_data = pd.read_csv(filename, sep="\t").set_index(
+                ["Peptide", "Protein"]
+            )
+        if self.data_type == "r":
+            self.raw_data = pd.read_csv(filename, sep="\t").set_index("#")
         if pool is not None:
-            self.norm_map = pd.read_parquet(pool)['pool_number'].to_dict()
+            self.norm_map = pd.read_parquet(pool)["pool_number"].to_dict()
         self.notdone = True
 
-    def pool_normalize(self):
+    def pool_normalize(self) -> None:
         """
         Preprocessing normalization.
 
@@ -67,7 +74,7 @@ class old_fashioned:
 
         """
 
-        def pool_norm(df,dmap):
+        def pool_norm(df, dmap):
             """
             Pool normalizes samples in a proteomics experiment.
 
@@ -92,9 +99,11 @@ class old_fashioned:
 
             newdf = pd.DataFrame(index=df.index)
             for column in df.columns.values:
-                if 'pool' not in column:
-                    newdf[column] = df[column].div(df['pool_'+'%02d' % dmap[column]],axis='index')
-            nonpool = [i for i in newdf.columns if 'pool' not in i]
+                if "pool" not in column:
+                    newdf[column] = df[column].div(
+                        df["pool_" + "%02d" % dmap[column]], axis="index"
+                    )
+            nonpool = [i for i in newdf.columns if "pool" not in i]
             newdf = newdf[nonpool]
             return newdf
 
@@ -119,25 +128,42 @@ class old_fashioned:
 
             """
 
-            ref = pd.concat([df[col].sort_values().reset_index(drop=True) for col in df], axis=1, ignore_index=True).mean(axis=1).values
-            for i in range(0,len(df.columns)):
+            ref = (
+                pd.concat(
+                    [df[col].sort_values().reset_index(drop=True) for col in df],
+                    axis=1,
+                    ignore_index=True,
+                )
+                .mean(axis=1)
+                .values
+            )
+            for i in range(0, len(df.columns)):
                 df = df.sort_values(df.columns[i])
                 df[df.columns[i]] = ref
             return df.sort_index()
-        if self.data_type == 'r':
+
+        if self.data_type == "r":
             self.data = qnorm(self.raw_data)
             self.scaler = preprocessing.StandardScaler().fit(self.data.values.T)
-            self.data = pd.DataFrame(self.scaler.transform(self.data.values.T).T,columns=self.data.columns,index=self.data.index)
+            self.data = pd.DataFrame(
+                self.scaler.transform(self.data.values.T).T,
+                columns=self.data.columns,
+                index=self.data.index,
+            )
         else:
-            self.data_pnorm = pool_norm(self.raw_data,self.norm_map)
+            self.data_pnorm = pool_norm(self.raw_data, self.norm_map)
             self.data_pnorm = self.data_pnorm.replace([np.inf, -np.inf], np.nan)
             self.data_pnorm = self.data_pnorm.dropna()
             self.data_pnorm = self.data_pnorm.sort_index(axis=1)
             self.data_pnorm = qnorm(self.data_pnorm)
             self.scaler = preprocessing.StandardScaler().fit(self.data_pnorm.values.T)
-            self.data = pd.DataFrame(self.scaler.transform(self.data_pnorm.values.T).T,columns=self.data_pnorm.columns,index=self.data_pnorm.index)
+            self.data = pd.DataFrame(
+                self.scaler.transform(self.data_pnorm.values.T).T,
+                columns=self.data_pnorm.columns,
+                index=self.data_pnorm.index,
+            )
 
-    def normalize(self,outname):
+    def normalize(self, outname: str) -> None:
         """
         Groups peptides by protein and outputs final processed dataset.
 
@@ -152,9 +178,9 @@ class old_fashioned:
 
         """
 
-        #self.old_norm = self.scaler.inverse_transform(self.data.values.T).T
-        #self.old_norm = pd.DataFrame(self.old_norm,index=self.data.index,columns=self.data.columns)
-        if self.data_type == 'p':
-            self.data = self.data.groupby(level='Protein').mean()
-        self.data.index.names = ['#']
-        self.data.to_csv(outname,sep='\t')
+        # self.old_norm = self.scaler.inverse_transform(self.data.values.T).T
+        # self.old_norm = pd.DataFrame(self.old_norm,index=self.data.index,columns=self.data.columns)
+        if self.data_type == "p":
+            self.data = self.data.groupby(level="Protein").mean()
+        self.data.index.names = ["#"]
+        self.data.to_csv(outname, sep="\t")

--- a/circ/limbr/simulations.py
+++ b/circ/limbr/simulations.py
@@ -3,6 +3,7 @@ import os
 import re
 import tempfile
 from collections import Counter
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -11,13 +12,15 @@ from circ.simulations import simulate  # noqa: F401  re-exported for backward co
 
 
 class analyze:
-    def __init__(self, filename_classes):
-        self.true_classes = pd.read_csv(filename_classes, sep='\t')
-        self.tags = {}
-        self.merged = []
+    def __init__(self, filename_classes: str) -> None:
+        self.true_classes = pd.read_csv(filename_classes, sep="\t")
+        self.tags: dict[str, int] = {}
+        self.merged: list[pd.DataFrame] = []
         self.i = 0
 
-    def run_bootjtk(self, filename, tag, size=50, workers=1):
+    def run_bootjtk(
+        self, filename: str, tag: str, size: int = 50, workers: int = 1
+    ) -> None:
         """
         Run bootjtk significance testing on a LIMBR-processed (or baseline) file.
 
@@ -35,90 +38,113 @@ class analyze:
         from circ.bootjtk import BooteJTK, CalcP
         import circ.bootjtk as _bootjtk_pkg
 
-        ref_dir = os.path.join(os.path.dirname(_bootjtk_pkg.__file__), 'ref_files')
+        ref_dir = os.path.join(os.path.dirname(_bootjtk_pkg.__file__), "ref_files")
 
-        df = pd.read_csv(filename, sep='\t', index_col=0)
+        df = pd.read_csv(filename, sep="\t", index_col=0)
 
-        data_cols = [c for c in df.columns if re.match(r'^(ZT|CT)?\d', str(c))]
+        data_cols = [c for c in df.columns if re.match(r"^(ZT|CT)?\d", str(c))]
         df = df[data_cols]
 
-        df.columns = [re.sub(r'_\d+$', '', str(c)) for c in df.columns]
-        df.index.name = 'ID'
-        df = df.replace('NULL', 'NA')
+        df.columns = [re.sub(r"_\d+$", "", str(c)) for c in df.columns]
+        df.index.name = "ID"
+        df = df.replace("NULL", "NA")
 
         reps = int(np.median(list(Counter(df.columns).values())))
 
         def _make_args(fn):
             return argparse.Namespace(
                 filename=fn,
-                means='DEFAULT', sds='DEFAULT', ns='DEFAULT',
-                output='DEFAULT', pickle='DEFAULT',
-                id_list='DEFAULT', null_list='DEFAULT',
-                write=False, prefix='', reps=reps, size=size,
-                workers=workers, waveform='cosine',
-                width=os.path.join(ref_dir, 'asymmetries_02-22_by2.txt'),
-                phase=os.path.join(ref_dir, 'phases_00-22_by2.txt'),
-                period=os.path.join(ref_dir, 'period24.txt'),
-                harding=False, normal=False,
+                means="DEFAULT",
+                sds="DEFAULT",
+                ns="DEFAULT",
+                output="DEFAULT",
+                pickle="DEFAULT",
+                id_list="DEFAULT",
+                null_list="DEFAULT",
+                write=False,
+                prefix="",
+                reps=reps,
+                size=size,
+                workers=workers,
+                waveform="cosine",
+                width=os.path.join(ref_dir, "asymmetries_02-22_by2.txt"),
+                phase=os.path.join(ref_dir, "phases_00-22_by2.txt"),
+                period=os.path.join(ref_dir, "period24.txt"),
+                harding=False,
+                normal=False,
             )
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            data_path = os.path.join(tmpdir, 'data.txt')
-            df.to_csv(data_path, sep='\t')
+            data_path = os.path.join(tmpdir, "data.txt")
+            df.to_csv(data_path, sep="\t")
 
             null_df = pd.DataFrame(
                 np.random.normal(0, 1, df.shape),
                 index=df.index,
                 columns=df.columns,
             )
-            null_df.index.name = 'ID'
-            null_path = os.path.join(tmpdir, 'null.txt')
-            null_df.to_csv(null_path, sep='\t')
+            null_df.index.name = "ID"
+            null_path = os.path.join(tmpdir, "null.txt")
+            null_df.to_csv(null_path, sep="\t")
 
             data_out, _, _ = BooteJTK.main(_make_args(data_path))
             null_out, _, _ = BooteJTK.main(_make_args(null_path))
 
-            CalcP.main(argparse.Namespace(
-                filename=data_out,
-                null=null_out,
-                fit=False,
-            ))
-            calcp_out = data_out.replace('.txt', '_GammaP.txt')
+            CalcP.main(
+                argparse.Namespace(
+                    filename=data_out,
+                    null=null_out,
+                    fit=False,
+                )
+            )
+            calcp_out = data_out.replace(".txt", "_GammaP.txt")
 
             self.add_data(calcp_out, tag)
 
-    def add_data(self, filename_ejtk, tag, include_missing=True):
+    def add_data(
+        self, filename_ejtk: str, tag: str, include_missing: bool = True
+    ) -> None:
         self.tags[tag] = self.i
-        ejtk = pd.read_csv(filename_ejtk, sep='\t')
+        ejtk = pd.read_csv(filename_ejtk, sep="\t")
         if include_missing:
-            self.merged.append(pd.merge(
-                self.true_classes[['Protein', 'Circadian']],
-                ejtk[['ID', 'GammaBH']],
-                left_on='Protein', right_on='ID', how='left',
-            ))
+            self.merged.append(
+                pd.merge(
+                    self.true_classes[["Protein", "Circadian"]],
+                    ejtk[["ID", "GammaBH"]],
+                    left_on="Protein",
+                    right_on="ID",
+                    how="left",
+                )
+            )
         else:
-            self.merged.append(pd.merge(
-                self.true_classes[['Protein', 'Circadian']],
-                ejtk[['ID', 'GammaBH']],
-                left_on='Protein', right_on='ID', how='inner',
-            ))
-        self.merged[self.i].set_index('Protein', inplace=True)
-        self.merged[self.i].drop('ID', axis=1, inplace=True)
+            self.merged.append(
+                pd.merge(
+                    self.true_classes[["Protein", "Circadian"]],
+                    ejtk[["ID", "GammaBH"]],
+                    left_on="Protein",
+                    right_on="ID",
+                    how="inner",
+                )
+            )
+        self.merged[self.i].set_index("Protein", inplace=True)
+        self.merged[self.i].drop("ID", axis=1, inplace=True)
         self.merged[self.i].fillna(1.0, inplace=True)
         self.i += 1
 
-    def _merged_dict(self):
+    def _merged_dict(self) -> dict[str, pd.DataFrame]:
         """Build the ``{tag: df}`` dict expected by the visualization module."""
         return {tag: self.merged[idx] for tag, idx in self.tags.items()}
 
-    def generate_roc_curve(self, outpath='ROC.pdf'):
+    def generate_roc_curve(self, outpath: str = "ROC.pdf") -> Any:
         """Plot ROC curves for all added datasets and save to *outpath*."""
         from circ.visualization.benchmarks import roc_curve_plot
+
         ax = roc_curve_plot(self._merged_dict(), outpath=outpath)
         return ax
 
-    def calculate_auc(self):
+    def calculate_auc(self) -> Any:
         """Compute AUC for each dataset and store in ``self.roc_auc``."""
         from circ.evaluation import roc_auc
+
         self.roc_auc = roc_auc(self._merged_dict())
         return self.roc_auc

--- a/circ/pirs/rank.py
+++ b/circ/pirs/rank.py
@@ -1,5 +1,9 @@
 import multiprocessing
-_mp_ctx = multiprocessing.get_context('forkserver')
+
+_mp_ctx = multiprocessing.get_context("forkserver")
+
+from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import numpy as np
@@ -12,7 +16,14 @@ from tqdm import tqdm
 # Module-level helpers (must be at top level for multiprocessing picklability)
 # ---------------------------------------------------------------------------
 
-def _pirs_score(y, X_pinv, X_obs, X_fine, dof):
+
+def _pirs_score(
+    y: np.ndarray,
+    X_pinv: np.ndarray,
+    X_obs: np.ndarray,
+    X_fine: np.ndarray,
+    dof: int,
+) -> float:
     """PIRS score for a single expression vector.
 
     score = max over fine grid of max(|PI_upper(t) - mean_expr|,
@@ -33,7 +44,7 @@ def _pirs_score(y, X_pinv, X_obs, X_fine, dof):
     """
     n = len(y)
     beta = X_pinv @ y
-    y_hat_obs  = X_obs  @ beta
+    y_hat_obs = X_obs @ beta
     y_hat_fine = X_fine @ beta
 
     mean_expr = np.mean(y)
@@ -44,12 +55,15 @@ def _pirs_score(y, X_pinv, X_obs, X_fine, dof):
     s = np.sqrt(max(rss, 1e-28) / df_resid)
     t_crit = t_dist.ppf(0.975, df_resid)
 
-    x_obs  = X_obs[:, 1]
+    x_obs = X_obs[:, 1]
     x_fine = X_fine[:, 1]
     x_mean = np.mean(x_obs)
     Sxx = np.sum((x_obs - x_mean) ** 2)
-    lev = (1.0 + 1.0 / n + (x_fine - x_mean) ** 2 / Sxx
-           if Sxx > 1e-14 else np.full(len(x_fine), 1.0 + 1.0 / n))
+    lev = (
+        1.0 + 1.0 / n + (x_fine - x_mean) ** 2 / Sxx
+        if Sxx > 1e-14
+        else np.full(len(x_fine), 1.0 + 1.0 / n)
+    )
 
     pi_half = t_crit * s * np.sqrt(lev)
     upper = y_hat_fine + pi_half
@@ -59,7 +73,11 @@ def _pirs_score(y, X_pinv, X_obs, X_fine, dof):
     return float(max_dev / denom)
 
 
-def _permutation_worker(args):
+def _permutation_worker(
+    args: tuple[
+        Any, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, float, int, int
+    ],
+) -> tuple[Any, float]:
     """Multiprocessing worker: permute y n_permutations times, return p-value.
 
     Uses a left-tail test: counts how many permuted PIRS scores are <= the
@@ -81,7 +99,11 @@ def _permutation_worker(args):
     return gene_id, (count_le + 1) / (n_perm + 1)
 
 
-def _slope_score(y, X_pinv, X_fine):
+def _slope_score(
+    y: np.ndarray,
+    X_pinv: np.ndarray,
+    X_fine: np.ndarray,
+) -> float:
     """Slope-only score: max regression trend deviation from mean, normalized by mean.
 
     score = max(|ŷ_fine(t) − mean_expr|) / |mean_expr|
@@ -97,7 +119,9 @@ def _slope_score(y, X_pinv, X_fine):
     return float(np.max(np.abs(y_hat_fine - mean_expr)) / denom)
 
 
-def _slope_permutation_worker(args):
+def _slope_permutation_worker(
+    args: tuple[Any, np.ndarray, np.ndarray, np.ndarray, float, int, int],
+) -> tuple[Any, float]:
     """Multiprocessing worker for the slope permutation test.
 
     Right-tail test: counts how many permuted slope scores are >= the observed
@@ -119,6 +143,7 @@ def _slope_permutation_worker(args):
 # ---------------------------------------------------------------------------
 # ranker
 # ---------------------------------------------------------------------------
+
 
 class ranker:
     """Ranks and sorts expression profiles from most to least constitutive.
@@ -145,20 +170,23 @@ class ranker:
                           calculate_scores() / calculate_pvals()
     """
 
-    def __init__(self, source, anova=True):
+    def __init__(self, source: str | Path | pd.DataFrame, anova: bool = True) -> None:
         from circ.io import read_expression
+
         self.data = read_expression(source)
         self.data = self.data[(self.data.T != 0).any()]
         self.anova = anova
-        self.errors = None
+        self.errors: pd.DataFrame | None = None
 
-    def get_tpoints(self):
+    def get_tpoints(self) -> None:
         """Extract numeric timepoints from column headers (ZT/CT prefix)."""
-        tpoints = [i.replace('ZT', '').replace('CT', '') for i in self.data.columns.values]
-        tpoints = [int(i.split('_')[0]) for i in tpoints]
+        tpoints = [
+            i.replace("ZT", "").replace("CT", "") for i in self.data.columns.values
+        ]
+        tpoints = [int(i.split("_")[0]) for i in tpoints]
         self.tpoints = np.asarray(tpoints)
 
-    def remove_anova(self, alpha=0.05):
+    def remove_anova(self, alpha: float = 0.05) -> None:
         """Remove profiles with significant differential expression (one-way ANOVA).
 
         Parameters
@@ -170,13 +198,15 @@ class ranker:
         for index, row in self.data.iterrows():
             vals = []
             for i in list(set(self.tpoints)):
-                vals.append([row.values[j] for j in range(len(row)) if self.tpoints[j] == i])
+                vals.append(
+                    [row.values[j] for j in range(len(row)) if self.tpoints[j] == i]
+                )
             f_val, p_val = f_oneway(*vals)
             if p_val < alpha:
                 to_remove.append(index)
         self.data = self.data[~self.data.index.isin(to_remove)]
 
-    def calculate_scores(self):
+    def calculate_scores(self) -> pd.DataFrame:
         """Compute PIRS scores for every expression profile.
 
         score = max over fine grid of max(|PI_upper(t) - mean_expr|,
@@ -192,12 +222,12 @@ class ranker:
             Index = gene IDs, column ``score``, sorted ascending.
         """
         tpoints = self.tpoints
-        dof     = len(np.unique(tpoints))
-        x_fine  = np.arange(min(tpoints), max(tpoints), 0.1)
+        dof = len(np.unique(tpoints))
+        x_fine = np.arange(min(tpoints), max(tpoints), 0.1)
 
         # Pre-compute design matrices — shared across all genes
-        X_obs    = np.column_stack([np.ones(len(tpoints)), tpoints])
-        X_pinv   = np.linalg.pinv(X_obs)
+        X_obs = np.column_stack([np.ones(len(tpoints)), tpoints])
+        X_pinv = np.linalg.pinv(X_obs)
         X_fine_m = np.column_stack([np.ones(len(x_fine)), x_fine])
 
         es = {}
@@ -205,13 +235,15 @@ class ranker:
             y = np.array(self.data.iloc[index], dtype=float)
             es[index] = _pirs_score(y, X_pinv, X_obs, X_fine_m, dof)
 
-        self.errors = pd.DataFrame.from_dict(es, orient='index')
-        self.errors.columns = ['score']
+        self.errors = pd.DataFrame.from_dict(es, orient="index")
+        self.errors.columns = ["score"]
         self.errors.index = self.data.index
-        self.errors.sort_values('score', inplace=True)
+        self.errors.sort_values("score", inplace=True)
         return self.errors
 
-    def calculate_pvals(self, n_permutations=1000, n_jobs=1):
+    def calculate_pvals(
+        self, n_permutations: int = 1000, n_jobs: int = 1
+    ) -> pd.DataFrame:
         """Compute permutation p-values for PIRS scores.
 
         For each gene, shuffles the expression values ``n_permutations``
@@ -242,21 +274,26 @@ class ranker:
             raise RuntimeError("Call calculate_scores() before calculate_pvals().")
 
         tpoints = self.tpoints
-        dof     = len(np.unique(tpoints))
-        x_fine  = np.arange(min(tpoints), max(tpoints), 0.1)
+        dof = len(np.unique(tpoints))
+        x_fine = np.arange(min(tpoints), max(tpoints), 0.1)
 
-        X_obs    = np.column_stack([np.ones(len(tpoints)), tpoints])
-        X_pinv   = np.linalg.pinv(X_obs)
+        X_obs = np.column_stack([np.ones(len(tpoints)), tpoints])
+        X_pinv = np.linalg.pinv(X_obs)
         X_fine_m = np.column_stack([np.ones(len(x_fine)), x_fine])
 
         # Build one arg-tuple per gene; seed is fixed per gene for reproducibility
         gene_args = [
-            (gene_id,
-             np.array(self.data.loc[gene_id], dtype=float),
-             X_pinv, X_obs, X_fine_m, dof,
-             float(self.errors.loc[gene_id, 'score']),
-             n_permutations,
-             i)
+            (
+                gene_id,
+                np.array(self.data.loc[gene_id], dtype=float),
+                X_pinv,
+                X_obs,
+                X_fine_m,
+                dof,
+                float(self.errors.loc[gene_id, "score"]),
+                n_permutations,
+                i,
+            )
             for i, gene_id in enumerate(self.errors.index)
         ]
 
@@ -264,26 +301,30 @@ class ranker:
             results = [_permutation_worker(a) for a in tqdm(gene_args)]
         else:
             pool_size = n_jobs if n_jobs > 0 else None
-            actual    = pool_size or multiprocessing.cpu_count()
+            actual = pool_size or multiprocessing.cpu_count()
             chunksize = max(1, len(gene_args) // (actual * 4))
             with _mp_ctx.Pool(pool_size) as pool:
-                results = list(tqdm(
-                    pool.imap(_permutation_worker, gene_args, chunksize=chunksize),
-                    total=len(gene_args),
-                ))
+                results = list(
+                    tqdm(
+                        pool.imap(_permutation_worker, gene_args, chunksize=chunksize),
+                        total=len(gene_args),
+                    )
+                )
 
         pvals = pd.Series(
             {gid: pval for gid, pval in results},
-            name='pval',
+            name="pval",
         ).reindex(self.errors.index)
 
-        _, pvals_bh, _, _ = ssm.multipletests(pvals.values, method='fdr_bh')
+        _, pvals_bh, _, _ = ssm.multipletests(pvals.values, method="fdr_bh")
 
-        self.errors['pval']    = pvals.values
-        self.errors['pval_bh'] = pvals_bh
+        self.errors["pval"] = pvals.values
+        self.errors["pval_bh"] = pvals_bh
         return self.errors
 
-    def calculate_slope_pvals(self, n_permutations=1000, n_jobs=1):
+    def calculate_slope_pvals(
+        self, n_permutations: int = 1000, n_jobs: int = 1
+    ) -> pd.DataFrame:
         """Compute permutation p-values for the slope component of expression.
 
         For each gene, shuffles expression values ``n_permutations`` times and
@@ -311,22 +352,29 @@ class ranker:
             ``slope_pval_bh``.
         """
         if self.errors is None:
-            raise RuntimeError("Call calculate_scores() before calculate_slope_pvals().")
+            raise RuntimeError(
+                "Call calculate_scores() before calculate_slope_pvals()."
+            )
 
         tpoints = self.tpoints
-        x_fine  = np.arange(min(tpoints), max(tpoints), 0.1)
+        x_fine = np.arange(min(tpoints), max(tpoints), 0.1)
 
-        X_obs    = np.column_stack([np.ones(len(tpoints)), tpoints])
-        X_pinv   = np.linalg.pinv(X_obs)
+        X_obs = np.column_stack([np.ones(len(tpoints)), tpoints])
+        X_pinv = np.linalg.pinv(X_obs)
         X_fine_m = np.column_stack([np.ones(len(x_fine)), x_fine])
 
         gene_args = [
-            (gene_id,
-             np.array(self.data.loc[gene_id], dtype=float),
-             X_pinv, X_fine_m,
-             _slope_score(np.array(self.data.loc[gene_id], dtype=float), X_pinv, X_fine_m),
-             n_permutations,
-             i)
+            (
+                gene_id,
+                np.array(self.data.loc[gene_id], dtype=float),
+                X_pinv,
+                X_fine_m,
+                _slope_score(
+                    np.array(self.data.loc[gene_id], dtype=float), X_pinv, X_fine_m
+                ),
+                n_permutations,
+                i,
+            )
             for i, gene_id in enumerate(self.errors.index)
         ]
 
@@ -334,27 +382,37 @@ class ranker:
             results = [_slope_permutation_worker(a) for a in tqdm(gene_args)]
         else:
             pool_size = n_jobs if n_jobs > 0 else None
-            actual    = pool_size or multiprocessing.cpu_count()
+            actual = pool_size or multiprocessing.cpu_count()
             chunksize = max(1, len(gene_args) // (actual * 4))
             with _mp_ctx.Pool(pool_size) as pool:
-                results = list(tqdm(
-                    pool.imap(_slope_permutation_worker, gene_args, chunksize=chunksize),
-                    total=len(gene_args),
-                ))
+                results = list(
+                    tqdm(
+                        pool.imap(
+                            _slope_permutation_worker, gene_args, chunksize=chunksize
+                        ),
+                        total=len(gene_args),
+                    )
+                )
 
         pvals = pd.Series(
             {gid: pval for gid, pval in results},
-            name='slope_pval',
+            name="slope_pval",
         ).reindex(self.errors.index)
 
-        _, pvals_bh, _, _ = ssm.multipletests(pvals.values, method='fdr_bh')
+        _, pvals_bh, _, _ = ssm.multipletests(pvals.values, method="fdr_bh")
 
-        self.errors['slope_pval']    = pvals.values
-        self.errors['slope_pval_bh'] = pvals_bh
+        self.errors["slope_pval"] = pvals.values
+        self.errors["slope_pval_bh"] = pvals_bh
         return self.errors
 
-    def pirs_sort(self, outname=False, pvals=False, slope_pvals=False,
-                  n_permutations=1000, n_jobs=1):
+    def pirs_sort(
+        self,
+        outname: str | None = None,
+        pvals: bool = False,
+        slope_pvals: bool = False,
+        n_permutations: int = 1000,
+        n_jobs: int = 1,
+    ) -> pd.DataFrame:
         """Run the full PIRS pipeline and return data sorted by score.
 
         Parameters
@@ -387,9 +445,11 @@ class ranker:
             self.calculate_pvals(n_permutations=n_permutations, n_jobs=n_jobs)
         if slope_pvals:
             self.calculate_slope_pvals(n_permutations=n_permutations, n_jobs=n_jobs)
+        assert self.errors is not None
         sorted_data = self.data.loc[self.errors.index.values]
-        if outname:
+        if outname is not None:
             from circ.io import write_expression
+
             write_expression(self.errors, outname)
         return sorted_data
 
@@ -397,6 +457,7 @@ class ranker:
 # ---------------------------------------------------------------------------
 # rsd_ranker  (unchanged — benchmarking baseline)
 # ---------------------------------------------------------------------------
+
 
 class rsd_ranker:
     """Ranks profiles by Relative Standard Deviation (benchmarking baseline).
@@ -411,20 +472,25 @@ class rsd_ranker:
     data : DataFrame
     """
 
-    def __init__(self, source):
+    def __init__(self, source: str | Path | pd.DataFrame) -> None:
         from circ.io import read_expression
+
         self.data = read_expression(source)
         self.data = self.data[(self.data.T != 0).any()]
 
-    def calculate_scores(self):
+    def calculate_scores(self) -> pd.DataFrame:
         """Compute RSD scores (sorted ascending)."""
-        rsd = (1 + (1 / (4 * len(self.data)))) * np.std(self.data.values, axis=1) / np.abs(np.mean(self.data.values, axis=1))
+        rsd = (
+            (1 + (1 / (4 * len(self.data))))
+            * np.std(self.data.values, axis=1)
+            / np.abs(np.mean(self.data.values, axis=1))
+        )
         self.rsd = pd.DataFrame(rsd, index=self.data.index)
-        self.rsd.columns = ['score']
-        self.rsd.sort_values('score', inplace=True)
+        self.rsd.columns = ["score"]
+        self.rsd.sort_values("score", inplace=True)
         return self.rsd
 
-    def rsd_sort(self, outname=False):
+    def rsd_sort(self, outname: str | None = None) -> pd.DataFrame:
         """Run pipeline and return data sorted by RSD.
 
         Parameters
@@ -438,7 +504,8 @@ class rsd_ranker:
         """
         self.calculate_scores()
         sorted_data = self.data.loc[self.rsd.index.values]
-        if outname:
+        if outname is not None:
             from circ.io import write_expression
+
             write_expression(self.rsd, outname)
         return sorted_data

--- a/circ/pirs/simulations.py
+++ b/circ/pirs/simulations.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import pandas as pd
 from sklearn.metrics import precision_recall_curve
@@ -6,58 +8,62 @@ from circ.simulations import simulate  # noqa: F401  re-exported for backward co
 
 
 class analyze:
-    def __init__(self):
+    def __init__(self) -> None:
         self.true_classes = pd.DataFrame()
         self.merged = pd.DataFrame()
 
-    def add_classes(self, filename_classes, rep=0):
-        tc = pd.read_csv(filename_classes, sep='\t')
-        tc['rep'] = rep
+    def add_classes(self, filename_classes: str, rep: int = 0) -> None:
+        tc = pd.read_csv(filename_classes, sep="\t")
+        tc["rep"] = rep
         self.true_classes = pd.concat([self.true_classes, tc])
 
-    def add_data(self, filename_pirs, tag, rep=0):
-        ranks = pd.read_csv(filename_pirs, sep='\t')
-        ranks['method'] = tag
-        ranks['rep'] = rep
-        ranks['score'] = ranks['score'].fillna(ranks['score'].max())
+    def add_data(self, filename_pirs: str, tag: str, rep: int = 0) -> None:
+        ranks = pd.read_csv(filename_pirs, sep="\t")
+        ranks["method"] = tag
+        ranks["rep"] = rep
+        ranks["score"] = ranks["score"].fillna(ranks["score"].max())
         if self.merged.empty:
             self.merged = ranks
         else:
             self.merged = pd.concat([self.merged, ranks])
 
-    def _build_curves(self):
+    def _build_curves(self) -> pd.DataFrame:
         """Compute per-method precision-recall curves and return as a DataFrame."""
-        curves = pd.DataFrame(columns=['precision', 'recall', 'method', 'rep'])
+        curves = pd.DataFrame(columns=["precision", "recall", "method", "rep"])
         melted = (
-            self.merged
-            .pivot_table(index=['rep', 'method'], columns='#', values='score')
+            self.merged.pivot_table(
+                index=["rep", "method"], columns="#", values="score"
+            )
             .fillna(self.merged.score.max())
             .reset_index()
-            .melt(id_vars=['rep', 'method'], value_name='score')
+            .melt(id_vars=["rep", "method"], value_name="score")
         )
         for rep in melted.rep.unique():
             for method in melted.method.unique():
                 pr = pd.merge(
-                    self.true_classes[self.true_classes['rep'] == rep],
+                    self.true_classes[self.true_classes["rep"] == rep],
                     melted[(melted.rep == rep) & (melted.method == method)],
-                    on=['#', 'rep'],
+                    on=["#", "rep"],
                 )
                 precision, recall, _ = precision_recall_curve(
-                    pr['Const'].values, 1 / pr['score'].values, pos_label=1
+                    pr["Const"].values, 1 / pr["score"].values, pos_label=1
                 )
-                temp = pd.DataFrame({
-                    'precision': precision,
-                    'recall': recall,
-                    'method': method,
-                    'rep': rep,
-                })
+                temp = pd.DataFrame(
+                    {
+                        "precision": precision,
+                        "recall": recall,
+                        "method": method,
+                        "rep": rep,
+                    }
+                )
                 curves = pd.concat([curves, temp], sort=False)
         return curves
 
-    def generate_pr_curve(self, outpath='PR.pdf'):
+    def generate_pr_curve(self, outpath: str = "PR.pdf") -> Any:
         """Build precision-recall curves and save to *outpath* (default PR.pdf)."""
         from circ.visualization.benchmarks import pr_curve
+
         self.curves = self._build_curves()
-        baseline = float(np.mean(self.true_classes['Const']))
+        baseline = float(np.mean(self.true_classes["Const"]))
         ax = pr_curve(self.curves, baseline=baseline, outpath=outpath)
         return ax

--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -64,22 +64,22 @@ class simulate:
 
     def __init__(
         self,
-        tpoints=24,
-        nrows=1000,
-        nreps=3,
-        tpoint_space=2,
-        pcirc=0.3,
-        plin=0.2,
-        phase_prop=0.5,
-        phase_noise=0.25,
-        amp_noise=0.75,
-        n_batch_effects=0,
-        pbatch=0.5,
-        effect_size=2.0,
-        p_miss=0.0,
-        lam_miss=5,
-        rseed=0,
-    ):
+        tpoints: int = 24,
+        nrows: int = 1000,
+        nreps: int = 3,
+        tpoint_space: int = 2,
+        pcirc: float = 0.3,
+        plin: float = 0.2,
+        phase_prop: float = 0.5,
+        phase_noise: float = 0.25,
+        amp_noise: float = 0.75,
+        n_batch_effects: int = 0,
+        pbatch: float = 0.5,
+        effect_size: float = 2.0,
+        p_miss: float = 0.0,
+        lam_miss: int = 5,
+        rseed: int = 0,
+    ) -> None:
         pconst = 1.0 - pcirc - plin
         if pconst < 0:
             raise ValueError("pcirc + plin must be <= 1.0")
@@ -158,12 +158,12 @@ class simulate:
     # ------------------------------------------------------------------
 
     @property
-    def circ(self):
+    def circ(self) -> np.ndarray:
         """int array, 1 where class == 'circadian'."""
         return (self.classes == "circadian").astype(int)
 
     @property
-    def const(self):
+    def const(self) -> np.ndarray:
         """int array, 1 where class == 'constitutive'."""
         return (self.classes == "constitutive").astype(int)
 
@@ -171,7 +171,7 @@ class simulate:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _true_classes_df(self, index=None):
+    def _true_classes_df(self, index: pd.Index | None = None) -> pd.DataFrame:
         df = pd.DataFrame(
             {
                 "Circadian": (self.classes == "circadian").astype(int),
@@ -187,7 +187,7 @@ class simulate:
     # Output methods
     # ------------------------------------------------------------------
 
-    def write_output(self, out_name="simulated_data.txt"):
+    def write_output(self, out_name: str = "simulated_data.txt") -> None:
         """Write expression-format output (gene / # index).
 
         Writes the scaled clean data to *out_name* and the per-row class
@@ -202,7 +202,7 @@ class simulate:
             stem + "_true_classes.txt", sep="\t"
         )
 
-    def write_proteomics(self, out_name="simulated_data"):
+    def write_proteomics(self, out_name: str = "simulated_data") -> None:
         """Write proteomics-format output (Peptide / Protein index).
 
         Writes three files:
@@ -239,17 +239,17 @@ class simulate:
         base_df.to_csv(out_name + "_baseline.txt", sep="\t")
 
         # True classes indexed by Protein
-        self._true_classes_df(
-            index=pd.Index(prots, name="Protein")
-        ).to_csv(out_name + "_true_classes.txt", sep="\t")
+        self._true_classes_df(index=pd.Index(prots, name="Protein")).to_csv(
+            out_name + "_true_classes.txt", sep="\t"
+        )
 
-    def generate_pool_map(self, out_name="pool_map"):
+    def generate_pool_map(self, out_name: str = "pool_map") -> None:
         """Write a pool map parquet file mapping every sample column to pool 1."""
         pd.DataFrame({"pool_number": {col: 1 for col in self.cols}}).to_parquet(
             out_name + ".parquet"
         )
 
-    def write_genorm(self, out_name="simulated_data_genorm.txt"):
+    def write_genorm(self, out_name: str = "simulated_data_genorm.txt") -> None:
         """Write geNorm-format output (Sample, Detector, Cq columns)."""
         df = pd.DataFrame(self.sim, columns=self.cols)
         df.index.name = "#"
@@ -259,27 +259,21 @@ class simulate:
         long["Sample"] = long["Sample"].apply(
             lambda x: "timepoint_" + str(x).split("_")[0]
         )
-        long["Detector"] = long["Detector"].astype(str).apply(
-            lambda x: "gene_" + x
-        )
+        long["Detector"] = long["Detector"].astype(str).apply(lambda x: "gene_" + x)
         long["Cq"] = (long["Cq"] - long["Cq"].min()) / (
             long["Cq"].max() - long["Cq"].min()
         )
         long.to_csv(out_name, sep=" ", index=False)
 
-    def write_normfinder(self, out_name="simulated_data_normfinder.txt"):
+    def write_normfinder(self, out_name: str = "simulated_data_normfinder.txt") -> None:
         """Write NormFinder-format output (Sample, Detector, Cq columns)."""
         df = pd.DataFrame(self.sim, columns=self.cols)
         df.index.name = "#"
         long = df.reset_index().melt(id_vars=["#"])
         long.columns = ["Detector", "Sample", "Cq"]
         long = long[["Sample", "Detector", "Cq"]]
-        long["Sample"] = long["Sample"].astype(str).apply(
-            lambda x: "timepoint_" + x
-        )
-        long["Detector"] = long["Detector"].astype(str).apply(
-            lambda x: "gene_" + x
-        )
+        long["Sample"] = long["Sample"].astype(str).apply(lambda x: "timepoint_" + x)
+        long["Detector"] = long["Detector"].astype(str).apply(lambda x: "gene_" + x)
         long["Cq"] = (long["Cq"] - long["Cq"].min()) / (
             long["Cq"].max() - long["Cq"].min()
         )

--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -36,6 +36,7 @@ Benchmark / evaluation plots
 The ``LABEL_COLORS`` dict maps each expression label to a consistent hex
 color and can be imported for use in custom plots.
 """
+
 from circ.visualization.classify import (
     LABEL_COLORS,
     label_distribution,
@@ -71,32 +72,32 @@ from circ.visualization.benchmarks import (
 
 __all__ = [
     # classify
-    'LABEL_COLORS',
-    'label_distribution',
-    'pirs_vs_tau',
-    'volcano',
-    'pirs_score_distribution',
-    'tau_pval_scatter',
-    'pirs_pval_scatter',
-    'slope_pval_scatter',
-    'slope_vs_rhythm',
-    'phase_wheel',
-    'period_distribution',
-    'phase_amplitude_scatter',
-    'top_constitutive_candidates',
-    'mean_expression_profiles',
-    'threshold_sensitivity',
-    'classification_summary',
+    "LABEL_COLORS",
+    "label_distribution",
+    "pirs_vs_tau",
+    "volcano",
+    "pirs_score_distribution",
+    "tau_pval_scatter",
+    "pirs_pval_scatter",
+    "slope_pval_scatter",
+    "slope_vs_rhythm",
+    "phase_wheel",
+    "period_distribution",
+    "phase_amplitude_scatter",
+    "top_constitutive_candidates",
+    "mean_expression_profiles",
+    "threshold_sensitivity",
+    "classification_summary",
     # compare
-    'rhythmicity_shift_scatter',
-    'phase_shift_histogram',
-    'label_transition_heatmap',
-    'delta_tau_volcano',
-    'comparison_summary',
+    "rhythmicity_shift_scatter",
+    "phase_shift_histogram",
+    "label_transition_heatmap",
+    "delta_tau_volcano",
+    "comparison_summary",
     # benchmarks
-    'pr_curve',
-    'roc_curve_plot',
-    'roc_auc',
-    'classification_pr',
-    'classification_roc',
+    "pr_curve",
+    "roc_curve_plot",
+    "roc_auc",
+    "classification_pr",
+    "classification_roc",
 ]

--- a/circ/visualization/benchmarks.py
+++ b/circ/visualization/benchmarks.py
@@ -6,14 +6,21 @@ called directly with pre-computed data.
 
 Metric-only functions (no matplotlib) live in ``circ.evaluation``.
 """
+
 import matplotlib.pyplot as plt
 import seaborn as sns
-from sklearn.metrics import average_precision_score, precision_recall_curve, roc_curve, auc
+from sklearn.metrics import (
+    average_precision_score,
+    precision_recall_curve,
+    roc_curve,
+    auc,
+)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _ax(ax):
     return ax if ax is not None else plt.subplots()[1]
@@ -22,6 +29,7 @@ def _ax(ax):
 # ---------------------------------------------------------------------------
 # Precision-recall
 # ---------------------------------------------------------------------------
+
 
 def pr_curve(curves, baseline=None, ax=None, outpath=None):
     """Plot one or more precision-recall curves from a pre-computed DataFrame.
@@ -43,29 +51,29 @@ def pr_curve(curves, baseline=None, ax=None, outpath=None):
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    palette = sns.color_palette('muted', n_colors=curves['method'].nunique())
+    palette = sns.color_palette("muted", n_colors=curves["method"].nunique())
     sns.lineplot(
         data=curves,
-        x='recall', y='precision',
-        hue='method', units='rep',
+        x="recall",
+        y="precision",
+        hue="method",
+        units="rep",
         palette=palette,
         estimator=None,
         linewidth=0.8,
         ax=ax,
     )
     if baseline is not None:
-        ax.axhline(baseline, color='#CC4444', ls=':', lw=0.9,
-                   label='random classifier')
+        ax.axhline(baseline, color="#CC4444", ls=":", lw=0.9, label="random classifier")
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.05)
-    ax.set_xlabel('Recall')
-    ax.set_ylabel('Precision')
-    ax.set_title('Precision–Recall comparison')
-    ax.legend(loc='upper right', bbox_to_anchor=(1.3, 1.0),
-              frameon=False, fontsize=8)
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.set_title("Precision–Recall comparison")
+    ax.legend(loc="upper right", bbox_to_anchor=(1.3, 1.0), frameon=False, fontsize=8)
     sns.despine(ax=ax)
     if outpath:
-        ax.get_figure().savefig(outpath, dpi=150, bbox_inches='tight')
+        ax.get_figure().savefig(outpath, dpi=150, bbox_inches="tight")
     return ax
 
 
@@ -87,21 +95,23 @@ def roc_curve_plot(merged_dict, ax=None, outpath=None):
     """
     ax = _ax(ax)
     for tag, df in merged_dict.items():
-        truth_col = 'truth' if 'truth' in df.columns else 'Circadian'
-        score_col = 'score' if 'score' in df.columns else 'GammaBH'
-        fpr, tpr, _ = roc_curve(df[truth_col].values, 1 - df[score_col].values, pos_label=1)
+        truth_col = "truth" if "truth" in df.columns else "Circadian"
+        score_col = "score" if "score" in df.columns else "GammaBH"
+        fpr, tpr, _ = roc_curve(
+            df[truth_col].values, 1 - df[score_col].values, pos_label=1
+        )
         auc_val = auc(fpr, tpr)
-        ax.plot(fpr, tpr, label=f'{tag}  (AUC={auc_val:.3f})')
-    ax.plot([0, 1], [0, 1], color='#999999', ls='--', lw=0.8, label='random')
+        ax.plot(fpr, tpr, label=f"{tag}  (AUC={auc_val:.3f})")
+    ax.plot([0, 1], [0, 1], color="#999999", ls="--", lw=0.8, label="random")
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.05)
-    ax.set_xlabel('False positive rate')
-    ax.set_ylabel('True positive rate')
-    ax.set_title('ROC comparison')
-    ax.legend(loc='lower right', frameon=False, fontsize=8)
+    ax.set_xlabel("False positive rate")
+    ax.set_ylabel("True positive rate")
+    ax.set_title("ROC comparison")
+    ax.legend(loc="lower right", frameon=False, fontsize=8)
     sns.despine(ax=ax)
     if outpath:
-        ax.get_figure().savefig(outpath, dpi=150, bbox_inches='tight')
+        ax.get_figure().savefig(outpath, dpi=150, bbox_inches="tight")
     return ax
 
 
@@ -109,11 +119,12 @@ def roc_curve_plot(merged_dict, ax=None, outpath=None):
 # Classification benchmarking (Classifier output + simulation ground truth)
 # ---------------------------------------------------------------------------
 
+
 def classification_pr(
     classifications,
     true_classes,
-    ground_truth_col='Const',
-    score_col='pirs_score',
+    ground_truth_col="Const",
+    score_col="pirs_score",
     invert_score=True,
     ax=None,
     title=None,
@@ -145,11 +156,13 @@ def classification_pr(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    merged = classifications[[score_col]].join(
-        true_classes[[ground_truth_col]], how='inner'
-    ).dropna()
+    merged = (
+        classifications[[score_col]]
+        .join(true_classes[[ground_truth_col]], how="inner")
+        .dropna()
+    )
     if merged.empty:
-        ax.set_title((title or 'PR curve') + ' (no matched genes)')
+        ax.set_title((title or "PR curve") + " (no matched genes)")
         return ax
 
     scores = merged[score_col].values
@@ -160,15 +173,15 @@ def classification_pr(
     )
     baseline = merged[ground_truth_col].mean()
     ap = average_precision_score(merged[ground_truth_col].values, scores)
-    ax.plot(recall, precision, color='#4878CF', lw=1.2,
-            label=f'{score_col} (AP={ap:.3f})')
-    ax.axhline(baseline, color='#CC4444', ls=':', lw=0.9,
-               label='random classifier')
+    ax.plot(
+        recall, precision, color="#4878CF", lw=1.2, label=f"{score_col} (AP={ap:.3f})"
+    )
+    ax.axhline(baseline, color="#CC4444", ls=":", lw=0.9, label="random classifier")
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.05)
-    ax.set_xlabel('Recall')
-    ax.set_ylabel('Precision')
-    ax.set_title(title or f'PR curve: {ground_truth_col}')
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.set_title(title or f"PR curve: {ground_truth_col}")
     ax.legend(frameon=False, fontsize=8)
     sns.despine(ax=ax)
     return ax
@@ -179,7 +192,7 @@ def classification_roc(
     true_classes,
     tasks=None,
     ax=None,
-    title='ROC: Classifier scores vs ground truth',
+    title="ROC: Classifier scores vs ground truth",
 ):
     """ROC curves for multiple binary classification tasks.
 
@@ -210,49 +223,61 @@ def classification_roc(
 
     if tasks is None:
         tasks = []
-        if 'pirs_score' in classifications.columns and 'Const' in true_classes.columns:
-            tasks.append(('pirs_score', 'Const', True))
-        if 'tau_mean' in classifications.columns and 'Circadian' in true_classes.columns:
-            tasks.append(('tau_mean', 'Circadian', False))
-        if 'emp_p' in classifications.columns and 'Circadian' in true_classes.columns:
-            tasks.append(('emp_p', 'Circadian', True))
-        if 'pval' in classifications.columns and 'Const' in true_classes.columns:
-            tasks.append(('pval', 'Const', True))
-        if 'slope_pval' in classifications.columns and 'Linear' in true_classes.columns:
-            tasks.append(('slope_pval', 'Linear', True))
+        if "pirs_score" in classifications.columns and "Const" in true_classes.columns:
+            tasks.append(("pirs_score", "Const", True))
+        if (
+            "tau_mean" in classifications.columns
+            and "Circadian" in true_classes.columns
+        ):
+            tasks.append(("tau_mean", "Circadian", False))
+        if "emp_p" in classifications.columns and "Circadian" in true_classes.columns:
+            tasks.append(("emp_p", "Circadian", True))
+        if "pval" in classifications.columns and "Const" in true_classes.columns:
+            tasks.append(("pval", "Const", True))
+        if "slope_pval" in classifications.columns and "Linear" in true_classes.columns:
+            tasks.append(("slope_pval", "Linear", True))
 
     # Human-readable descriptions for each (score, truth) task pair
     _task_names = {
-        ('pirs_score', 'Const'):      'PIRS score → constitutive',
-        ('tau_mean',   'Circadian'):  'TauMean → circadian',
-        ('emp_p',      'Circadian'):  'GammaBH p-val → circadian',
-        ('pval',       'Const'):      'PIRS p-val → constitutive',
-        ('pval_bh',    'Const'):      'PIRS p-val (BH) → constitutive',
-        ('slope_pval', 'Linear'):     'slope p-val → linear',
-        ('slope_pval_bh', 'Linear'):  'slope p-val (BH) → linear',
+        ("pirs_score", "Const"): "PIRS score → constitutive",
+        ("tau_mean", "Circadian"): "TauMean → circadian",
+        ("emp_p", "Circadian"): "GammaBH p-val → circadian",
+        ("pval", "Const"): "PIRS p-val → constitutive",
+        ("pval_bh", "Const"): "PIRS p-val (BH) → constitutive",
+        ("slope_pval", "Linear"): "slope p-val → linear",
+        ("slope_pval_bh", "Linear"): "slope p-val (BH) → linear",
     }
 
-    palette = sns.color_palette('muted', n_colors=max(len(tasks), 1))
+    palette = sns.color_palette("muted", n_colors=max(len(tasks), 1))
     for (score_col, truth_col, invert), color in zip(tasks, palette):
-        merged = classifications[[score_col]].join(
-            true_classes[[truth_col]], how='inner'
-        ).dropna()
+        merged = (
+            classifications[[score_col]]
+            .join(true_classes[[truth_col]], how="inner")
+            .dropna()
+        )
         if merged.empty:
             continue
         scores = -merged[score_col].values if invert else merged[score_col].values
         fpr, tpr, _ = roc_curve(merged[truth_col].values, scores, pos_label=1)
         auc_val = auc(fpr, tpr)
-        label = _task_names.get((score_col, truth_col), f'{score_col} → {truth_col}')
-        ax.plot(fpr, tpr, color=color, lw=1.2, label=f'{label}  (AUC={auc_val:.3f})')
+        label = _task_names.get((score_col, truth_col), f"{score_col} → {truth_col}")
+        ax.plot(fpr, tpr, color=color, lw=1.2, label=f"{label}  (AUC={auc_val:.3f})")
 
-    ax.plot([0, 1], [0, 1], color='#999999', ls='--', lw=0.8, label='random (AUC=0.5)')
+    ax.plot([0, 1], [0, 1], color="#999999", ls="--", lw=0.8, label="random (AUC=0.5)")
     ax.set_xlim(0.0, 1.0)
     ax.set_ylim(0.0, 1.05)
-    ax.set_xlabel('False positive rate')
-    ax.set_ylabel('True positive rate')
+    ax.set_xlabel("False positive rate")
+    ax.set_ylabel("True positive rate")
     ax.set_title(title)
-    ax.text(0.01, 0.01, 'Each curve: does score rank its gene class above others?',
-            transform=ax.transAxes, fontsize=7, color='#666666', va='bottom')
-    ax.legend(loc='lower right', frameon=False, fontsize=8)
+    ax.text(
+        0.01,
+        0.01,
+        "Each curve: does score rank its gene class above others?",
+        transform=ax.transAxes,
+        fontsize=7,
+        color="#666666",
+        va="bottom",
+    )
+    ax.legend(loc="lower right", frameon=False, fontsize=8)
     sns.despine(ax=ax)
     return ax

--- a/circ/visualization/classify.py
+++ b/circ/visualization/classify.py
@@ -1,4 +1,5 @@
 """Visualizations for expression classification results from Classifier.classify()."""
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -7,23 +8,28 @@ import seaborn as sns
 
 # Consistent label colors used across every plot in this module
 LABEL_COLORS = {
-    'constitutive':  '#4878CF',
-    'rhythmic':      '#6ACC65',
-    'linear':        '#D65F5F',
-    'variable':      '#B47CC7',
-    'noisy_rhythmic': '#C4AD66',
-    'unclassified':  '#8C8C8C',
+    "constitutive": "#4878CF",
+    "rhythmic": "#6ACC65",
+    "linear": "#D65F5F",
+    "variable": "#B47CC7",
+    "noisy_rhythmic": "#C4AD66",
+    "unclassified": "#8C8C8C",
 }
 
 _LABEL_ORDER = [
-    'constitutive', 'rhythmic', 'linear',
-    'variable', 'noisy_rhythmic', 'unclassified',
+    "constitutive",
+    "rhythmic",
+    "linear",
+    "variable",
+    "noisy_rhythmic",
+    "unclassified",
 ]
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _ax(ax):
     return ax if ax is not None else plt.subplots()[1]
@@ -39,12 +45,15 @@ def _has(df, col):
 
 def _scatter_by_label(df, xcol, ycol, ax, size=18, alpha=0.65):
     for lbl in _LABEL_ORDER:
-        sub = df[df['label'] == lbl] if 'label' in df.columns else df
+        sub = df[df["label"] == lbl] if "label" in df.columns else df
         if not sub.empty:
             ax.scatter(
-                sub[xcol], sub[ycol],
-                color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-                s=size, alpha=alpha, label=lbl,
+                sub[xcol],
+                sub[ycol],
+                color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                s=size,
+                alpha=alpha,
+                label=lbl,
                 rasterized=len(df) > 1000,
             )
 
@@ -52,10 +61,11 @@ def _scatter_by_label(df, xcol, ycol, ax, size=18, alpha=0.65):
 def _label_legend(present, ax):
     patches = [
         mpatches.Patch(color=LABEL_COLORS[l], label=l)
-        for l in _LABEL_ORDER if l in present
+        for l in _LABEL_ORDER
+        if l in present
     ]
     if patches:
-        ax.legend(handles=patches, loc='best', frameon=False, fontsize=9)
+        ax.legend(handles=patches, loc="best", frameon=False, fontsize=9)
 
 
 def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
@@ -76,7 +86,8 @@ def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
 # Public plot functions
 # ---------------------------------------------------------------------------
 
-def label_distribution(classifications, ax=None, title='Expression label counts'):
+
+def label_distribution(classifications, ax=None, title="Expression label counts"):
     """Horizontal bar chart of gene counts per expression label.
 
     Parameters
@@ -91,18 +102,14 @@ def label_distribution(classifications, ax=None, title='Expression label counts'
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    present = [l for l in _LABEL_ORDER if l in classifications['label'].values]
+    present = [l for l in _LABEL_ORDER if l in classifications["label"].values]
     counts = (
-        classifications['label']
-        .value_counts()
-        .reindex(present)
-        .fillna(0)
-        .astype(int)
+        classifications["label"].value_counts().reindex(present).fillna(0).astype(int)
     )
     colors = [LABEL_COLORS[l] for l in counts.index]
     bars = ax.barh(counts.index, counts.values, color=colors)
-    ax.bar_label(bars, fmt='%d', padding=3, fontsize=9)
-    ax.set_xlabel('Gene count')
+    ax.bar_label(bars, fmt="%d", padding=3, fontsize=9)
+    ax.set_xlabel("Gene count")
     ax.set_title(title)
     ax.invert_yaxis()
     sns.despine(ax=ax, left=True)
@@ -114,7 +121,7 @@ def pirs_vs_tau(
     pirs_percentile=50,
     tau_threshold=0.5,
     ax=None,
-    title='PIRS score vs rhythmicity (TauMean)',
+    title="PIRS score vs rhythmicity (TauMean)",
 ):
     """Scatter of PIRS constitutiveness score vs BooteJTK TauMean.
 
@@ -137,22 +144,34 @@ def pirs_vs_tau(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    df = classifications.dropna(subset=['pirs_score', 'tau_mean'])
-    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+    df = classifications.dropna(subset=["pirs_score", "tau_mean"])
+    pirs_cut = np.percentile(df["pirs_score"], pirs_percentile)
 
-    _scatter_by_label(df, 'pirs_score', 'tau_mean', ax)
+    _scatter_by_label(df, "pirs_score", "tau_mean", ax)
 
-    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'PIRS p{int(pirs_percentile)}')
-    ax.axhline(tau_threshold, color='#333333', ls=':', lw=0.9, alpha=0.7,
-               label=f'τ = {tau_threshold}')
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"PIRS p{int(pirs_percentile)}",
+    )
+    ax.axhline(
+        tau_threshold,
+        color="#333333",
+        ls=":",
+        lw=0.9,
+        alpha=0.7,
+        label=f"τ = {tau_threshold}",
+    )
     # Clip x to 95th percentile to match pirs_score_distribution and avoid
     # high-PIRS outliers compressing the constitutive cluster at the left edge
-    _clip_axes_to_data(ax, df['pirs_score'], df['tau_mean'], x_pct=(0, 95))
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel('TauMean')
+    _clip_axes_to_data(ax, df["pirs_score"], df["tau_mean"], x_pct=(0, 95))
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel("TauMean")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
@@ -162,7 +181,7 @@ def volcano(
     emp_p_threshold=0.05,
     pirs_percentile=50,
     ax=None,
-    title='PIRS score vs rhythmicity significance',
+    title="PIRS score vs rhythmicity significance",
 ):
     """Scatter of PIRS score vs −log₁₀(emp_p).
 
@@ -186,24 +205,36 @@ def volcano(
     -------
     matplotlib.axes.Axes
     """
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
     ax = _ax(ax)
-    df = classifications.dropna(subset=['pirs_score', 'emp_p'])
-    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
-    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+    df = classifications.dropna(subset=["pirs_score", "emp_p"])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df["emp_p"]))
+    pirs_cut = np.percentile(df["pirs_score"], pirs_percentile)
 
-    _scatter_by_label(df, 'pirs_score', 'neg_log_emp_p', ax)
+    _scatter_by_label(df, "pirs_score", "neg_log_emp_p", ax)
 
-    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'FDR = {emp_p_threshold}')
-    ax.axvline(pirs_cut, color='#333333', ls=':', lw=0.9, alpha=0.7,
-               label=f'PIRS p{int(pirs_percentile)}')
-    _clip_axes_to_data(ax, df['pirs_score'], df['neg_log_emp_p'])
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel('−log₁₀(GammaBH)')
+    ax.axhline(
+        -np.log10(emp_p_threshold),
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"FDR = {emp_p_threshold}",
+    )
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls=":",
+        lw=0.9,
+        alpha=0.7,
+        label=f"PIRS p{int(pirs_percentile)}",
+    )
+    _clip_axes_to_data(ax, df["pirs_score"], df["neg_log_emp_p"])
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel("−log₁₀(GammaBH)")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
@@ -212,7 +243,7 @@ def pirs_score_distribution(
     classifications,
     pirs_percentile=50,
     ax=None,
-    title='PIRS score distribution by label',
+    title="PIRS score distribution by label",
 ):
     """KDE of PIRS scores overlaid per expression label.
 
@@ -232,22 +263,35 @@ def pirs_score_distribution(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    all_scores = classifications['pirs_score'].dropna()
+    all_scores = classifications["pirs_score"].dropna()
     pirs_cut = np.percentile(all_scores, pirs_percentile)
     for lbl in _LABEL_ORDER:
-        sub = classifications[classifications['label'] == lbl]['pirs_score'].dropna()
+        sub = classifications[classifications["label"] == lbl]["pirs_score"].dropna()
         if len(sub) >= 3:
-            sns.kdeplot(sub, ax=ax, color=LABEL_COLORS[lbl], label=lbl, fill=True,
-                        alpha=0.3, linewidth=1.2)
-    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.8,
-               label=f'p{int(pirs_percentile)} cut')
+            sns.kdeplot(
+                sub,
+                ax=ax,
+                color=LABEL_COLORS[lbl],
+                label=lbl,
+                fill=True,
+                alpha=0.3,
+                linewidth=1.2,
+            )
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.8,
+        label=f"p{int(pirs_percentile)} cut",
+    )
     # Clip x-axis: always start at 0 and end at the 95th percentile so the
     # constitutive spike and the label separation are both visible.
     hi = np.percentile(all_scores, 95)
     margin = max(hi * 0.05, 0.05)
     ax.set_xlim(0, hi + margin)
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel('Density')
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel("Density")
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
@@ -259,7 +303,7 @@ def tau_pval_scatter(
     tau_threshold=0.5,
     emp_p_threshold=0.05,
     ax=None,
-    title='Rhythmicity: TauMean vs GammaBH significance',
+    title="Rhythmicity: TauMean vs GammaBH significance",
 ):
     """Scatter of TauMean vs −log₁₀(emp_p), showing the BooteJTK decision space.
 
@@ -281,24 +325,36 @@ def tau_pval_scatter(
     -------
     matplotlib.axes.Axes
     """
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
     ax = _ax(ax)
-    df = classifications.dropna(subset=['tau_mean', 'emp_p'])
-    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
+    df = classifications.dropna(subset=["tau_mean", "emp_p"])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df["emp_p"]))
 
-    _scatter_by_label(df, 'tau_mean', 'neg_log_emp_p', ax)
+    _scatter_by_label(df, "tau_mean", "neg_log_emp_p", ax)
 
-    ax.axvline(tau_threshold, color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'τ = {tau_threshold}')
-    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls=':', lw=0.9, alpha=0.7,
-               label=f'FDR = {emp_p_threshold}')
+    ax.axvline(
+        tau_threshold,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"τ = {tau_threshold}",
+    )
+    ax.axhline(
+        -np.log10(emp_p_threshold),
+        color="#333333",
+        ls=":",
+        lw=0.9,
+        alpha=0.7,
+        label=f"FDR = {emp_p_threshold}",
+    )
     # Always start tau from 0 so the threshold line is never at the left edge
-    _clip_axes_to_data(ax, df['tau_mean'], df['neg_log_emp_p'], x_pct=(0, 99))
-    ax.set_xlabel('TauMean')
-    ax.set_ylabel('−log₁₀(GammaBH)')
+    _clip_axes_to_data(ax, df["tau_mean"], df["neg_log_emp_p"], x_pct=(0, 99))
+    ax.set_xlabel("TauMean")
+    ax.set_ylabel("−log₁₀(GammaBH)")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
@@ -307,7 +363,7 @@ def pirs_pval_scatter(
     classifications,
     pval_threshold=0.05,
     ax=None,
-    title='PIRS score vs temporal structure significance',
+    title="PIRS score vs temporal structure significance",
 ):
     """Scatter of PIRS score vs −log₁₀(pval_bh).
 
@@ -330,25 +386,29 @@ def pirs_pval_scatter(
     -------
     matplotlib.axes.Axes
     """
-    p_col = 'pval_bh' if _has(classifications, 'pval_bh') else 'pval'
+    p_col = "pval_bh" if _has(classifications, "pval_bh") else "pval"
     if not _has(classifications, p_col):
-        raise ValueError(
-            "'pval' column is required. Call run_pirs(pvals=True) first."
-        )
+        raise ValueError("'pval' column is required. Call run_pirs(pvals=True) first.")
     ax = _ax(ax)
-    df = classifications.dropna(subset=['pirs_score', p_col])
+    df = classifications.dropna(subset=["pirs_score", p_col])
     df = df.assign(neg_log_p=_safe_neglog10(df[p_col]))
 
-    _scatter_by_label(df, 'pirs_score', 'neg_log_p', ax)
+    _scatter_by_label(df, "pirs_score", "neg_log_p", ax)
 
-    ax.axhline(-np.log10(pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'α = {pval_threshold}')
-    lbl_used = 'pval_bh' if p_col == 'pval_bh' else 'pval'
-    _clip_axes_to_data(ax, df['pirs_score'], df['neg_log_p'])
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel(f'−log₁₀({lbl_used})')
+    ax.axhline(
+        -np.log10(pval_threshold),
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"α = {pval_threshold}",
+    )
+    lbl_used = "pval_bh" if p_col == "pval_bh" else "pval"
+    _clip_axes_to_data(ax, df["pirs_score"], df["neg_log_p"])
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel(f"−log₁₀({lbl_used})")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
@@ -358,7 +418,7 @@ def slope_pval_scatter(
     slope_pval_threshold=0.05,
     pirs_percentile=50,
     ax=None,
-    title='PIRS score vs linear slope significance',
+    title="PIRS score vs linear slope significance",
 ):
     """Scatter of PIRS score vs −log₁₀(slope_pval_bh).
 
@@ -382,28 +442,40 @@ def slope_pval_scatter(
     -------
     matplotlib.axes.Axes
     """
-    p_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    p_col = "slope_pval_bh" if _has(classifications, "slope_pval_bh") else "slope_pval"
     if not _has(classifications, p_col):
         raise ValueError(
             "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
         )
     ax = _ax(ax)
-    df = classifications.dropna(subset=['pirs_score', p_col])
+    df = classifications.dropna(subset=["pirs_score", p_col])
     df = df.assign(neg_log_slope=_safe_neglog10(df[p_col]))
-    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+    pirs_cut = np.percentile(df["pirs_score"], pirs_percentile)
 
-    _scatter_by_label(df, 'pirs_score', 'neg_log_slope', ax)
+    _scatter_by_label(df, "pirs_score", "neg_log_slope", ax)
 
-    ax.axhline(-np.log10(slope_pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'α = {slope_pval_threshold}')
-    ax.axvline(pirs_cut, color='#333333', ls=':', lw=0.9, alpha=0.7,
-               label=f'PIRS p{int(pirs_percentile)}')
-    lbl_used = 'slope_pval_bh' if p_col == 'slope_pval_bh' else 'slope_pval'
-    _clip_axes_to_data(ax, df['pirs_score'], df['neg_log_slope'])
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel(f'−log₁₀({lbl_used})')
+    ax.axhline(
+        -np.log10(slope_pval_threshold),
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"α = {slope_pval_threshold}",
+    )
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls=":",
+        lw=0.9,
+        alpha=0.7,
+        label=f"PIRS p{int(pirs_percentile)}",
+    )
+    lbl_used = "slope_pval_bh" if p_col == "slope_pval_bh" else "slope_pval"
+    _clip_axes_to_data(ax, df["pirs_score"], df["neg_log_slope"])
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel(f"−log₁₀({lbl_used})")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
@@ -413,7 +485,7 @@ def slope_vs_rhythm(
     slope_pval_threshold=0.05,
     emp_p_threshold=0.05,
     ax=None,
-    title='Slope significance vs rhythmicity significance',
+    title="Slope significance vs rhythmicity significance",
 ):
     """Scatter of −log₁₀(slope_pval_bh) vs −log₁₀(emp_p).
 
@@ -443,42 +515,54 @@ def slope_vs_rhythm(
     -------
     matplotlib.axes.Axes
     """
-    sp_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    sp_col = "slope_pval_bh" if _has(classifications, "slope_pval_bh") else "slope_pval"
     if not _has(classifications, sp_col):
         raise ValueError(
             "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
         )
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
 
     ax = _ax(ax)
-    df = classifications.dropna(subset=[sp_col, 'emp_p'])
+    df = classifications.dropna(subset=[sp_col, "emp_p"])
     df = df.assign(
         neg_log_slope=_safe_neglog10(df[sp_col]),
-        neg_log_emp_p=_safe_neglog10(df['emp_p']),
+        neg_log_emp_p=_safe_neglog10(df["emp_p"]),
     )
 
-    _scatter_by_label(df, 'neg_log_slope', 'neg_log_emp_p', ax)
+    _scatter_by_label(df, "neg_log_slope", "neg_log_emp_p", ax)
 
-    ax.axvline(-np.log10(slope_pval_threshold), color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'slope α = {slope_pval_threshold}')
-    ax.axhline(-np.log10(emp_p_threshold), color='#333333', ls=':', lw=0.9, alpha=0.7,
-               label=f'rhythm α = {emp_p_threshold}')
-    lbl_used = 'slope_pval_bh' if sp_col == 'slope_pval_bh' else 'slope_pval'
-    _clip_axes_to_data(ax, df['neg_log_slope'], df['neg_log_emp_p'])
-    ax.set_xlabel(f'−log₁₀({lbl_used})')
-    ax.set_ylabel('−log₁₀(GammaBH)')
+    ax.axvline(
+        -np.log10(slope_pval_threshold),
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"slope α = {slope_pval_threshold}",
+    )
+    ax.axhline(
+        -np.log10(emp_p_threshold),
+        color="#333333",
+        ls=":",
+        lw=0.9,
+        alpha=0.7,
+        label=f"rhythm α = {emp_p_threshold}",
+    )
+    lbl_used = "slope_pval_bh" if sp_col == "slope_pval_bh" else "slope_pval"
+    _clip_axes_to_data(ax, df["neg_log_slope"], df["neg_log_emp_p"])
+    ax.set_xlabel(f"−log₁₀({lbl_used})")
+    ax.set_ylabel("−log₁₀(GammaBH)")
     ax.set_title(title)
-    _label_legend(df['label'].unique() if 'label' in df.columns else [], ax)
+    _label_legend(df["label"].unique() if "label" in df.columns else [], ax)
     sns.despine(ax=ax)
     return ax
 
 
 def phase_wheel(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
+    labels=("rhythmic", "noisy_rhythmic"),
     ax=None,
-    title='Phase distribution (rhythmic genes)',
+    title="Phase distribution (rhythmic genes)",
 ):
     """Polar histogram of estimated phase angles for rhythmic genes.
 
@@ -501,40 +585,56 @@ def phase_wheel(
     -------
     matplotlib.axes.Axes
     """
-    if not _has(classifications, 'phase_mean'):
+    if not _has(classifications, "phase_mean"):
         raise ValueError("'phase_mean' column is required. Call run_bootjtk() first.")
 
     if ax is None:
-        _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+        _, ax = plt.subplots(subplot_kw={"projection": "polar"})
 
-    df = classifications[classifications['label'].isin(labels)].dropna(subset=['phase_mean'])
+    df = classifications[classifications["label"].isin(labels)].dropna(
+        subset=["phase_mean"]
+    )
     if df.empty:
-        df = classifications.dropna(subset=['phase_mean'])
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        df = classifications.dropna(subset=["phase_mean"])
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
-    phases_rad = df['phase_mean'] * (2 * np.pi / 24)
+    phases_rad = df["phase_mean"] * (2 * np.pi / 24)
     nbins = 12
     bins = np.linspace(0, 2 * np.pi, nbins + 1)
     counts, _ = np.histogram(phases_rad, bins=bins)
     widths = np.diff(bins)
-    bars = ax.bar(bins[:-1], counts, width=widths, align='edge', alpha=0.7,
-                  color='#6ACC65', edgecolor='white')
+    bars = ax.bar(
+        bins[:-1],
+        counts,
+        width=widths,
+        align="edge",
+        alpha=0.7,
+        color="#6ACC65",
+        edgecolor="white",
+    )
 
-    ax.set_theta_zero_location('N')
+    ax.set_theta_zero_location("N")
     ax.set_theta_direction(-1)
     ax.set_xticks(np.linspace(0, 2 * np.pi, 8, endpoint=False))
-    hour_labels = [f'ZT{int(h):02d}' for h in np.linspace(0, 24, 8, endpoint=False)]
+    hour_labels = [f"ZT{int(h):02d}" for h in np.linspace(0, 24, 8, endpoint=False)]
     ax.set_xticklabels(hour_labels, fontsize=9)
 
     # Show integer counts on the radial axis and label each bar
     max_count = max(counts) if counts.max() > 0 else 1
     ax.set_rmax(max_count * 1.30)
     ax.yaxis.set_major_locator(plt.MaxNLocator(integer=True, nbins=4))
-    ax.tick_params(axis='y', labelsize=8, labelcolor='#555555')
+    ax.tick_params(axis="y", labelsize=8, labelcolor="#555555")
     for angle, count in zip(bins[:-1] + widths / 2, counts):
         if count > 0:
-            ax.text(angle, count + max_count * 0.10, str(count),
-                    ha='center', va='bottom', fontsize=8, color='#333333')
+            ax.text(
+                angle,
+                count + max_count * 0.10,
+                str(count),
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="#333333",
+            )
 
     ax.set_title(title, pad=15)
     return ax
@@ -542,10 +642,10 @@ def phase_wheel(
 
 def period_distribution(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
+    labels=("rhythmic", "noisy_rhythmic"),
     reference_period=24.0,
     ax=None,
-    title='Period distribution (rhythmic genes)',
+    title="Period distribution (rhythmic genes)",
 ):
     """Histogram of estimated period lengths for rhythmic genes.
 
@@ -568,23 +668,27 @@ def period_distribution(
     -------
     matplotlib.axes.Axes
     """
-    if not _has(classifications, 'period_mean'):
+    if not _has(classifications, "period_mean"):
         raise ValueError("'period_mean' column is required. Call run_bootjtk() first.")
 
     ax = _ax(ax)
 
     # Collect data for the requested labels; fall back to all genes if none qualify
     label_subsets = {
-        lbl: classifications[classifications['label'] == lbl]['period_mean'].dropna()
+        lbl: classifications[classifications["label"] == lbl]["period_mean"].dropna()
         for lbl in labels
     }
     has_data = any(not s.empty for s in label_subsets.values())
     if not has_data:
-        all_genes = classifications['period_mean'].dropna()
-        label_subsets = {'(all genes)': all_genes}
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        all_genes = classifications["period_mean"].dropna()
+        label_subsets = {"(all genes)": all_genes}
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
-    all_periods = pd.concat(list(label_subsets.values())) if label_subsets else pd.Series(dtype=float)
+    all_periods = (
+        pd.concat(list(label_subsets.values()))
+        if label_subsets
+        else pd.Series(dtype=float)
+    )
     data_range = all_periods.max() - all_periods.min() if len(all_periods) > 1 else 0.0
 
     if data_range < 1.0:
@@ -598,14 +702,26 @@ def period_distribution(
 
     for lbl, sub in label_subsets.items():
         if not sub.empty:
-            ax.hist(sub, bins=bins, color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-                    alpha=0.6, label=lbl, edgecolor='white')
+            ax.hist(
+                sub,
+                bins=bins,
+                color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                alpha=0.6,
+                label=lbl,
+                edgecolor="white",
+            )
 
-    ax.axvline(reference_period, color='#333333', ls='--', lw=0.9, alpha=0.8,
-               label=f'{reference_period:.0f} h')
+    ax.axvline(
+        reference_period,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.8,
+        label=f"{reference_period:.0f} h",
+    )
     ax.set_xlim(xlo, xhi)
-    ax.set_xlabel('Period (h)')
-    ax.set_ylabel('Gene count')
+    ax.set_xlabel("Period (h)")
+    ax.set_ylabel("Gene count")
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
@@ -614,9 +730,9 @@ def period_distribution(
 
 def phase_amplitude_scatter(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
+    labels=("rhythmic", "noisy_rhythmic"),
     ax=None,
-    title='Phase vs rhythm strength (rhythmic genes)',
+    title="Phase vs rhythm strength (rhythmic genes)",
 ):
     """Scatter of estimated phase angle vs rhythm strength for rhythmic genes.
 
@@ -640,18 +756,18 @@ def phase_amplitude_scatter(
     -------
     matplotlib.axes.Axes
     """
-    if not _has(classifications, 'phase_mean'):
+    if not _has(classifications, "phase_mean"):
         raise ValueError("'phase_mean' column is required. Call run_bootjtk() first.")
 
     ax = _ax(ax)
-    df = classifications[classifications['label'].isin(labels)].dropna(
-        subset=['phase_mean', 'tau_mean']
+    df = classifications[classifications["label"].isin(labels)].dropna(
+        subset=["phase_mean", "tau_mean"]
     )
     if df.empty:
-        df = classifications.dropna(subset=['phase_mean', 'tau_mean'])
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        df = classifications.dropna(subset=["phase_mean", "tau_mean"])
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
-    _scatter_by_label(df, 'phase_mean', 'tau_mean', ax, size=20, alpha=0.7)
+    _scatter_by_label(df, "phase_mean", "tau_mean", ax, size=20, alpha=0.7)
 
     # Ensure the y-axis shows a minimum readable range even with few genes
     y_lo, y_hi = ax.get_ylim()
@@ -659,13 +775,13 @@ def phase_amplitude_scatter(
         mid = (y_lo + y_hi) / 2
         ax.set_ylim(max(0.0, mid - 0.075), min(1.15, mid + 0.075))
 
-    ax.set_xlabel('Phase (h)')
+    ax.set_xlabel("Phase (h)")
     ax.set_xlim(0, 24)
     ax.set_xticks(range(0, 25, 4))
-    ax.set_xticklabels([f'ZT{h:02d}' for h in range(0, 25, 4)])
-    ax.set_ylabel('Rhythm strength (TauMean)')
+    ax.set_xticklabels([f"ZT{h:02d}" for h in range(0, 25, 4)])
+    ax.set_ylabel("Rhythm strength (TauMean)")
     ax.set_title(title)
-    _label_legend(df['label'].unique(), ax)
+    _label_legend(df["label"].unique(), ax)
     sns.despine(ax=ax)
     return ax
 
@@ -675,7 +791,7 @@ def top_constitutive_candidates(
     n_top=20,
     pirs_percentile=50,
     ax=None,
-    title='Top constitutive gene candidates',
+    title="Top constitutive gene candidates",
 ):
     """Ranked horizontal bar chart of the top-scoring constitutive gene candidates.
 
@@ -707,55 +823,69 @@ def top_constitutive_candidates(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    df = classifications.dropna(subset=['pirs_score'])
-    top = df.nsmallest(n_top, 'pirs_score')
+    df = classifications.dropna(subset=["pirs_score"])
+    top = df.nsmallest(n_top, "pirs_score")
 
-    all_scores = classifications['pirs_score'].dropna()
+    all_scores = classifications["pirs_score"].dropna()
     pirs_cut = np.percentile(all_scores, pirs_percentile)
 
-    p_col  = ('pval_bh'      if _has(df, 'pval_bh')      else
-              'pval'          if _has(df, 'pval')          else None)
-    sp_col = ('slope_pval_bh' if _has(df, 'slope_pval_bh') else
-              'slope_pval'    if _has(df, 'slope_pval')    else None)
+    p_col = "pval_bh" if _has(df, "pval_bh") else "pval" if _has(df, "pval") else None
+    sp_col = (
+        "slope_pval_bh"
+        if _has(df, "slope_pval_bh")
+        else "slope_pval"
+        if _has(df, "slope_pval")
+        else None
+    )
 
     def _bar_color(row):
-        lbl = row['label'] if 'label' in row.index else 'constitutive'
-        if lbl != 'constitutive':
-            return LABEL_COLORS.get(lbl, '#8C8C8C')
+        lbl = row["label"] if "label" in row.index else "constitutive"
+        if lbl != "constitutive":
+            return LABEL_COLORS.get(lbl, "#8C8C8C")
         if p_col is None:
-            return LABEL_COLORS['constitutive']
-        pval_sig  = pd.notna(row[p_col])  and row[p_col]  <= 0.05
-        slope_ns  = sp_col is None or (pd.notna(row[sp_col]) and row[sp_col] > 0.05)
+            return LABEL_COLORS["constitutive"]
+        pval_sig = pd.notna(row[p_col]) and row[p_col] <= 0.05
+        slope_ns = sp_col is None or (pd.notna(row[sp_col]) and row[sp_col] > 0.05)
         if pval_sig and slope_ns:
-            return LABEL_COLORS['constitutive']
+            return LABEL_COLORS["constitutive"]
         if pval_sig:
-            return '#7BA7D4'
-        return '#B0C4DE'
+            return "#7BA7D4"
+        return "#B0C4DE"
 
-    colors    = [_bar_color(row) for _, row in top.iterrows()]
-    top_rev   = top.iloc[::-1]
+    colors = [_bar_color(row) for _, row in top.iterrows()]
+    top_rev = top.iloc[::-1]
     colors_rev = colors[::-1]
 
-    ax.barh(top_rev.index.tolist(), top_rev['pirs_score'].values, color=colors_rev)
-    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'PIRS p{int(pirs_percentile)}')
-    ax.set_xlabel('PIRS score')
+    ax.barh(top_rev.index.tolist(), top_rev["pirs_score"].values, color=colors_rev)
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"PIRS p{int(pirs_percentile)}",
+    )
+    ax.set_xlabel("PIRS score")
     ax.set_title(title)
 
     color_set = set(colors)
     legend_patches = []
-    base_lbl = 'constitutive' if p_col is None else 'strong candidate'
-    if LABEL_COLORS['constitutive'] in color_set:
-        legend_patches.append(mpatches.Patch(color=LABEL_COLORS['constitutive'], label=base_lbl))
-    if '#7BA7D4' in color_set:
-        legend_patches.append(mpatches.Patch(color='#7BA7D4', label='has linear slope'))
-    if '#B0C4DE' in color_set:
-        legend_patches.append(mpatches.Patch(color='#B0C4DE', label='not yet significant'))
+    base_lbl = "constitutive" if p_col is None else "strong candidate"
+    if LABEL_COLORS["constitutive"] in color_set:
+        legend_patches.append(
+            mpatches.Patch(color=LABEL_COLORS["constitutive"], label=base_lbl)
+        )
+    if "#7BA7D4" in color_set:
+        legend_patches.append(mpatches.Patch(color="#7BA7D4", label="has linear slope"))
+    if "#B0C4DE" in color_set:
+        legend_patches.append(
+            mpatches.Patch(color="#B0C4DE", label="not yet significant")
+        )
     for lbl in _LABEL_ORDER:
-        if lbl != 'constitutive' and LABEL_COLORS.get(lbl) in color_set:
+        if lbl != "constitutive" and LABEL_COLORS.get(lbl) in color_set:
             legend_patches.append(mpatches.Patch(color=LABEL_COLORS[lbl], label=lbl))
     if legend_patches:
-        ax.legend(handles=legend_patches, loc='lower right', frameon=False, fontsize=8)
+        ax.legend(handles=legend_patches, loc="lower right", frameon=False, fontsize=8)
 
     sns.despine(ax=ax, left=True)
     return ax
@@ -802,46 +932,91 @@ def classification_summary(
     -------
     matplotlib.figure.Figure
     """
-    has_emp_p     = _has(classifications, 'emp_p')
-    has_phase     = _has(classifications, 'phase_mean')
-    has_period    = _has(classifications, 'period_mean')
-    has_pval      = _has(classifications, 'pval') or _has(classifications, 'pval_bh')
-    has_slope_emp = (_has(classifications, 'slope_pval') or _has(classifications, 'slope_pval_bh')) and has_emp_p
+    has_emp_p = _has(classifications, "emp_p")
+    has_phase = _has(classifications, "phase_mean")
+    has_period = _has(classifications, "period_mean")
+    has_pval = _has(classifications, "pval") or _has(classifications, "pval_bh")
+    has_slope_emp = (
+        _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
+    ) and has_emp_p
 
     # Build ordered list of (title, callable) for each panel
     panels = [
-        ('label_distribution', lambda ax: label_distribution(classifications, ax=ax)),
-        ('pirs_vs_tau', lambda ax: pirs_vs_tau(
-            classifications, pirs_percentile=pirs_percentile,
-            tau_threshold=tau_threshold, ax=ax)),
-        ('pirs_score_distribution', lambda ax: pirs_score_distribution(
-            classifications, pirs_percentile=pirs_percentile, ax=ax)),
-        ('top_constitutive_candidates', lambda ax: top_constitutive_candidates(
-            classifications, pirs_percentile=pirs_percentile, ax=ax)),
+        ("label_distribution", lambda ax: label_distribution(classifications, ax=ax)),
+        (
+            "pirs_vs_tau",
+            lambda ax: pirs_vs_tau(
+                classifications,
+                pirs_percentile=pirs_percentile,
+                tau_threshold=tau_threshold,
+                ax=ax,
+            ),
+        ),
+        (
+            "pirs_score_distribution",
+            lambda ax: pirs_score_distribution(
+                classifications, pirs_percentile=pirs_percentile, ax=ax
+            ),
+        ),
+        (
+            "top_constitutive_candidates",
+            lambda ax: top_constitutive_candidates(
+                classifications, pirs_percentile=pirs_percentile, ax=ax
+            ),
+        ),
     ]
     if has_emp_p:
         panels += [
-            ('volcano', lambda ax: volcano(
-                classifications, emp_p_threshold=emp_p_threshold,
-                pirs_percentile=pirs_percentile, ax=ax)),
-            ('tau_pval_scatter', lambda ax: tau_pval_scatter(
-                classifications, tau_threshold=tau_threshold,
-                emp_p_threshold=emp_p_threshold, ax=ax)),
+            (
+                "volcano",
+                lambda ax: volcano(
+                    classifications,
+                    emp_p_threshold=emp_p_threshold,
+                    pirs_percentile=pirs_percentile,
+                    ax=ax,
+                ),
+            ),
+            (
+                "tau_pval_scatter",
+                lambda ax: tau_pval_scatter(
+                    classifications,
+                    tau_threshold=tau_threshold,
+                    emp_p_threshold=emp_p_threshold,
+                    ax=ax,
+                ),
+            ),
         ]
     if has_pval:
-        panels.append(('pirs_pval_scatter', lambda ax: pirs_pval_scatter(
-            classifications, ax=ax)))
+        panels.append(
+            ("pirs_pval_scatter", lambda ax: pirs_pval_scatter(classifications, ax=ax))
+        )
     if has_slope_emp:
-        panels.append(('slope_vs_rhythm', lambda ax: slope_vs_rhythm(
-            classifications, slope_pval_threshold=slope_pval_threshold,
-            emp_p_threshold=emp_p_threshold, ax=ax)))
+        panels.append(
+            (
+                "slope_vs_rhythm",
+                lambda ax: slope_vs_rhythm(
+                    classifications,
+                    slope_pval_threshold=slope_pval_threshold,
+                    emp_p_threshold=emp_p_threshold,
+                    ax=ax,
+                ),
+            )
+        )
     if has_phase:
-        panels.append(('phase_wheel', None))  # handled separately — polar axes
-        panels.append(('phase_amplitude_scatter', lambda ax: phase_amplitude_scatter(
-            classifications, ax=ax)))
+        panels.append(("phase_wheel", None))  # handled separately — polar axes
+        panels.append(
+            (
+                "phase_amplitude_scatter",
+                lambda ax: phase_amplitude_scatter(classifications, ax=ax),
+            )
+        )
     if has_period:
-        panels.append(('period_distribution', lambda ax: period_distribution(
-            classifications, ax=ax)))
+        panels.append(
+            (
+                "period_distribution",
+                lambda ax: period_distribution(classifications, ax=ax),
+            )
+        )
 
     n = len(panels)
     ncols = min(3, n)
@@ -850,8 +1025,8 @@ def classification_summary(
     fig = plt.figure(figsize=(5 * ncols, 4 * nrows))
 
     for i, (name, fn) in enumerate(panels, 1):
-        if name == 'phase_wheel':
-            ax = fig.add_subplot(nrows, ncols, i, projection='polar')
+        if name == "phase_wheel":
+            ax = fig.add_subplot(nrows, ncols, i, projection="polar")
             phase_wheel(classifications, ax=ax)
         else:
             ax = fig.add_subplot(nrows, ncols, i)
@@ -859,7 +1034,7 @@ def classification_summary(
 
     fig.tight_layout(pad=1.5, h_pad=2.0, w_pad=1.5)
     if outpath:
-        fig.savefig(outpath, dpi=150, bbox_inches='tight')
+        fig.savefig(outpath, dpi=150, bbox_inches="tight")
     return fig
 
 
@@ -868,7 +1043,7 @@ def mean_expression_profiles(
     classifications,
     labels=None,
     ax=None,
-    title='Mean expression profile by label',
+    title="Mean expression profile by label",
 ):
     """Mean ± SEM time-series expression profile for each expression label.
 
@@ -895,55 +1070,61 @@ def mean_expression_profiles(
     """
     ax = _ax(ax)
 
-    zt_cols = [c for c in expression.columns
-               if c.startswith('ZT') or c.startswith('CT')]
+    zt_cols = [
+        c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")
+    ]
     if not zt_cols:
         raise ValueError("No ZT/CT columns found in expression DataFrame.")
 
     def _parse_zt(col):
-        return int(col.replace('ZT', '').replace('CT', '').split('_')[0])
+        return int(col.replace("ZT", "").replace("CT", "").split("_")[0])
 
     timepoints = np.array([_parse_zt(c) for c in zt_cols])
-    unique_tp  = np.sort(np.unique(timepoints))
+    unique_tp = np.sort(np.unique(timepoints))
 
     # Average replicates → one value per gene per unique timepoint
     tp_means = pd.DataFrame(
-        {int(tp): expression[
-            [c for c, t in zip(zt_cols, timepoints) if t == tp]
-        ].mean(axis=1)
-         for tp in unique_tp},
+        {
+            int(tp): expression[
+                [c for c, t in zip(zt_cols, timepoints) if t == tp]
+            ].mean(axis=1)
+            for tp in unique_tp
+        },
         index=expression.index,
     )
 
     # Z-score each gene across its timepoint means so profiles are comparable
     row_mean = tp_means.mean(axis=1)
-    row_std  = tp_means.std(axis=1).replace(0, np.nan)
-    tp_z     = tp_means.sub(row_mean, axis=0).div(row_std, axis=0)
+    row_std = tp_means.std(axis=1).replace(0, np.nan)
+    tp_z = tp_means.sub(row_mean, axis=0).div(row_std, axis=0)
 
     common = tp_z.index.intersection(classifications.index)
-    tp_z   = tp_z.loc[common]
-    clf    = classifications.loc[common]
+    tp_z = tp_z.loc[common]
+    clf = classifications.loc[common]
 
     if labels is None:
-        labels = [l for l in _LABEL_ORDER if l in clf['label'].values]
+        labels = [l for l in _LABEL_ORDER if l in clf["label"].values]
 
     for lbl in labels:
-        genes = clf[clf['label'] == lbl].index
+        genes = clf[clf["label"] == lbl].index
         if len(genes) == 0:
             continue
         profiles = tp_z.loc[genes].astype(float)
-        mean_p   = profiles.mean(axis=0)
-        sem_p    = profiles.sem(axis=0)
-        color    = LABEL_COLORS.get(lbl, '#8C8C8C')
+        mean_p = profiles.mean(axis=0)
+        sem_p = profiles.sem(axis=0)
+        color = LABEL_COLORS.get(lbl, "#8C8C8C")
         ax.plot(unique_tp, mean_p.values, color=color, label=lbl, lw=1.5)
-        ax.fill_between(unique_tp,
-                        (mean_p - sem_p).values,
-                        (mean_p + sem_p).values,
-                        color=color, alpha=0.15)
+        ax.fill_between(
+            unique_tp,
+            (mean_p - sem_p).values,
+            (mean_p + sem_p).values,
+            color=color,
+            alpha=0.15,
+        )
 
-    ax.axhline(0, color='#999999', ls=':', lw=0.8)
-    ax.set_xlabel('Zeitgeber time (h)')
-    ax.set_ylabel('Mean z-scored expression ± SEM')
+    ax.axhline(0, color="#999999", ls=":", lw=0.8)
+    ax.set_xlabel("Zeitgeber time (h)")
+    ax.set_ylabel("Mean z-scored expression ± SEM")
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
@@ -954,7 +1135,7 @@ def threshold_sensitivity(
     classifications,
     pirs_percentile=50,
     ax=None,
-    title='PIRS score distribution by label (ECDF)',
+    title="PIRS score distribution by label (ECDF)",
 ):
     """Empirical CDFs of PIRS scores per expression label.
 
@@ -977,27 +1158,39 @@ def threshold_sensitivity(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    all_scores = classifications['pirs_score'].dropna()
-    pirs_cut   = np.percentile(all_scores, pirs_percentile)
+    all_scores = classifications["pirs_score"].dropna()
+    pirs_cut = np.percentile(all_scores, pirs_percentile)
 
     for lbl in _LABEL_ORDER:
-        sub = classifications[classifications['label'] == lbl]['pirs_score'].dropna()
+        sub = classifications[classifications["label"] == lbl]["pirs_score"].dropna()
         if sub.empty:
             continue
         sorted_scores = np.sort(sub)
         ecdf = np.arange(1, len(sorted_scores) + 1) / len(sorted_scores)
-        ax.step(sorted_scores, ecdf,
-                color=LABEL_COLORS[lbl], label=lbl, lw=1.5, where='post')
+        ax.step(
+            sorted_scores,
+            ecdf,
+            color=LABEL_COLORS[lbl],
+            label=lbl,
+            lw=1.5,
+            where="post",
+        )
 
-    ax.axvline(pirs_cut, color='#333333', ls='--', lw=0.9, alpha=0.8,
-               label=f'p{int(pirs_percentile)} cut')
+    ax.axvline(
+        pirs_cut,
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.8,
+        label=f"p{int(pirs_percentile)} cut",
+    )
 
     lo, hi = np.percentile(all_scores, [1, 99])
     margin = max((hi - lo) * 0.05, 0.05)
     ax.set_xlim(lo - margin, hi + margin)
     ax.set_ylim(0, 1.05)
-    ax.set_xlabel('PIRS score')
-    ax.set_ylabel('Cumulative fraction')
+    ax.set_xlabel("PIRS score")
+    ax.set_ylabel("Cumulative fraction")
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)

--- a/circ/visualization/compare.py
+++ b/circ/visualization/compare.py
@@ -1,4 +1,5 @@
 """Visualizations for between-condition comparison results from circ.compare."""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -8,19 +9,19 @@ from circ.visualization.classify import LABEL_COLORS, _ax
 
 # Colors and draw order for rhythmicity change categories
 _STATUS_COLORS = {
-    'maintained_rhythmic':    '#6ACC65',
-    'gained':                 '#D65F5F',
-    'lost':                   '#4878CF',
-    'maintained_nonrhythmic': '#CCCCCC',
+    "maintained_rhythmic": "#6ACC65",
+    "gained": "#D65F5F",
+    "lost": "#4878CF",
+    "maintained_nonrhythmic": "#CCCCCC",
 }
-_STATUS_ORDER = ['maintained_rhythmic', 'gained', 'lost', 'maintained_nonrhythmic']
+_STATUS_ORDER = ["maintained_rhythmic", "gained", "lost", "maintained_nonrhythmic"]
 
 
 def rhythmicity_shift_scatter(
     comparison,
     alpha=0.05,
     ax=None,
-    title='Rhythmicity shift: TauMean per condition',
+    title="Rhythmicity shift: TauMean per condition",
 ):
     """Scatter of tau_mean_A vs tau_mean_B, colored by rhythmicity status.
 
@@ -43,44 +44,60 @@ def rhythmicity_shift_scatter(
     matplotlib.axes.Axes
     """
     ax = _ax(ax)
-    has_padj = 'tau_padj' in comparison.columns
+    has_padj = "tau_padj" in comparison.columns
 
     for status in _STATUS_ORDER:
-        sub = comparison[comparison['rhythmicity_status'] == status]
+        sub = comparison[comparison["rhythmicity_status"] == status]
         if sub.empty:
             continue
         color = _STATUS_COLORS[status]
         if has_padj:
-            sig = sub['tau_padj'] < alpha
+            sig = sub["tau_padj"] < alpha
             if sig.any():
                 ax.scatter(
-                    sub.loc[sig, 'tau_mean_A'], sub.loc[sig, 'tau_mean_B'],
-                    color=color, s=28, alpha=0.85, zorder=4,
-                    edgecolors='white', linewidths=0.5,
-                    label=f'{status} (FDR<{alpha})',
+                    sub.loc[sig, "tau_mean_A"],
+                    sub.loc[sig, "tau_mean_B"],
+                    color=color,
+                    s=28,
+                    alpha=0.85,
+                    zorder=4,
+                    edgecolors="white",
+                    linewidths=0.5,
+                    label=f"{status} (FDR<{alpha})",
                 )
             if (~sig).any():
                 ax.scatter(
-                    sub.loc[~sig, 'tau_mean_A'], sub.loc[~sig, 'tau_mean_B'],
-                    color=color, s=10, alpha=0.35, zorder=3,
+                    sub.loc[~sig, "tau_mean_A"],
+                    sub.loc[~sig, "tau_mean_B"],
+                    color=color,
+                    s=10,
+                    alpha=0.35,
+                    zorder=3,
                     label=status,
                 )
         else:
             ax.scatter(
-                sub['tau_mean_A'], sub['tau_mean_B'],
-                color=color, s=10, alpha=0.55, zorder=3,
+                sub["tau_mean_A"],
+                sub["tau_mean_B"],
+                color=color,
+                s=10,
+                alpha=0.55,
+                zorder=3,
                 label=status,
             )
 
-    lim = max(comparison['tau_mean_A'].max(), comparison['tau_mean_B'].max()) * 1.05
-    ax.plot([0, lim], [0, lim], color='#999999', ls='--', lw=0.9, alpha=0.6)
+    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
+    ax.plot([0, lim], [0, lim], color="#999999", ls="--", lw=0.9, alpha=0.6)
     ax.set_xlim(0, lim)
     ax.set_ylim(0, lim)
-    ax.set_xlabel('TauMean — condition A')
-    ax.set_ylabel('TauMean — condition B')
+    ax.set_xlabel("TauMean — condition A")
+    ax.set_ylabel("TauMean — condition B")
     ax.set_title(title)
-    patches = [mpatches.Patch(color=_STATUS_COLORS[s], label=s)
-               for s in _STATUS_ORDER if s in comparison['rhythmicity_status'].values]
+    patches = [
+        mpatches.Patch(color=_STATUS_COLORS[s], label=s)
+        for s in _STATUS_ORDER
+        if s in comparison["rhythmicity_status"].values
+    ]
     ax.legend(handles=patches, frameon=False, fontsize=9)
     sns.despine(ax=ax)
     return ax
@@ -89,7 +106,7 @@ def rhythmicity_shift_scatter(
 def phase_shift_histogram(
     comparison,
     ax=None,
-    title='Phase shift distribution (rhythmic in both conditions)',
+    title="Phase shift distribution (rhythmic in both conditions)",
 ):
     """Histogram of circular phase differences for genes rhythmic in both conditions.
 
@@ -111,28 +128,44 @@ def phase_shift_histogram(
     """
     ax = _ax(ax)
 
-    if 'delta_phase' not in comparison.columns:
-        ax.text(0.5, 0.5, 'No phase data available',
-                transform=ax.transAxes, ha='center', va='center', color='#888888')
+    if "delta_phase" not in comparison.columns:
+        ax.text(
+            0.5,
+            0.5,
+            "No phase data available",
+            transform=ax.transAxes,
+            ha="center",
+            va="center",
+            color="#888888",
+        )
         ax.set_title(title)
         return ax
 
-    dp = comparison['delta_phase'].dropna()
+    dp = comparison["delta_phase"].dropna()
     if dp.empty:
-        ax.text(0.5, 0.5, 'No genes rhythmic\nin both conditions',
-                transform=ax.transAxes, ha='center', va='center', color='#888888')
+        ax.text(
+            0.5,
+            0.5,
+            "No genes rhythmic\nin both conditions",
+            transform=ax.transAxes,
+            ha="center",
+            va="center",
+            color="#888888",
+        )
         ax.set_title(title)
         sns.despine(ax=ax)
         return ax
 
     bins = np.arange(-12, 13, 2)
-    ax.hist(dp, bins=bins, color=LABEL_COLORS['rhythmic'], alpha=0.75, edgecolor='white')
-    ax.axvline(0, color='#333333', ls='--', lw=0.9, alpha=0.8, label='no shift')
-    ax.set_xlabel('Phase shift B − A (h)')
-    ax.set_ylabel('Gene count')
+    ax.hist(
+        dp, bins=bins, color=LABEL_COLORS["rhythmic"], alpha=0.75, edgecolor="white"
+    )
+    ax.axvline(0, color="#333333", ls="--", lw=0.9, alpha=0.8, label="no shift")
+    ax.set_xlabel("Phase shift B − A (h)")
+    ax.set_ylabel("Gene count")
     ax.set_xlim(-12, 12)
     ax.set_xticks(range(-12, 13, 4))
-    ax.set_xticklabels([f'{h:+d}' if h != 0 else '0' for h in range(-12, 13, 4)])
+    ax.set_xticklabels([f"{h:+d}" if h != 0 else "0" for h in range(-12, 13, 4)])
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
@@ -142,7 +175,7 @@ def phase_shift_histogram(
 def label_transition_heatmap(
     comparison,
     ax=None,
-    title='Label transitions A → B',
+    title="Label transitions A → B",
 ):
     """Heatmap of classification label changes between conditions.
 
@@ -162,6 +195,7 @@ def label_transition_heatmap(
     matplotlib.axes.Axes
     """
     from circ.compare import label_change_table
+
     ax = _ax(ax)
     ct = label_change_table(comparison)
     if ct.empty:
@@ -169,12 +203,18 @@ def label_transition_heatmap(
         return ax
 
     sns.heatmap(
-        ct, ax=ax, annot=True, fmt='d', cmap='Blues',
-        linewidths=0.5, linecolor='white', cbar=False,
-        annot_kws={'size': 9},
+        ct,
+        ax=ax,
+        annot=True,
+        fmt="d",
+        cmap="Blues",
+        linewidths=0.5,
+        linecolor="white",
+        cbar=False,
+        annot_kws={"size": 9},
     )
-    ax.set_xlabel('Label in condition B')
-    ax.set_ylabel('Label in condition A')
+    ax.set_xlabel("Label in condition B")
+    ax.set_ylabel("Label in condition A")
     ax.set_title(title)
     return ax
 
@@ -183,7 +223,7 @@ def delta_tau_volcano(
     comparison,
     alpha=0.05,
     ax=None,
-    title='Rhythmicity change: Δ TauMean vs significance',
+    title="Rhythmicity change: Δ TauMean vs significance",
 ):
     """Volcano plot of Δ TauMean vs −log₁₀(tau_padj).
 
@@ -208,35 +248,47 @@ def delta_tau_volcano(
     -------
     matplotlib.axes.Axes
     """
-    if 'tau_padj' not in comparison.columns:
+    if "tau_padj" not in comparison.columns:
         raise ValueError(
             "'tau_padj' column missing — re-run compare_conditions() with "
             "result DataFrames that include tau_std and n_boots (produced "
             "automatically when Classifier.classify() is run after run_bootjtk())."
         )
     ax = _ax(ax)
-    df = comparison.dropna(subset=['delta_tau', 'tau_padj'])
-    df = df.assign(neg_log_p=-np.log10(df['tau_padj'].clip(lower=1e-300)))
+    df = comparison.dropna(subset=["delta_tau", "tau_padj"])
+    df = df.assign(neg_log_p=-np.log10(df["tau_padj"].clip(lower=1e-300)))
 
     for status in _STATUS_ORDER:
-        sub = df[df['rhythmicity_status'] == status]
+        sub = df[df["rhythmicity_status"] == status]
         if sub.empty:
             continue
         ax.scatter(
-            sub['delta_tau'], sub['neg_log_p'],
-            color=_STATUS_COLORS[status], s=14, alpha=0.65,
+            sub["delta_tau"],
+            sub["neg_log_p"],
+            color=_STATUS_COLORS[status],
+            s=14,
+            alpha=0.65,
             rasterized=len(df) > 500,
         )
 
-    ax.axhline(-np.log10(alpha), color='#333333', ls='--', lw=0.9, alpha=0.7,
-               label=f'FDR = {alpha}')
-    ax.axvline(0, color='#999999', ls=':', lw=0.8, alpha=0.5)
+    ax.axhline(
+        -np.log10(alpha),
+        color="#333333",
+        ls="--",
+        lw=0.9,
+        alpha=0.7,
+        label=f"FDR = {alpha}",
+    )
+    ax.axvline(0, color="#999999", ls=":", lw=0.8, alpha=0.5)
 
-    ax.set_xlabel('Δ TauMean (B − A)')
-    ax.set_ylabel('−log₁₀(tau_padj)')
+    ax.set_xlabel("Δ TauMean (B − A)")
+    ax.set_ylabel("−log₁₀(tau_padj)")
     ax.set_title(title)
-    patches = [mpatches.Patch(color=_STATUS_COLORS[s], label=s)
-               for s in _STATUS_ORDER if s in df['rhythmicity_status'].values]
+    patches = [
+        mpatches.Patch(color=_STATUS_COLORS[s], label=s)
+        for s in _STATUS_ORDER
+        if s in df["rhythmicity_status"].values
+    ]
     ax.legend(handles=patches, frameon=False, fontsize=9)
     sns.despine(ax=ax)
     return ax
@@ -266,16 +318,18 @@ def comparison_summary(comparison, outpath=None):
         lambda ax: rhythmicity_shift_scatter(comparison, ax=ax),
         lambda ax: label_transition_heatmap(comparison, ax=ax),
     ]
-    if 'delta_phase' in comparison.columns:
+    if "delta_phase" in comparison.columns:
         panels.append(lambda ax: phase_shift_histogram(comparison, ax=ax))
-    if 'tau_padj' in comparison.columns:
+    if "tau_padj" in comparison.columns:
         panels.append(lambda ax: delta_tau_volcano(comparison, ax=ax))
 
     n = len(panels)
     ncols = min(2, n)
     nrows = (n + ncols - 1) // ncols
 
-    fig, axes = plt.subplots(nrows, ncols, figsize=(7 * ncols, 5 * nrows), squeeze=False)
+    fig, axes = plt.subplots(
+        nrows, ncols, figsize=(7 * ncols, 5 * nrows), squeeze=False
+    )
     axes_flat = axes.flatten()
 
     for ax, fn in zip(axes_flat, panels):
@@ -285,5 +339,5 @@ def comparison_summary(comparison, outpath=None):
 
     fig.tight_layout(pad=1.5, h_pad=2.0, w_pad=1.5)
     if outpath:
-        fig.savefig(outpath, dpi=150, bbox_inches='tight')
+        fig.savefig(outpath, dpi=150, bbox_inches="tight")
     return fig

--- a/circ/visualization/interactive/__init__.py
+++ b/circ/visualization/interactive/__init__.py
@@ -25,6 +25,7 @@ Benchmark / evaluation plots
    classification_pr
    classification_roc
 """
+
 try:
     import plotly.graph_objects  # noqa: F401
 except ImportError as exc:
@@ -54,19 +55,19 @@ from circ.visualization.interactive.benchmarks import (
 )
 
 __all__ = [
-    'label_distribution',
-    'pirs_vs_tau',
-    'volcano',
-    'pirs_score_distribution',
-    'tau_pval_scatter',
-    'pirs_pval_scatter',
-    'slope_pval_scatter',
-    'slope_vs_rhythm',
-    'phase_wheel',
-    'period_distribution',
-    'phase_amplitude_scatter',
-    'top_constitutive_candidates',
-    'classification_summary',
-    'classification_pr',
-    'classification_roc',
+    "label_distribution",
+    "pirs_vs_tau",
+    "volcano",
+    "pirs_score_distribution",
+    "tau_pval_scatter",
+    "pirs_pval_scatter",
+    "slope_pval_scatter",
+    "slope_vs_rhythm",
+    "phase_wheel",
+    "period_distribution",
+    "phase_amplitude_scatter",
+    "top_constitutive_candidates",
+    "classification_summary",
+    "classification_pr",
+    "classification_roc",
 ]

--- a/circ/visualization/interactive/benchmarks.py
+++ b/circ/visualization/interactive/benchmarks.py
@@ -1,4 +1,5 @@
 """Interactive (Plotly) benchmark visualizations: PR curves and ROC curves."""
+
 import numpy as np
 import plotly.graph_objects as go
 from sklearn.metrics import (
@@ -10,26 +11,32 @@ from sklearn.metrics import (
 
 
 _COLORS = [
-    '#636EFA', '#EF553B', '#00CC96', '#AB63FA',
-    '#FFA15A', '#19D3F3', '#FF6692', '#B6E880',
+    "#636EFA",
+    "#EF553B",
+    "#00CC96",
+    "#AB63FA",
+    "#FFA15A",
+    "#19D3F3",
+    "#FF6692",
+    "#B6E880",
 ]
 
 _TASK_NAMES = {
-    ('pirs_score', 'Const'):      'PIRS score → constitutive',
-    ('tau_mean',   'Circadian'):  'TauMean → circadian',
-    ('emp_p',      'Circadian'):  'GammaBH p-val → circadian',
-    ('pval',       'Const'):      'PIRS p-val → constitutive',
-    ('pval_bh',    'Const'):      'PIRS p-val (BH) → constitutive',
-    ('slope_pval', 'Linear'):     'slope p-val → linear',
-    ('slope_pval_bh', 'Linear'):  'slope p-val (BH) → linear',
+    ("pirs_score", "Const"): "PIRS score → constitutive",
+    ("tau_mean", "Circadian"): "TauMean → circadian",
+    ("emp_p", "Circadian"): "GammaBH p-val → circadian",
+    ("pval", "Const"): "PIRS p-val → constitutive",
+    ("pval_bh", "Const"): "PIRS p-val (BH) → constitutive",
+    ("slope_pval", "Linear"): "slope p-val → linear",
+    ("slope_pval_bh", "Linear"): "slope p-val (BH) → linear",
 }
 
 
 def classification_pr(
     classifications,
     true_classes,
-    ground_truth_col='Const',
-    score_col='pirs_score',
+    ground_truth_col="Const",
+    score_col="pirs_score",
     invert_score=True,
     title=None,
 ):
@@ -54,14 +61,16 @@ def classification_pr(
     -------
     plotly.graph_objects.Figure
     """
-    merged = classifications[[score_col]].join(
-        true_classes[[ground_truth_col]], how='inner'
-    ).dropna()
+    merged = (
+        classifications[[score_col]]
+        .join(true_classes[[ground_truth_col]], how="inner")
+        .dropna()
+    )
 
     fig = go.Figure()
 
     if merged.empty:
-        fig.update_layout(title=(title or 'PR curve') + ' (no matched genes)')
+        fig.update_layout(title=(title or "PR curve") + " (no matched genes)")
         return fig
 
     scores = -merged[score_col].values if invert_score else merged[score_col].values
@@ -73,25 +82,34 @@ def classification_pr(
 
     # precision_recall_curve returns len(thresholds) + 1 precision/recall points
     thresh_padded = np.append(thresholds, np.nan)
-    fig.add_trace(go.Scatter(
-        x=recall, y=precision,
-        mode='lines',
-        name=f'{score_col} (AP={ap:.3f})',
-        line=dict(color='#4878CF', width=2),
-        customdata=thresh_padded.reshape(-1, 1),
-        hovertemplate=(
-            'recall: %{x:.3f}<br>'
-            'precision: %{y:.3f}<br>'
-            'threshold: %{customdata[0]:.4g}'
-            '<extra></extra>'
-        ),
-    ))
-    fig.add_hline(y=baseline, line_dash='dot', line_color='#CC4444', opacity=0.8,
-                  annotation_text='random', annotation_position='bottom right')
+    fig.add_trace(
+        go.Scatter(
+            x=recall,
+            y=precision,
+            mode="lines",
+            name=f"{score_col} (AP={ap:.3f})",
+            line=dict(color="#4878CF", width=2),
+            customdata=thresh_padded.reshape(-1, 1),
+            hovertemplate=(
+                "recall: %{x:.3f}<br>"
+                "precision: %{y:.3f}<br>"
+                "threshold: %{customdata[0]:.4g}"
+                "<extra></extra>"
+            ),
+        )
+    )
+    fig.add_hline(
+        y=baseline,
+        line_dash="dot",
+        line_color="#CC4444",
+        opacity=0.8,
+        annotation_text="random",
+        annotation_position="bottom right",
+    )
     fig.update_layout(
-        title=title or f'PR curve: {ground_truth_col}',
-        xaxis=dict(title='Recall', range=[0, 1]),
-        yaxis=dict(title='Precision', range=[0, 1.05]),
+        title=title or f"PR curve: {ground_truth_col}",
+        xaxis=dict(title="Recall", range=[0, 1]),
+        yaxis=dict(title="Precision", range=[0, 1.05]),
     )
     return fig
 
@@ -100,7 +118,7 @@ def classification_roc(
     classifications,
     true_classes,
     tasks=None,
-    title='ROC: Classifier scores vs ground truth',
+    title="ROC: Classifier scores vs ground truth",
 ):
     """Interactive ROC curves for multiple binary classification tasks.
 
@@ -124,55 +142,66 @@ def classification_roc(
     """
     if tasks is None:
         tasks = []
-        if 'pirs_score' in classifications.columns and 'Const' in true_classes.columns:
-            tasks.append(('pirs_score', 'Const', True))
-        if 'tau_mean' in classifications.columns and 'Circadian' in true_classes.columns:
-            tasks.append(('tau_mean', 'Circadian', False))
-        if 'emp_p' in classifications.columns and 'Circadian' in true_classes.columns:
-            tasks.append(('emp_p', 'Circadian', True))
-        if 'pval' in classifications.columns and 'Const' in true_classes.columns:
-            tasks.append(('pval', 'Const', True))
-        if 'slope_pval' in classifications.columns and 'Linear' in true_classes.columns:
-            tasks.append(('slope_pval', 'Linear', True))
+        if "pirs_score" in classifications.columns and "Const" in true_classes.columns:
+            tasks.append(("pirs_score", "Const", True))
+        if (
+            "tau_mean" in classifications.columns
+            and "Circadian" in true_classes.columns
+        ):
+            tasks.append(("tau_mean", "Circadian", False))
+        if "emp_p" in classifications.columns and "Circadian" in true_classes.columns:
+            tasks.append(("emp_p", "Circadian", True))
+        if "pval" in classifications.columns and "Const" in true_classes.columns:
+            tasks.append(("pval", "Const", True))
+        if "slope_pval" in classifications.columns and "Linear" in true_classes.columns:
+            tasks.append(("slope_pval", "Linear", True))
 
     fig = go.Figure()
     for i, (score_col, truth_col, invert) in enumerate(tasks):
-        merged = classifications[[score_col]].join(
-            true_classes[[truth_col]], how='inner'
-        ).dropna()
+        merged = (
+            classifications[[score_col]]
+            .join(true_classes[[truth_col]], how="inner")
+            .dropna()
+        )
         if merged.empty:
             continue
         scores = -merged[score_col].values if invert else merged[score_col].values
         fpr, tpr, thresholds = roc_curve(merged[truth_col].values, scores, pos_label=1)
         auc_val = auc(fpr, tpr)
-        label = _TASK_NAMES.get((score_col, truth_col), f'{score_col} → {truth_col}')
+        label = _TASK_NAMES.get((score_col, truth_col), f"{score_col} → {truth_col}")
 
         thresh_padded = np.append(thresholds, np.nan)
-        fig.add_trace(go.Scatter(
-            x=fpr, y=tpr,
-            mode='lines',
-            name=f'{label}  (AUC={auc_val:.3f})',
-            line=dict(color=_COLORS[i % len(_COLORS)], width=2),
-            customdata=thresh_padded.reshape(-1, 1),
-            hovertemplate=(
-                'FPR: %{x:.3f}<br>'
-                'TPR: %{y:.3f}<br>'
-                'threshold: %{customdata[0]:.4g}'
-                '<extra></extra>'
-            ),
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=fpr,
+                y=tpr,
+                mode="lines",
+                name=f"{label}  (AUC={auc_val:.3f})",
+                line=dict(color=_COLORS[i % len(_COLORS)], width=2),
+                customdata=thresh_padded.reshape(-1, 1),
+                hovertemplate=(
+                    "FPR: %{x:.3f}<br>"
+                    "TPR: %{y:.3f}<br>"
+                    "threshold: %{customdata[0]:.4g}"
+                    "<extra></extra>"
+                ),
+            )
+        )
 
-    fig.add_trace(go.Scatter(
-        x=[0, 1], y=[0, 1],
-        mode='lines',
-        name='random (AUC=0.5)',
-        line=dict(color='#999999', dash='dash', width=1),
-        hoverinfo='skip',
-    ))
+    fig.add_trace(
+        go.Scatter(
+            x=[0, 1],
+            y=[0, 1],
+            mode="lines",
+            name="random (AUC=0.5)",
+            line=dict(color="#999999", dash="dash", width=1),
+            hoverinfo="skip",
+        )
+    )
     fig.update_layout(
         title=title,
-        xaxis=dict(title='False positive rate', range=[0, 1]),
-        yaxis=dict(title='True positive rate', range=[0, 1.05]),
-        legend=dict(x=0.01, y=0.01, xanchor='left', yanchor='bottom'),
+        xaxis=dict(title="False positive rate", range=[0, 1]),
+        yaxis=dict(title="True positive rate", range=[0, 1.05]),
+        legend=dict(x=0.01, y=0.01, xanchor="left", yanchor="bottom"),
     )
     return fig

--- a/circ/visualization/interactive/classify.py
+++ b/circ/visualization/interactive/classify.py
@@ -1,4 +1,5 @@
 """Interactive (Plotly) visualizations for expression classification results."""
+
 import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
@@ -10,27 +11,32 @@ def _scatter_traces(df, xcol, ycol):
     """One Scatter trace per label, coloured by LABEL_COLORS with gene-ID hover."""
     traces = []
     for lbl in _LABEL_ORDER:
-        sub = df[df['label'] == lbl] if 'label' in df.columns else df
+        sub = df[df["label"] == lbl] if "label" in df.columns else df
         if sub.empty:
             continue
-        traces.append(go.Scatter(
-            x=sub[xcol], y=sub[ycol],
-            mode='markers',
-            name=lbl,
-            text=sub.index.tolist(),
-            hovertemplate=(
-                f'<b>%{{text}}</b><br>'
-                f'{xcol}: %{{x:.4g}}<br>'
-                f'{ycol}: %{{y:.4g}}<br>'
-                f'label: {lbl}'
-                '<extra></extra>'
-            ),
-            marker=dict(color=LABEL_COLORS.get(lbl, '#8C8C8C'), size=5, opacity=0.7),
-        ))
+        traces.append(
+            go.Scatter(
+                x=sub[xcol],
+                y=sub[ycol],
+                mode="markers",
+                name=lbl,
+                text=sub.index.tolist(),
+                hovertemplate=(
+                    f"<b>%{{text}}</b><br>"
+                    f"{xcol}: %{{x:.4g}}<br>"
+                    f"{ycol}: %{{y:.4g}}<br>"
+                    f"label: {lbl}"
+                    "<extra></extra>"
+                ),
+                marker=dict(
+                    color=LABEL_COLORS.get(lbl, "#8C8C8C"), size=5, opacity=0.7
+                ),
+            )
+        )
     return traces
 
 
-def label_distribution(classifications, title='Expression label counts'):
+def label_distribution(classifications, title="Expression label counts"):
     """Interactive bar chart of gene counts per expression label.
 
     Parameters
@@ -43,27 +49,25 @@ def label_distribution(classifications, title='Expression label counts'):
     -------
     plotly.graph_objects.Figure
     """
-    present = [l for l in _LABEL_ORDER if l in classifications['label'].values]
+    present = [l for l in _LABEL_ORDER if l in classifications["label"].values]
     counts = (
-        classifications['label']
-        .value_counts()
-        .reindex(present)
-        .fillna(0)
-        .astype(int)
+        classifications["label"].value_counts().reindex(present).fillna(0).astype(int)
     )
-    fig = go.Figure(go.Bar(
-        x=counts.values,
-        y=counts.index.tolist(),
-        orientation='h',
-        marker_color=[LABEL_COLORS[l] for l in counts.index],
-        text=counts.values,
-        textposition='outside',
-        hovertemplate='%{y}: %{x} genes<extra></extra>',
-    ))
+    fig = go.Figure(
+        go.Bar(
+            x=counts.values,
+            y=counts.index.tolist(),
+            orientation="h",
+            marker_color=[LABEL_COLORS[l] for l in counts.index],
+            text=counts.values,
+            textposition="outside",
+            hovertemplate="%{y}: %{x} genes<extra></extra>",
+        )
+    )
     fig.update_layout(
         title=title,
-        xaxis_title='Gene count',
-        yaxis={'categoryorder': 'array', 'categoryarray': list(reversed(present))},
+        xaxis_title="Gene count",
+        yaxis={"categoryorder": "array", "categoryarray": list(reversed(present))},
         showlegend=False,
     )
     return fig
@@ -73,7 +77,7 @@ def pirs_vs_tau(
     classifications,
     pirs_percentile=50,
     tau_threshold=0.5,
-    title='PIRS score vs rhythmicity (TauMean)',
+    title="PIRS score vs rhythmicity (TauMean)",
 ):
     """Interactive scatter of PIRS score vs BooteJTK TauMean.
 
@@ -90,18 +94,32 @@ def pirs_vs_tau(
     -------
     plotly.graph_objects.Figure
     """
-    df = classifications.dropna(subset=['pirs_score', 'tau_mean'])
-    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+    df = classifications.dropna(subset=["pirs_score", "tau_mean"])
+    pirs_cut = np.percentile(df["pirs_score"], pirs_percentile)
 
-    fig = go.Figure(_scatter_traces(df, 'pirs_score', 'tau_mean'))
-    fig.add_vline(x=float(pirs_cut), line_dash='dash', line_color='#333333', opacity=0.7,
-                  annotation_text=f'PIRS p{int(pirs_percentile)}',
-                  annotation_position='top right')
-    fig.add_hline(y=tau_threshold, line_dash='dot', line_color='#333333', opacity=0.7,
-                  annotation_text=f'τ={tau_threshold}',
-                  annotation_position='bottom right')
-    fig.update_layout(title=title, xaxis_title='PIRS score', yaxis_title='TauMean',
-                      legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "pirs_score", "tau_mean"))
+    fig.add_vline(
+        x=float(pirs_cut),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"PIRS p{int(pirs_percentile)}",
+        annotation_position="top right",
+    )
+    fig.add_hline(
+        y=tau_threshold,
+        line_dash="dot",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"τ={tau_threshold}",
+        annotation_position="bottom right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="PIRS score",
+        yaxis_title="TauMean",
+        legend_title="Label",
+    )
     return fig
 
 
@@ -109,7 +127,7 @@ def volcano(
     classifications,
     emp_p_threshold=0.05,
     pirs_percentile=50,
-    title='PIRS score vs rhythmicity significance',
+    title="PIRS score vs rhythmicity significance",
 ):
     """Interactive scatter of PIRS score vs −log₁₀(emp_p).
 
@@ -126,28 +144,42 @@ def volcano(
     -------
     plotly.graph_objects.Figure
     """
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
-    df = classifications.dropna(subset=['pirs_score', 'emp_p'])
-    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
-    pirs_cut = np.percentile(df['pirs_score'], pirs_percentile)
+    df = classifications.dropna(subset=["pirs_score", "emp_p"])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df["emp_p"]))
+    pirs_cut = np.percentile(df["pirs_score"], pirs_percentile)
 
-    fig = go.Figure(_scatter_traces(df, 'pirs_score', 'neg_log_emp_p'))
-    fig.add_vline(x=float(pirs_cut), line_dash='dot', line_color='#333333', opacity=0.7,
-                  annotation_text=f'PIRS p{int(pirs_percentile)}',
-                  annotation_position='top right')
-    fig.add_hline(y=-np.log10(emp_p_threshold), line_dash='dash', line_color='#333333', opacity=0.7,
-                  annotation_text=f'FDR={emp_p_threshold}',
-                  annotation_position='bottom right')
-    fig.update_layout(title=title, xaxis_title='PIRS score', yaxis_title='−log₁₀(GammaBH)',
-                      legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "pirs_score", "neg_log_emp_p"))
+    fig.add_vline(
+        x=float(pirs_cut),
+        line_dash="dot",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"PIRS p{int(pirs_percentile)}",
+        annotation_position="top right",
+    )
+    fig.add_hline(
+        y=-np.log10(emp_p_threshold),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"FDR={emp_p_threshold}",
+        annotation_position="bottom right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="PIRS score",
+        yaxis_title="−log₁₀(GammaBH)",
+        legend_title="Label",
+    )
     return fig
 
 
 def pirs_score_distribution(
     classifications,
     pirs_percentile=50,
-    title='PIRS score distribution by label',
+    title="PIRS score distribution by label",
 ):
     """Interactive overlaid histograms of PIRS scores split by expression label.
 
@@ -161,25 +193,38 @@ def pirs_score_distribution(
     -------
     plotly.graph_objects.Figure
     """
-    all_scores = classifications['pirs_score'].dropna()
+    all_scores = classifications["pirs_score"].dropna()
     pirs_cut = np.percentile(all_scores, pirs_percentile)
 
     fig = go.Figure()
     for lbl in _LABEL_ORDER:
-        sub = classifications[classifications['label'] == lbl]['pirs_score'].dropna()
+        sub = classifications[classifications["label"] == lbl]["pirs_score"].dropna()
         if len(sub) < 2:
             continue
-        fig.add_trace(go.Histogram(
-            x=sub, name=lbl,
-            marker_color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-            opacity=0.5,
-            hovertemplate=f'label: {lbl}<br>PIRS score: %{{x:.4g}}<br>count: %{{y}}<extra></extra>',
-        ))
-    fig.add_vline(x=float(pirs_cut), line_dash='dash', line_color='#333333', opacity=0.8,
-                  annotation_text=f'p{int(pirs_percentile)} cut',
-                  annotation_position='top right')
-    fig.update_layout(title=title, xaxis_title='PIRS score', yaxis_title='Count',
-                      barmode='overlay', legend_title='Label')
+        fig.add_trace(
+            go.Histogram(
+                x=sub,
+                name=lbl,
+                marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                opacity=0.5,
+                hovertemplate=f"label: {lbl}<br>PIRS score: %{{x:.4g}}<br>count: %{{y}}<extra></extra>",
+            )
+        )
+    fig.add_vline(
+        x=float(pirs_cut),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.8,
+        annotation_text=f"p{int(pirs_percentile)} cut",
+        annotation_position="top right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="PIRS score",
+        yaxis_title="Count",
+        barmode="overlay",
+        legend_title="Label",
+    )
     return fig
 
 
@@ -187,7 +232,7 @@ def tau_pval_scatter(
     classifications,
     tau_threshold=0.5,
     emp_p_threshold=0.05,
-    title='Rhythmicity: TauMean vs GammaBH significance',
+    title="Rhythmicity: TauMean vs GammaBH significance",
 ):
     """Interactive scatter of TauMean vs −log₁₀(emp_p).
 
@@ -204,27 +249,41 @@ def tau_pval_scatter(
     -------
     plotly.graph_objects.Figure
     """
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
-    df = classifications.dropna(subset=['tau_mean', 'emp_p'])
-    df = df.assign(neg_log_emp_p=_safe_neglog10(df['emp_p']))
+    df = classifications.dropna(subset=["tau_mean", "emp_p"])
+    df = df.assign(neg_log_emp_p=_safe_neglog10(df["emp_p"]))
 
-    fig = go.Figure(_scatter_traces(df, 'tau_mean', 'neg_log_emp_p'))
-    fig.add_vline(x=tau_threshold, line_dash='dash', line_color='#333333', opacity=0.7,
-                  annotation_text=f'τ={tau_threshold}',
-                  annotation_position='top right')
-    fig.add_hline(y=-np.log10(emp_p_threshold), line_dash='dot', line_color='#333333', opacity=0.7,
-                  annotation_text=f'FDR={emp_p_threshold}',
-                  annotation_position='bottom right')
-    fig.update_layout(title=title, xaxis_title='TauMean', yaxis_title='−log₁₀(GammaBH)',
-                      legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "tau_mean", "neg_log_emp_p"))
+    fig.add_vline(
+        x=tau_threshold,
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"τ={tau_threshold}",
+        annotation_position="top right",
+    )
+    fig.add_hline(
+        y=-np.log10(emp_p_threshold),
+        line_dash="dot",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"FDR={emp_p_threshold}",
+        annotation_position="bottom right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="TauMean",
+        yaxis_title="−log₁₀(GammaBH)",
+        legend_title="Label",
+    )
     return fig
 
 
 def phase_wheel(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
-    title='Phase distribution (rhythmic genes)',
+    labels=("rhythmic", "noisy_rhythmic"),
+    title="Phase distribution (rhythmic genes)",
 ):
     """Interactive polar bar chart of estimated phase angles for rhythmic genes.
 
@@ -244,46 +303,52 @@ def phase_wheel(
     -------
     plotly.graph_objects.Figure
     """
-    if not _has(classifications, 'phase_mean'):
+    if not _has(classifications, "phase_mean"):
         raise ValueError("'phase_mean' column is required. Call run_bootjtk() first.")
 
-    df = classifications[classifications['label'].isin(labels)].dropna(subset=['phase_mean'])
+    df = classifications[classifications["label"].isin(labels)].dropna(
+        subset=["phase_mean"]
+    )
     if df.empty:
-        df = classifications.dropna(subset=['phase_mean'])
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        df = classifications.dropna(subset=["phase_mean"])
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
     nbins = 12
     bin_size_h = 24 / nbins
     bin_edges = np.linspace(0, 24, nbins + 1)
     bin_centers_h = bin_edges[:-1] + bin_size_h / 2
-    counts, _ = np.histogram(df['phase_mean'].values, bins=bin_edges)
+    counts, _ = np.histogram(df["phase_mean"].values, bins=bin_edges)
 
     theta_deg = bin_centers_h * (360 / 24)
     width_deg = bin_size_h * (360 / 24)
     hover = [
-        f'ZT{c - bin_size_h / 2:.0f}–ZT{c + bin_size_h / 2:.0f}: {n} genes'
+        f"ZT{c - bin_size_h / 2:.0f}–ZT{c + bin_size_h / 2:.0f}: {n} genes"
         for c, n in zip(bin_centers_h, counts)
     ]
 
-    fig = go.Figure(go.Barpolar(
-        r=counts,
-        theta=theta_deg,
-        width=width_deg,
-        marker_color='#6ACC65',
-        marker_line_color='white',
-        marker_line_width=1,
-        opacity=0.7,
-        hovertext=hover,
-        hovertemplate='%{hovertext}<extra></extra>',
-    ))
+    fig = go.Figure(
+        go.Barpolar(
+            r=counts,
+            theta=theta_deg,
+            width=width_deg,
+            marker_color="#6ACC65",
+            marker_line_color="white",
+            marker_line_width=1,
+            opacity=0.7,
+            hovertext=hover,
+            hovertemplate="%{hovertext}<extra></extra>",
+        )
+    )
     fig.update_layout(
         title=title,
         polar=dict(
             angularaxis=dict(
-                tickmode='array',
+                tickmode="array",
                 tickvals=list(np.linspace(0, 360, 8, endpoint=False)),
-                ticktext=[f'ZT{int(h):02d}' for h in np.linspace(0, 24, 8, endpoint=False)],
-                direction='clockwise',
+                ticktext=[
+                    f"ZT{int(h):02d}" for h in np.linspace(0, 24, 8, endpoint=False)
+                ],
+                direction="clockwise",
                 rotation=90,
             ),
         ),
@@ -293,9 +358,9 @@ def phase_wheel(
 
 def period_distribution(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
+    labels=("rhythmic", "noisy_rhythmic"),
     reference_period=24.0,
-    title='Period distribution (rhythmic genes)',
+    title="Period distribution (rhythmic genes)",
 ):
     """Interactive histogram of estimated period lengths for rhythmic genes.
 
@@ -314,41 +379,55 @@ def period_distribution(
     -------
     plotly.graph_objects.Figure
     """
-    if not _has(classifications, 'period_mean'):
+    if not _has(classifications, "period_mean"):
         raise ValueError("'period_mean' column is required. Call run_bootjtk() first.")
 
     fig = go.Figure()
     any_data = False
     for lbl in labels:
-        sub = classifications[classifications['label'] == lbl]['period_mean'].dropna()
+        sub = classifications[classifications["label"] == lbl]["period_mean"].dropna()
         if sub.empty:
             continue
         any_data = True
-        fig.add_trace(go.Histogram(
-            x=sub, name=lbl,
-            marker_color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-            opacity=0.6,
-            hovertemplate=f'label: {lbl}<br>period: %{{x:.2f}} h<br>count: %{{y}}<extra></extra>',
-        ))
+        fig.add_trace(
+            go.Histogram(
+                x=sub,
+                name=lbl,
+                marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                opacity=0.6,
+                hovertemplate=f"label: {lbl}<br>period: %{{x:.2f}} h<br>count: %{{y}}<extra></extra>",
+            )
+        )
 
     if not any_data:
-        sub = classifications['period_mean'].dropna()
-        fig.add_trace(go.Histogram(x=sub, name='all genes',
-                                   marker_color='#8C8C8C', opacity=0.6))
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        sub = classifications["period_mean"].dropna()
+        fig.add_trace(
+            go.Histogram(x=sub, name="all genes", marker_color="#8C8C8C", opacity=0.6)
+        )
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
-    fig.add_vline(x=reference_period, line_dash='dash', line_color='#333333', opacity=0.8,
-                  annotation_text=f'{reference_period:.0f} h',
-                  annotation_position='top right')
-    fig.update_layout(title=title, xaxis_title='Period (h)', yaxis_title='Gene count',
-                      barmode='overlay', legend_title='Label')
+    fig.add_vline(
+        x=reference_period,
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.8,
+        annotation_text=f"{reference_period:.0f} h",
+        annotation_position="top right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title="Period (h)",
+        yaxis_title="Gene count",
+        barmode="overlay",
+        legend_title="Label",
+    )
     return fig
 
 
 def phase_amplitude_scatter(
     classifications,
-    labels=('rhythmic', 'noisy_rhythmic'),
-    title='Phase vs rhythm strength (rhythmic genes)',
+    labels=("rhythmic", "noisy_rhythmic"),
+    title="Phase vs rhythm strength (rhythmic genes)",
 ):
     """Interactive scatter of estimated phase angle vs rhythm strength.
 
@@ -367,45 +446,55 @@ def phase_amplitude_scatter(
     -------
     plotly.graph_objects.Figure
     """
-    if not _has(classifications, 'phase_mean'):
+    if not _has(classifications, "phase_mean"):
         raise ValueError("'phase_mean' column is required. Call run_bootjtk() first.")
 
-    df = classifications[classifications['label'].isin(labels)].dropna(
-        subset=['phase_mean', 'tau_mean']
+    df = classifications[classifications["label"].isin(labels)].dropna(
+        subset=["phase_mean", "tau_mean"]
     )
     if df.empty:
-        df = classifications.dropna(subset=['phase_mean', 'tau_mean'])
-        title = title + ' (all genes — no rhythmic genes at current thresholds)'
+        df = classifications.dropna(subset=["phase_mean", "tau_mean"])
+        title = title + " (all genes — no rhythmic genes at current thresholds)"
 
     traces = []
     for lbl in _LABEL_ORDER:
-        sub = df[df['label'] == lbl] if 'label' in df.columns else df
+        sub = df[df["label"] == lbl] if "label" in df.columns else df
         if sub.empty:
             continue
-        traces.append(go.Scatter(
-            x=sub['phase_mean'], y=sub['tau_mean'],
-            mode='markers',
-            name=lbl,
-            text=sub.index.tolist(),
-            hovertemplate=(
-                '<b>%{text}</b><br>'
-                'phase: %{x:.2f} h<br>'
-                'TauMean: %{y:.4g}<br>'
-                f'label: {lbl}'
-                '<extra></extra>'
-            ),
-            marker=dict(color=LABEL_COLORS.get(lbl, '#8C8C8C'), size=5, opacity=0.7),
-        ))
+        traces.append(
+            go.Scatter(
+                x=sub["phase_mean"],
+                y=sub["tau_mean"],
+                mode="markers",
+                name=lbl,
+                text=sub.index.tolist(),
+                hovertemplate=(
+                    "<b>%{text}</b><br>"
+                    "phase: %{x:.2f} h<br>"
+                    "TauMean: %{y:.4g}<br>"
+                    f"label: {lbl}"
+                    "<extra></extra>"
+                ),
+                marker=dict(
+                    color=LABEL_COLORS.get(lbl, "#8C8C8C"), size=5, opacity=0.7
+                ),
+            )
+        )
 
-    zt_vals  = list(range(0, 25, 4))
-    zt_texts = [f'ZT{h:02d}' for h in zt_vals]
+    zt_vals = list(range(0, 25, 4))
+    zt_texts = [f"ZT{h:02d}" for h in zt_vals]
     fig = go.Figure(traces)
     fig.update_layout(
         title=title,
-        xaxis=dict(title='Phase (h)', range=[0, 24],
-                   tickmode='array', tickvals=zt_vals, ticktext=zt_texts),
-        yaxis_title='Rhythm strength (TauMean)',
-        legend_title='Label',
+        xaxis=dict(
+            title="Phase (h)",
+            range=[0, 24],
+            tickmode="array",
+            tickvals=zt_vals,
+            ticktext=zt_texts,
+        ),
+        yaxis_title="Rhythm strength (TauMean)",
+        legend_title="Label",
     )
     return fig
 
@@ -414,7 +503,7 @@ def top_constitutive_candidates(
     classifications,
     n_top=20,
     pirs_percentile=50,
-    title='Top constitutive gene candidates',
+    title="Top constitutive gene candidates",
 ):
     """Interactive ranked horizontal bar chart of the top constitutive gene candidates.
 
@@ -440,61 +529,72 @@ def top_constitutive_candidates(
     from circ.visualization.classify import LABEL_COLORS as _LC
     import pandas as _pd
 
-    df  = classifications.dropna(subset=['pirs_score'])
-    top = df.nsmallest(n_top, 'pirs_score')
+    df = classifications.dropna(subset=["pirs_score"])
+    top = df.nsmallest(n_top, "pirs_score")
 
-    all_scores = classifications['pirs_score'].dropna()
-    pirs_cut   = float(np.percentile(all_scores, pirs_percentile))
+    all_scores = classifications["pirs_score"].dropna()
+    pirs_cut = float(np.percentile(all_scores, pirs_percentile))
 
-    p_col  = ('pval_bh'      if _has(df, 'pval_bh')      else
-              'pval'          if _has(df, 'pval')          else None)
-    sp_col = ('slope_pval_bh' if _has(df, 'slope_pval_bh') else
-              'slope_pval'    if _has(df, 'slope_pval')    else None)
+    p_col = "pval_bh" if _has(df, "pval_bh") else "pval" if _has(df, "pval") else None
+    sp_col = (
+        "slope_pval_bh"
+        if _has(df, "slope_pval_bh")
+        else "slope_pval"
+        if _has(df, "slope_pval")
+        else None
+    )
 
     def _bar_color(row):
-        lbl = row['label'] if 'label' in row.index else 'constitutive'
-        if lbl != 'constitutive':
-            return _LC.get(lbl, '#8C8C8C')
+        lbl = row["label"] if "label" in row.index else "constitutive"
+        if lbl != "constitutive":
+            return _LC.get(lbl, "#8C8C8C")
         if p_col is None:
-            return _LC['constitutive']
+            return _LC["constitutive"]
         pval_sig = _pd.notna(row[p_col]) and row[p_col] <= 0.05
         slope_ns = sp_col is None or (_pd.notna(row[sp_col]) and row[sp_col] > 0.05)
         if pval_sig and slope_ns:
-            return _LC['constitutive']
+            return _LC["constitutive"]
         if pval_sig:
-            return '#7BA7D4'
-        return '#B0C4DE'
+            return "#7BA7D4"
+        return "#B0C4DE"
 
     hover_texts = []
     for gene_id, row in top.iterrows():
-        txt = f'<b>{gene_id}</b><br>PIRS score: {row["pirs_score"]:.4g}'
-        if p_col and _pd.notna(row.get(p_col, float('nan'))):
-            txt += f'<br>{p_col}: {row[p_col]:.3g}'
-        if sp_col and _pd.notna(row.get(sp_col, float('nan'))):
-            txt += f'<br>{sp_col}: {row[sp_col]:.3g}'
-        if 'label' in row.index:
-            txt += f'<br>label: {row["label"]}'
+        txt = f"<b>{gene_id}</b><br>PIRS score: {row['pirs_score']:.4g}"
+        if p_col and _pd.notna(row.get(p_col, float("nan"))):
+            txt += f"<br>{p_col}: {row[p_col]:.3g}"
+        if sp_col and _pd.notna(row.get(sp_col, float("nan"))):
+            txt += f"<br>{sp_col}: {row[sp_col]:.3g}"
+        if "label" in row.index:
+            txt += f"<br>label: {row['label']}"
         hover_texts.append(txt)
 
-    colors    = [_bar_color(row) for _, row in top.iterrows()]
-    top_rev   = top.iloc[::-1]
+    colors = [_bar_color(row) for _, row in top.iterrows()]
+    top_rev = top.iloc[::-1]
     colors_rev = colors[::-1]
-    hover_rev  = hover_texts[::-1]
+    hover_rev = hover_texts[::-1]
 
-    fig = go.Figure(go.Bar(
-        x=top_rev['pirs_score'].values,
-        y=top_rev.index.tolist(),
-        orientation='h',
-        marker_color=colors_rev,
-        hovertext=hover_rev,
-        hovertemplate='%{hovertext}<extra></extra>',
-    ))
-    fig.add_vline(x=pirs_cut, line_dash='dash', line_color='#333333', opacity=0.7,
-                  annotation_text=f'PIRS p{int(pirs_percentile)}',
-                  annotation_position='top right')
+    fig = go.Figure(
+        go.Bar(
+            x=top_rev["pirs_score"].values,
+            y=top_rev.index.tolist(),
+            orientation="h",
+            marker_color=colors_rev,
+            hovertext=hover_rev,
+            hovertemplate="%{hovertext}<extra></extra>",
+        )
+    )
+    fig.add_vline(
+        x=pirs_cut,
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"PIRS p{int(pirs_percentile)}",
+        annotation_position="top right",
+    )
     fig.update_layout(
         title=title,
-        xaxis_title='PIRS score',
+        xaxis_title="PIRS score",
         showlegend=False,
     )
     return fig
@@ -503,7 +603,7 @@ def top_constitutive_candidates(
 def pirs_pval_scatter(
     classifications,
     pval_threshold=0.05,
-    title='PIRS score vs temporal structure significance',
+    title="PIRS score vs temporal structure significance",
 ):
     """Interactive scatter of PIRS score vs −log₁₀(pval_bh).
 
@@ -519,18 +619,28 @@ def pirs_pval_scatter(
     -------
     plotly.graph_objects.Figure
     """
-    p_col = 'pval_bh' if _has(classifications, 'pval_bh') else 'pval'
+    p_col = "pval_bh" if _has(classifications, "pval_bh") else "pval"
     if not _has(classifications, p_col):
         raise ValueError("'pval' column is required. Call run_pirs(pvals=True) first.")
-    df = classifications.dropna(subset=['pirs_score', p_col])
+    df = classifications.dropna(subset=["pirs_score", p_col])
     df = df.assign(neg_log_p=_safe_neglog10(df[p_col]))
 
-    fig = go.Figure(_scatter_traces(df, 'pirs_score', 'neg_log_p'))
-    fig.add_hline(y=-np.log10(pval_threshold), line_dash='dash', line_color='#333333', opacity=0.7,
-                  annotation_text=f'α={pval_threshold}', annotation_position='bottom right')
-    lbl = 'pval_bh' if p_col == 'pval_bh' else 'pval'
-    fig.update_layout(title=title, xaxis_title='PIRS score',
-                      yaxis_title=f'−log₁₀({lbl})', legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "pirs_score", "neg_log_p"))
+    fig.add_hline(
+        y=-np.log10(pval_threshold),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"α={pval_threshold}",
+        annotation_position="bottom right",
+    )
+    lbl = "pval_bh" if p_col == "pval_bh" else "pval"
+    fig.update_layout(
+        title=title,
+        xaxis_title="PIRS score",
+        yaxis_title=f"−log₁₀({lbl})",
+        legend_title="Label",
+    )
     return fig
 
 
@@ -538,7 +648,7 @@ def slope_pval_scatter(
     classifications,
     slope_pval_threshold=0.05,
     pirs_percentile=50,
-    title='PIRS score vs linear slope significance',
+    title="PIRS score vs linear slope significance",
 ):
     """Interactive scatter of PIRS score vs −log₁₀(slope_pval_bh).
 
@@ -555,25 +665,39 @@ def slope_pval_scatter(
     -------
     plotly.graph_objects.Figure
     """
-    sp_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    sp_col = "slope_pval_bh" if _has(classifications, "slope_pval_bh") else "slope_pval"
     if not _has(classifications, sp_col):
         raise ValueError(
             "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
         )
-    df = classifications.dropna(subset=['pirs_score', sp_col])
+    df = classifications.dropna(subset=["pirs_score", sp_col])
     df = df.assign(neg_log_slope=_safe_neglog10(df[sp_col]))
-    pirs_cut = float(np.percentile(df['pirs_score'], pirs_percentile))
+    pirs_cut = float(np.percentile(df["pirs_score"], pirs_percentile))
 
-    fig = go.Figure(_scatter_traces(df, 'pirs_score', 'neg_log_slope'))
-    fig.add_hline(y=-np.log10(slope_pval_threshold), line_dash='dash', line_color='#333333',
-                  opacity=0.7, annotation_text=f'α={slope_pval_threshold}',
-                  annotation_position='bottom right')
-    fig.add_vline(x=pirs_cut, line_dash='dot', line_color='#333333', opacity=0.7,
-                  annotation_text=f'PIRS p{int(pirs_percentile)}',
-                  annotation_position='top right')
-    lbl = 'slope_pval_bh' if sp_col == 'slope_pval_bh' else 'slope_pval'
-    fig.update_layout(title=title, xaxis_title='PIRS score',
-                      yaxis_title=f'−log₁₀({lbl})', legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "pirs_score", "neg_log_slope"))
+    fig.add_hline(
+        y=-np.log10(slope_pval_threshold),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"α={slope_pval_threshold}",
+        annotation_position="bottom right",
+    )
+    fig.add_vline(
+        x=pirs_cut,
+        line_dash="dot",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"PIRS p{int(pirs_percentile)}",
+        annotation_position="top right",
+    )
+    lbl = "slope_pval_bh" if sp_col == "slope_pval_bh" else "slope_pval"
+    fig.update_layout(
+        title=title,
+        xaxis_title="PIRS score",
+        yaxis_title=f"−log₁₀({lbl})",
+        legend_title="Label",
+    )
     return fig
 
 
@@ -581,7 +705,7 @@ def slope_vs_rhythm(
     classifications,
     slope_pval_threshold=0.05,
     emp_p_threshold=0.05,
-    title='Slope significance vs rhythmicity significance',
+    title="Slope significance vs rhythmicity significance",
 ):
     """Interactive scatter of −log₁₀(slope_pval_bh) vs −log₁₀(emp_p).
 
@@ -598,29 +722,43 @@ def slope_vs_rhythm(
     -------
     plotly.graph_objects.Figure
     """
-    sp_col = 'slope_pval_bh' if _has(classifications, 'slope_pval_bh') else 'slope_pval'
+    sp_col = "slope_pval_bh" if _has(classifications, "slope_pval_bh") else "slope_pval"
     if not _has(classifications, sp_col):
         raise ValueError(
             "'slope_pval' column is required. Call run_pirs(slope_pvals=True) first."
         )
-    if not _has(classifications, 'emp_p'):
+    if not _has(classifications, "emp_p"):
         raise ValueError("'emp_p' column is required. Call run_bootjtk() first.")
-    df = classifications.dropna(subset=[sp_col, 'emp_p'])
+    df = classifications.dropna(subset=[sp_col, "emp_p"])
     df = df.assign(
         neg_log_slope=_safe_neglog10(df[sp_col]),
-        neg_log_emp_p=_safe_neglog10(df['emp_p']),
+        neg_log_emp_p=_safe_neglog10(df["emp_p"]),
     )
-    lbl = 'slope_pval_bh' if sp_col == 'slope_pval_bh' else 'slope_pval'
+    lbl = "slope_pval_bh" if sp_col == "slope_pval_bh" else "slope_pval"
 
-    fig = go.Figure(_scatter_traces(df, 'neg_log_slope', 'neg_log_emp_p'))
-    fig.add_vline(x=-np.log10(slope_pval_threshold), line_dash='dash', line_color='#333333',
-                  opacity=0.7, annotation_text=f'slope α={slope_pval_threshold}',
-                  annotation_position='top right')
-    fig.add_hline(y=-np.log10(emp_p_threshold), line_dash='dot', line_color='#333333',
-                  opacity=0.7, annotation_text=f'rhythm α={emp_p_threshold}',
-                  annotation_position='bottom right')
-    fig.update_layout(title=title, xaxis_title=f'−log₁₀({lbl})',
-                      yaxis_title='−log₁₀(GammaBH)', legend_title='Label')
+    fig = go.Figure(_scatter_traces(df, "neg_log_slope", "neg_log_emp_p"))
+    fig.add_vline(
+        x=-np.log10(slope_pval_threshold),
+        line_dash="dash",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"slope α={slope_pval_threshold}",
+        annotation_position="top right",
+    )
+    fig.add_hline(
+        y=-np.log10(emp_p_threshold),
+        line_dash="dot",
+        line_color="#333333",
+        opacity=0.7,
+        annotation_text=f"rhythm α={emp_p_threshold}",
+        annotation_position="bottom right",
+    )
+    fig.update_layout(
+        title=title,
+        xaxis_title=f"−log₁₀({lbl})",
+        yaxis_title="−log₁₀(GammaBH)",
+        legend_title="Label",
+    )
     return fig
 
 
@@ -649,30 +787,31 @@ def classification_summary(
     -------
     plotly.graph_objects.Figure
     """
-    has_emp_p     = _has(classifications, 'emp_p')
-    has_phase     = _has(classifications, 'phase_mean')
-    has_period    = _has(classifications, 'period_mean')
-    has_pval      = _has(classifications, 'pval') or _has(classifications, 'pval_bh')
+    has_emp_p = _has(classifications, "emp_p")
+    has_phase = _has(classifications, "phase_mean")
+    has_period = _has(classifications, "period_mean")
+    has_pval = _has(classifications, "pval") or _has(classifications, "pval_bh")
     has_slope_emp = (
-        (_has(classifications, 'slope_pval') or _has(classifications, 'slope_pval_bh'))
-        and has_emp_p
-    )
+        _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
+    ) and has_emp_p
 
     panel_names = [
-        'label_distribution', 'pirs_vs_tau', 'pirs_score_distribution',
-        'top_constitutive_candidates',
+        "label_distribution",
+        "pirs_vs_tau",
+        "pirs_score_distribution",
+        "top_constitutive_candidates",
     ]
     if has_emp_p:
-        panel_names += ['volcano', 'tau_pval_scatter']
+        panel_names += ["volcano", "tau_pval_scatter"]
     if has_pval:
-        panel_names.append('pirs_pval_scatter')
+        panel_names.append("pirs_pval_scatter")
     if has_slope_emp:
-        panel_names.append('slope_vs_rhythm')
+        panel_names.append("slope_vs_rhythm")
     if has_phase:
-        panel_names.append('phase_wheel')
-        panel_names.append('phase_amplitude_scatter')
+        panel_names.append("phase_wheel")
+        panel_names.append("phase_amplitude_scatter")
     if has_period:
-        panel_names.append('period_distribution')
+        panel_names.append("period_distribution")
 
     n = len(panel_names)
     ncols = min(3, n)
@@ -681,20 +820,21 @@ def classification_summary(
     polar_cells = {
         (i // ncols + 1, i % ncols + 1)
         for i, name in enumerate(panel_names)
-        if name == 'phase_wheel'
+        if name == "phase_wheel"
     }
     specs = [
         [
-            {'type': 'polar'} if (r + 1, c + 1) in polar_cells else {'type': 'xy'}
+            {"type": "polar"} if (r + 1, c + 1) in polar_cells else {"type": "xy"}
             for c in range(ncols)
         ]
         for r in range(nrows)
     ]
 
     fig = make_subplots(
-        rows=nrows, cols=ncols,
+        rows=nrows,
+        cols=ncols,
         specs=specs,
-        subplot_titles=panel_names + [''] * (nrows * ncols - n),
+        subplot_titles=panel_names + [""] * (nrows * ncols - n),
     )
 
     # Resolve polar subplot names (e.g. 'polar', 'polar2') from the figure's
@@ -702,7 +842,7 @@ def classification_summary(
     # using row=/col=, which Plotly 6 incorrectly maps to xaxis/yaxis.
     polar_refs = {}
     for i, name in enumerate(panel_names):
-        if name == 'phase_wheel':
+        if name == "phase_wheel":
             r, c = i // ncols, i % ncols
             grid_cell = fig._grid_ref[r][c]
             if grid_cell:
@@ -718,197 +858,311 @@ def classification_summary(
     # every trace in the figure and tries to set xaxis on each one, which
     # raises for go.Barpolar.  Adding phase_wheel last avoids this.
     for i, name in enumerate(panel_names):
-        if name != 'phase_wheel':
-            _add_panel(fig, name, classifications, i // ncols + 1, i % ncols + 1,
-                       polar_ref=None, **kw)
+        if name != "phase_wheel":
+            _add_panel(
+                fig,
+                name,
+                classifications,
+                i // ncols + 1,
+                i % ncols + 1,
+                polar_ref=None,
+                **kw,
+            )
     for i, name in enumerate(panel_names):
-        if name == 'phase_wheel':
-            _add_panel(fig, name, classifications, i // ncols + 1, i % ncols + 1,
-                       polar_ref=polar_refs.get(i), **kw)
+        if name == "phase_wheel":
+            _add_panel(
+                fig,
+                name,
+                classifications,
+                i // ncols + 1,
+                i % ncols + 1,
+                polar_ref=polar_refs.get(i),
+                **kw,
+            )
 
     fig.update_layout(
         height=350 * nrows,
         showlegend=False,
-        title_text='Classification Summary',
+        title_text="Classification Summary",
     )
     return fig
 
 
 def _add_panel(fig, name, df, row, col, polar_ref=None, **kw):
     """Add traces and threshold lines for one named panel to a subplot figure."""
-    pp  = kw.get('pirs_percentile', 50)
-    tau = kw.get('tau_threshold', 0.5)
-    ep  = kw.get('emp_p_threshold', 0.05)
-    sp  = kw.get('slope_pval_threshold', 0.05)
+    pp = kw.get("pirs_percentile", 50)
+    tau = kw.get("tau_threshold", 0.5)
+    ep = kw.get("emp_p_threshold", 0.05)
+    sp = kw.get("slope_pval_threshold", 0.05)
 
     def _traces(traces):
         for t in traces:
             t.showlegend = False
             fig.add_trace(t, row=row, col=col)
 
-    if name == 'label_distribution':
-        present = [l for l in _LABEL_ORDER if l in df['label'].values]
-        counts = df['label'].value_counts().reindex(present).fillna(0).astype(int)
-        fig.add_trace(go.Bar(
-            x=counts.values, y=counts.index.tolist(), orientation='h',
-            marker_color=[LABEL_COLORS[l] for l in counts.index],
-            hovertemplate='%{y}: %{x} genes<extra></extra>',
-            showlegend=False,
-        ), row=row, col=col)
+    if name == "label_distribution":
+        present = [l for l in _LABEL_ORDER if l in df["label"].values]
+        counts = df["label"].value_counts().reindex(present).fillna(0).astype(int)
+        fig.add_trace(
+            go.Bar(
+                x=counts.values,
+                y=counts.index.tolist(),
+                orientation="h",
+                marker_color=[LABEL_COLORS[l] for l in counts.index],
+                hovertemplate="%{y}: %{x} genes<extra></extra>",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
 
-    elif name == 'pirs_vs_tau':
-        sub = df.dropna(subset=['pirs_score', 'tau_mean'])
-        pirs_cut = float(np.percentile(sub['pirs_score'], pp))
-        _traces(_scatter_traces(sub, 'pirs_score', 'tau_mean'))
-        fig.add_vline(x=pirs_cut, line_dash='dash', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
-        fig.add_hline(y=tau, line_dash='dot', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
+    elif name == "pirs_vs_tau":
+        sub = df.dropna(subset=["pirs_score", "tau_mean"])
+        pirs_cut = float(np.percentile(sub["pirs_score"], pp))
+        _traces(_scatter_traces(sub, "pirs_score", "tau_mean"))
+        fig.add_vline(
+            x=pirs_cut,
+            line_dash="dash",
+            line_color="#333333",
+            opacity=0.7,
+            row=row,
+            col=col,
+        )
+        fig.add_hline(
+            y=tau, line_dash="dot", line_color="#333333", opacity=0.7, row=row, col=col
+        )
 
-    elif name == 'pirs_score_distribution':
-        all_scores = df['pirs_score'].dropna()
+    elif name == "pirs_score_distribution":
+        all_scores = df["pirs_score"].dropna()
         pirs_cut = float(np.percentile(all_scores, pp))
         for lbl in _LABEL_ORDER:
-            sub = df[df['label'] == lbl]['pirs_score'].dropna()
+            sub = df[df["label"] == lbl]["pirs_score"].dropna()
             if len(sub) < 2:
                 continue
-            fig.add_trace(go.Histogram(
-                x=sub, name=lbl,
-                marker_color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-                opacity=0.5, showlegend=False,
-            ), row=row, col=col)
-        fig.add_vline(x=pirs_cut, line_dash='dash', line_color='#333333', opacity=0.8,
-                      row=row, col=col)
+            fig.add_trace(
+                go.Histogram(
+                    x=sub,
+                    name=lbl,
+                    marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                    opacity=0.5,
+                    showlegend=False,
+                ),
+                row=row,
+                col=col,
+            )
+        fig.add_vline(
+            x=pirs_cut,
+            line_dash="dash",
+            line_color="#333333",
+            opacity=0.8,
+            row=row,
+            col=col,
+        )
 
-    elif name == 'volcano' and _has(df, 'emp_p'):
-        sub = df.dropna(subset=['pirs_score', 'emp_p'])
-        sub = sub.assign(neg_log_emp_p=_safe_neglog10(sub['emp_p']))
-        pirs_cut = float(np.percentile(sub['pirs_score'], pp))
-        _traces(_scatter_traces(sub, 'pirs_score', 'neg_log_emp_p'))
-        fig.add_vline(x=pirs_cut, line_dash='dot', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
-        fig.add_hline(y=-np.log10(ep), line_dash='dash', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
+    elif name == "volcano" and _has(df, "emp_p"):
+        sub = df.dropna(subset=["pirs_score", "emp_p"])
+        sub = sub.assign(neg_log_emp_p=_safe_neglog10(sub["emp_p"]))
+        pirs_cut = float(np.percentile(sub["pirs_score"], pp))
+        _traces(_scatter_traces(sub, "pirs_score", "neg_log_emp_p"))
+        fig.add_vline(
+            x=pirs_cut,
+            line_dash="dot",
+            line_color="#333333",
+            opacity=0.7,
+            row=row,
+            col=col,
+        )
+        fig.add_hline(
+            y=-np.log10(ep),
+            line_dash="dash",
+            line_color="#333333",
+            opacity=0.7,
+            row=row,
+            col=col,
+        )
 
-    elif name == 'tau_pval_scatter' and _has(df, 'emp_p'):
-        sub = df.dropna(subset=['tau_mean', 'emp_p'])
-        sub = sub.assign(neg_log_emp_p=_safe_neglog10(sub['emp_p']))
-        _traces(_scatter_traces(sub, 'tau_mean', 'neg_log_emp_p'))
-        fig.add_vline(x=tau, line_dash='dash', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
-        fig.add_hline(y=-np.log10(ep), line_dash='dot', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
+    elif name == "tau_pval_scatter" and _has(df, "emp_p"):
+        sub = df.dropna(subset=["tau_mean", "emp_p"])
+        sub = sub.assign(neg_log_emp_p=_safe_neglog10(sub["emp_p"]))
+        _traces(_scatter_traces(sub, "tau_mean", "neg_log_emp_p"))
+        fig.add_vline(
+            x=tau, line_dash="dash", line_color="#333333", opacity=0.7, row=row, col=col
+        )
+        fig.add_hline(
+            y=-np.log10(ep),
+            line_dash="dot",
+            line_color="#333333",
+            opacity=0.7,
+            row=row,
+            col=col,
+        )
 
-    elif name == 'pirs_pval_scatter':
-        p_col = 'pval_bh' if _has(df, 'pval_bh') else 'pval'
+    elif name == "pirs_pval_scatter":
+        p_col = "pval_bh" if _has(df, "pval_bh") else "pval"
         if _has(df, p_col):
-            sub = df.dropna(subset=['pirs_score', p_col])
+            sub = df.dropna(subset=["pirs_score", p_col])
             sub = sub.assign(neg_log_p=_safe_neglog10(sub[p_col]))
-            _traces(_scatter_traces(sub, 'pirs_score', 'neg_log_p'))
-            fig.add_hline(y=-np.log10(0.05), line_dash='dash', line_color='#333333', opacity=0.7,
-                          row=row, col=col)
+            _traces(_scatter_traces(sub, "pirs_score", "neg_log_p"))
+            fig.add_hline(
+                y=-np.log10(0.05),
+                line_dash="dash",
+                line_color="#333333",
+                opacity=0.7,
+                row=row,
+                col=col,
+            )
 
-    elif name == 'slope_vs_rhythm':
-        sp_col = 'slope_pval_bh' if _has(df, 'slope_pval_bh') else 'slope_pval'
-        if _has(df, sp_col) and _has(df, 'emp_p'):
-            sub = df.dropna(subset=[sp_col, 'emp_p'])
+    elif name == "slope_vs_rhythm":
+        sp_col = "slope_pval_bh" if _has(df, "slope_pval_bh") else "slope_pval"
+        if _has(df, sp_col) and _has(df, "emp_p"):
+            sub = df.dropna(subset=[sp_col, "emp_p"])
             sub = sub.assign(
                 neg_log_slope=_safe_neglog10(sub[sp_col]),
-                neg_log_emp_p=_safe_neglog10(sub['emp_p']),
+                neg_log_emp_p=_safe_neglog10(sub["emp_p"]),
             )
-            _traces(_scatter_traces(sub, 'neg_log_slope', 'neg_log_emp_p'))
-            fig.add_vline(x=-np.log10(sp), line_dash='dash', line_color='#333333', opacity=0.7,
-                          row=row, col=col)
-            fig.add_hline(y=-np.log10(ep), line_dash='dot', line_color='#333333', opacity=0.7,
-                          row=row, col=col)
+            _traces(_scatter_traces(sub, "neg_log_slope", "neg_log_emp_p"))
+            fig.add_vline(
+                x=-np.log10(sp),
+                line_dash="dash",
+                line_color="#333333",
+                opacity=0.7,
+                row=row,
+                col=col,
+            )
+            fig.add_hline(
+                y=-np.log10(ep),
+                line_dash="dot",
+                line_color="#333333",
+                opacity=0.7,
+                row=row,
+                col=col,
+            )
 
-    elif name == 'phase_wheel' and _has(df, 'phase_mean'):
-        sub = df[df['label'].isin(['rhythmic', 'noisy_rhythmic'])].dropna(subset=['phase_mean'])
+    elif name == "phase_wheel" and _has(df, "phase_mean"):
+        sub = df[df["label"].isin(["rhythmic", "noisy_rhythmic"])].dropna(
+            subset=["phase_mean"]
+        )
         if sub.empty:
-            sub = df.dropna(subset=['phase_mean'])
+            sub = df.dropna(subset=["phase_mean"])
         nbins = 12
         bin_size_h = 24 / nbins
         bin_edges = np.linspace(0, 24, nbins + 1)
         bin_centers_h = bin_edges[:-1] + bin_size_h / 2
-        counts, _ = np.histogram(sub['phase_mean'].values, bins=bin_edges)
+        counts, _ = np.histogram(sub["phase_mean"].values, bins=bin_edges)
         # Set subplot explicitly — passing row=/col= to add_trace for a
         # Barpolar raises in Plotly 6 because it tries to assign xaxis.
         trace = go.Barpolar(
             r=counts,
             theta=bin_centers_h * (360 / 24),
             width=bin_size_h * (360 / 24),
-            marker_color='#6ACC65',
-            marker_line_color='white',
+            marker_color="#6ACC65",
+            marker_line_color="white",
             marker_line_width=1,
             opacity=0.7,
             showlegend=False,
-            subplot=polar_ref or 'polar',
+            subplot=polar_ref or "polar",
         )
         fig.add_trace(trace)
 
-    elif name == 'slope_pval_scatter':
-        sp_col = 'slope_pval_bh' if _has(df, 'slope_pval_bh') else 'slope_pval'
+    elif name == "slope_pval_scatter":
+        sp_col = "slope_pval_bh" if _has(df, "slope_pval_bh") else "slope_pval"
         if _has(df, sp_col):
-            sub = df.dropna(subset=['pirs_score', sp_col])
-            pirs_cut = float(np.percentile(sub['pirs_score'], pp))
+            sub = df.dropna(subset=["pirs_score", sp_col])
+            pirs_cut = float(np.percentile(sub["pirs_score"], pp))
             sub = sub.assign(neg_log_slope=_safe_neglog10(sub[sp_col]))
-            _traces(_scatter_traces(sub, 'pirs_score', 'neg_log_slope'))
-            fig.add_hline(y=-np.log10(sp), line_dash='dash', line_color='#333333', opacity=0.7,
-                          row=row, col=col)
-            fig.add_vline(x=pirs_cut, line_dash='dot', line_color='#333333', opacity=0.7,
-                          row=row, col=col)
+            _traces(_scatter_traces(sub, "pirs_score", "neg_log_slope"))
+            fig.add_hline(
+                y=-np.log10(sp),
+                line_dash="dash",
+                line_color="#333333",
+                opacity=0.7,
+                row=row,
+                col=col,
+            )
+            fig.add_vline(
+                x=pirs_cut,
+                line_dash="dot",
+                line_color="#333333",
+                opacity=0.7,
+                row=row,
+                col=col,
+            )
 
-    elif name == 'phase_amplitude_scatter' and _has(df, 'phase_mean'):
-        sub = df[df['label'].isin(['rhythmic', 'noisy_rhythmic'])].dropna(
-            subset=['phase_mean', 'tau_mean']
+    elif name == "phase_amplitude_scatter" and _has(df, "phase_mean"):
+        sub = df[df["label"].isin(["rhythmic", "noisy_rhythmic"])].dropna(
+            subset=["phase_mean", "tau_mean"]
         )
         if sub.empty:
-            sub = df.dropna(subset=['phase_mean', 'tau_mean'])
-        _traces(_scatter_traces(sub, 'phase_mean', 'tau_mean'))
+            sub = df.dropna(subset=["phase_mean", "tau_mean"])
+        _traces(_scatter_traces(sub, "phase_mean", "tau_mean"))
 
-    elif name == 'top_constitutive_candidates':
+    elif name == "top_constitutive_candidates":
         import pandas as _pd
-        top = df.dropna(subset=['pirs_score']).nsmallest(20, 'pirs_score')
-        all_sc  = df['pirs_score'].dropna()
-        pc      = float(np.percentile(all_sc, pp))
-        p_col   = ('pval_bh'      if _has(df, 'pval_bh')      else
-                   'pval'          if _has(df, 'pval')          else None)
-        sp_col2 = ('slope_pval_bh' if _has(df, 'slope_pval_bh') else
-                   'slope_pval'    if _has(df, 'slope_pval')    else None)
+
+        top = df.dropna(subset=["pirs_score"]).nsmallest(20, "pirs_score")
+        all_sc = df["pirs_score"].dropna()
+        pc = float(np.percentile(all_sc, pp))
+        p_col = (
+            "pval_bh" if _has(df, "pval_bh") else "pval" if _has(df, "pval") else None
+        )
+        sp_col2 = (
+            "slope_pval_bh"
+            if _has(df, "slope_pval_bh")
+            else "slope_pval"
+            if _has(df, "slope_pval")
+            else None
+        )
 
         def _bc(r):
-            lbl = r['label'] if 'label' in r.index else 'constitutive'
-            if lbl != 'constitutive':
-                return LABEL_COLORS.get(lbl, '#8C8C8C')
+            lbl = r["label"] if "label" in r.index else "constitutive"
+            if lbl != "constitutive":
+                return LABEL_COLORS.get(lbl, "#8C8C8C")
             if p_col is None:
-                return LABEL_COLORS['constitutive']
+                return LABEL_COLORS["constitutive"]
             ps = _pd.notna(r[p_col]) and r[p_col] <= 0.05
             sn = sp_col2 is None or (_pd.notna(r[sp_col2]) and r[sp_col2] > 0.05)
             if ps and sn:
-                return LABEL_COLORS['constitutive']
-            return '#7BA7D4' if ps else '#B0C4DE'
+                return LABEL_COLORS["constitutive"]
+            return "#7BA7D4" if ps else "#B0C4DE"
 
         colors2 = [_bc(r) for _, r in top.iterrows()]
         top_rev = top.iloc[::-1]
-        fig.add_trace(go.Bar(
-            x=top_rev['pirs_score'].values,
-            y=top_rev.index.tolist(),
-            orientation='h',
-            marker_color=colors2[::-1],
-            showlegend=False,
-        ), row=row, col=col)
-        fig.add_vline(x=pc, line_dash='dash', line_color='#333333', opacity=0.7,
-                      row=row, col=col)
+        fig.add_trace(
+            go.Bar(
+                x=top_rev["pirs_score"].values,
+                y=top_rev.index.tolist(),
+                orientation="h",
+                marker_color=colors2[::-1],
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+        fig.add_vline(
+            x=pc, line_dash="dash", line_color="#333333", opacity=0.7, row=row, col=col
+        )
 
-    elif name == 'period_distribution' and _has(df, 'period_mean'):
-        for lbl in ('rhythmic', 'noisy_rhythmic'):
-            sub = df[df['label'] == lbl]['period_mean'].dropna()
+    elif name == "period_distribution" and _has(df, "period_mean"):
+        for lbl in ("rhythmic", "noisy_rhythmic"):
+            sub = df[df["label"] == lbl]["period_mean"].dropna()
             if sub.empty:
                 continue
-            fig.add_trace(go.Histogram(
-                x=sub, name=lbl,
-                marker_color=LABEL_COLORS.get(lbl, '#8C8C8C'),
-                opacity=0.6, showlegend=False,
-            ), row=row, col=col)
-        fig.add_vline(x=24.0, line_dash='dash', line_color='#333333', opacity=0.8,
-                      row=row, col=col)
+            fig.add_trace(
+                go.Histogram(
+                    x=sub,
+                    name=lbl,
+                    marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                    opacity=0.6,
+                    showlegend=False,
+                ),
+                row=row,
+                col=col,
+            )
+        fig.add_vline(
+            x=24.0,
+            line_dash="dash",
+            line_color="#333333",
+            opacity=0.8,
+            row=row,
+            col=col,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,12 @@ select = ["E", "F"]
 ignore = [
     "E402",  # module-level import not at top — common in scientific modules with sys.path setup
     "E501",  # line too long — scientific code routinely exceeds 88 chars
-    "E701",  # multiple statements on one line — legacy style in bootjtk
     "E731",  # lambda assignment — common in scientific code
     "E741",  # ambiguous variable name — l, O, I are standard in linear algebra
     "F841",  # unused variable — common in scientific unpacking
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"circ/bootjtk/*.py" = ["F401", "F811", "E711", "E712", "E702", "E703"]
 "circ/*/__init__.py" = ["F401"]
 "circ/__init__.py" = ["F401"]
 


### PR DESCRIPTION
## Summary

- **Type annotations** added to all public API modules (`circ/io`, `circ/cli`, `circ/simulations`, `circ/pirs/`, `circ/limbr/`, `circ/expression_classification/`) using Python 3.11+ union syntax; mypy passes cleanly on all annotated files
- **Format checking** (`ruff format --check`) added to the CI lint job; `ruff format` applied across all 28 files that needed reformatting
- **Lint coverage extended** to bootjtk: removed the `circ/bootjtk/*.py` per-file exemptions and fixed the 40 underlying violations (unused imports, duplicate imports, `== True`/`== False` comparisons)
- **Latent CLI bug fixed**: `--pirs-alpha` flag was being passed to `Classifier.run_all()` which never accepted it; removed the dead flag and the stale kwarg

## Test plan

- [x] `poetry run pytest` — 786 passed, 0 failed
- [x] `poetry run ruff check circ/` — no violations
- [x] `poetry run ruff format --check circ/` — 32 files already formatted
- [x] `poetry run mypy circ/io.py circ/cli.py circ/simulations.py circ/pirs/rank.py circ/limbr/imputation.py circ/limbr/batch_fx.py circ/expression_classification/classify.py circ/limbr/old_fashioned.py circ/pirs/simulations.py circ/limbr/simulations.py` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)