### PR TITLE
Add gene_profile, expression_heatmap, and interactive compare plots

### DIFF
--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -52,6 +52,8 @@ from circ.visualization.classify import (
     phase_amplitude_scatter,
     top_constitutive_candidates,
     mean_expression_profiles,
+    gene_profile,
+    expression_heatmap,
     threshold_sensitivity,
     classification_summary,
 )
@@ -86,6 +88,8 @@ __all__ = [
     "phase_amplitude_scatter",
     "top_constitutive_candidates",
     "mean_expression_profiles",
+    "gene_profile",
+    "expression_heatmap",
     "threshold_sensitivity",
     "classification_summary",
     # compare

--- a/circ/visualization/benchmarks.py
+++ b/circ/visualization/benchmarks.py
@@ -7,7 +7,6 @@ called directly with pre-computed data.
 Metric-only functions (no matplotlib) live in ``circ.evaluation``.
 """
 
-import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.metrics import (
     average_precision_score,
@@ -16,14 +15,7 @@ from sklearn.metrics import (
     auc,
 )
 
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _ax(ax):
-    return ax if ax is not None else plt.subplots()[1]
+from circ.visualization.classify import _ax
 
 
 # ---------------------------------------------------------------------------

--- a/circ/visualization/classify.py
+++ b/circ/visualization/classify.py
@@ -36,7 +36,7 @@ def _ax(ax):
 
 
 def _safe_neglog10(series, floor=1e-300):
-    return -np.log10(np.maximum(series.clip(lower=floor), floor))
+    return -np.log10(np.maximum(series, floor))
 
 
 def _has(df, col):
@@ -68,6 +68,15 @@ def _label_legend(present, ax):
         ax.legend(handles=patches, loc="best", frameon=False, fontsize=9)
 
 
+def _zt_timepoints(expression):
+    """Return (zt_cols, timepoints_array, unique_tp_array) for an expression DataFrame."""
+    cols = [c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")]
+    if not cols:
+        raise ValueError("No ZT/CT columns found in expression DataFrame.")
+    tp = np.array([int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in cols])
+    return cols, tp, np.sort(np.unique(tp))
+
+
 def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
     """Set axis limits to data percentiles so outliers don't compress the view."""
     x = x_series.dropna()
@@ -87,7 +96,9 @@ def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
 # ---------------------------------------------------------------------------
 
 
-def label_distribution(classifications, ax=None, title="Expression label counts"):
+def label_distribution(
+    classifications, ax=None, title="Expression label counts", xlim=None
+):
     """Horizontal bar chart of gene counts per expression label.
 
     Parameters
@@ -96,6 +107,14 @@ def label_distribution(classifications, ax=None, title="Expression label counts"
         Output of ``Classifier.classify()``.
     ax : matplotlib.axes.Axes, optional
     title : str, optional
+    xlim : float or None
+        If provided, fix the x-axis upper limit to this value.  Useful when
+        placing two side-by-side distribution charts on a shared scale::
+
+            xmax = max(result_A["label"].value_counts().max(),
+                       result_B["label"].value_counts().max()) * 1.15
+            viz.label_distribution(result_A, ax=axes[0], xlim=xmax)
+            viz.label_distribution(result_B, ax=axes[1], xlim=xmax)
 
     Returns
     -------
@@ -112,6 +131,8 @@ def label_distribution(classifications, ax=None, title="Expression label counts"
     ax.set_xlabel("Gene count")
     ax.set_title(title)
     ax.invert_yaxis()
+    if xlim is not None:
+        ax.set_xlim(0, xlim)
     sns.despine(ax=ax, left=True)
     return ax
 
@@ -231,6 +252,11 @@ def volcano(
         label=f"PIRS p{int(pirs_percentile)}",
     )
     _clip_axes_to_data(ax, df["pirs_score"], df["neg_log_emp_p"])
+    _qstyle = dict(transform=ax.transAxes, fontsize=7, color="#AAAAAA", style="italic")
+    ax.text(0.02, 0.04, "constitutive", va="bottom", ha="left", **_qstyle)
+    ax.text(0.98, 0.04, "variable", va="bottom", ha="right", **_qstyle)
+    ax.text(0.02, 0.96, "noisy_rhythmic", va="top", ha="left", **_qstyle)
+    ax.text(0.98, 0.96, "rhythmic", va="top", ha="right", **_qstyle)
     ax.set_xlabel("PIRS score")
     ax.set_ylabel("−log₁₀(GammaBH)")
     ax.set_title(title)
@@ -609,7 +635,7 @@ def phase_wheel(
         width=widths,
         align="edge",
         alpha=0.7,
-        color="#6ACC65",
+        color=LABEL_COLORS["rhythmic"],
         edgecolor="white",
     )
 
@@ -936,9 +962,8 @@ def classification_summary(
     has_phase = _has(classifications, "phase_mean")
     has_period = _has(classifications, "period_mean")
     has_pval = _has(classifications, "pval") or _has(classifications, "pval_bh")
-    has_slope_emp = (
-        _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
-    ) and has_emp_p
+    has_slope = _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
+    has_slope_emp = has_slope and has_emp_p
 
     # Build ordered list of (title, callable) for each panel
     panels = [
@@ -961,6 +986,12 @@ def classification_summary(
         (
             "top_constitutive_candidates",
             lambda ax: top_constitutive_candidates(
+                classifications, pirs_percentile=pirs_percentile, ax=ax
+            ),
+        ),
+        (
+            "threshold_sensitivity",
+            lambda ax: threshold_sensitivity(
                 classifications, pirs_percentile=pirs_percentile, ax=ax
             ),
         ),
@@ -989,6 +1020,18 @@ def classification_summary(
     if has_pval:
         panels.append(
             ("pirs_pval_scatter", lambda ax: pirs_pval_scatter(classifications, ax=ax))
+        )
+    if has_slope:
+        panels.append(
+            (
+                "slope_pval_scatter",
+                lambda ax: slope_pval_scatter(
+                    classifications,
+                    slope_pval_threshold=slope_pval_threshold,
+                    pirs_percentile=pirs_percentile,
+                    ax=ax,
+                ),
+            )
         )
     if has_slope_emp:
         panels.append(
@@ -1070,17 +1113,7 @@ def mean_expression_profiles(
     """
     ax = _ax(ax)
 
-    zt_cols = [
-        c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")
-    ]
-    if not zt_cols:
-        raise ValueError("No ZT/CT columns found in expression DataFrame.")
-
-    def _parse_zt(col):
-        return int(col.replace("ZT", "").replace("CT", "").split("_")[0])
-
-    timepoints = np.array([_parse_zt(c) for c in zt_cols])
-    unique_tp = np.sort(np.unique(timepoints))
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
 
     # Average replicates → one value per gene per unique timepoint
     tp_means = pd.DataFrame(
@@ -1128,6 +1161,300 @@ def mean_expression_profiles(
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
+    return ax
+
+
+def gene_profile(
+    expression,
+    gene_id,
+    classifications=None,
+    color=None,
+    ax=None,
+    title=None,
+):
+    """Time-series profile for a single gene.
+
+    Scatter-plots all replicate sample values with the per-timepoint mean as
+    a line.  When *classifications* is provided the color is derived from the
+    gene's label and the title is annotated with τ, phase, and PIRS score.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns.
+    gene_id : str
+        Row label in *expression*.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``, indexed by the same gene IDs.
+        Used to determine label color and to annotate the title with scores.
+    color : str, optional
+        Point/line color.  Derived from the label in *classifications* when
+        omitted; falls back to ``LABEL_COLORS['constitutive']``.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+        Defaults to *gene_id* with score annotations appended.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    if gene_id not in expression.index:
+        raise ValueError(f"{gene_id!r} not found in expression index.")
+
+    vals = expression.loc[gene_id, zt_cols].astype(float).values
+
+    if color is None:
+        if classifications is not None and gene_id in classifications.index:
+            lbl = (
+                classifications.at[gene_id, "label"]
+                if "label" in classifications.columns
+                else None
+            )
+            color = LABEL_COLORS.get(lbl, "#8C8C8C")
+        else:
+            color = LABEL_COLORS["constitutive"]
+
+    ax.scatter(timepoints, vals, color=color, s=14, alpha=0.55, zorder=3)
+    means = np.array(
+        [vals[[i for i, t in enumerate(timepoints) if t == tp]].mean() for tp in unique_tp]
+    )
+    ax.plot(unique_tp, means, color=color, lw=1.5, zorder=2)
+
+    if title is None:
+        title = gene_id
+        if classifications is not None and gene_id in classifications.index:
+            row = classifications.loc[gene_id]
+            parts = []
+            if "tau_mean" in row.index and pd.notna(row["tau_mean"]):
+                parts.append(f"τ={row['tau_mean']:.2f}")
+            if "phase_mean" in row.index and pd.notna(row["phase_mean"]):
+                parts.append(f"φ={row['phase_mean']:.1f}h")
+            if parts:
+                title += "\n" + "  ".join(parts)
+            if "pirs_score" in row.index and pd.notna(row["pirs_score"]):
+                title += f"\nPIRS={row['pirs_score']:.3f}"
+
+    ax.set_title(title)
+    ax.set_xlabel("ZT (h)")
+    ax.set_ylabel("Expression")
+    ax.set_xticks(unique_tp)
+    sns.despine(ax=ax)
+    return ax
+
+
+# Per-label column and sort direction for representative gene selection
+_LABEL_SELECT_COL = {
+    "constitutive":   ("pirs_score", True),   # ascending PIRS → most stable
+    "rhythmic":       ("tau_mean",   False),  # descending tau → clearest rhythm
+    "noisy_rhythmic": ("tau_mean",   False),
+    "linear":         ("slope_pval", True),   # ascending slope_pval → clearest trend
+    "variable":       ("pirs_score", False),  # descending PIRS → most variable
+    "unclassified":   (None,         True),
+}
+
+
+def expression_heatmap(
+    expression,
+    classifications=None,
+    labels=None,
+    n_per_label=20,
+    z_score=True,
+    method="ward",
+    cmap="RdBu_r",
+    show_gene_labels=None,
+    colorbar=True,
+    ax=None,
+    title="Expression heatmap",
+):
+    """Clustered heatmap of gene expression grouped by label.
+
+    Genes are subsampled per label (most representative first), z-scored
+    across timepoints, and sorted by within-group hierarchical clustering.
+    A narrow color strip on the left side encodes the expression label.
+    White lines separate label groups.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns, indexed by
+        gene ID.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``.  When provided, genes are
+        grouped and color-coded by label.  If omitted, all genes are
+        clustered together.
+    labels : list of str, optional
+        Labels to include, in display order.  Defaults to all labels in
+        ``_LABEL_ORDER`` present in *classifications*.
+    n_per_label : int
+        Maximum genes per label.  Genes are ranked by the most
+        informative score for each label (lowest PIRS for constitutive,
+        highest TauMean for rhythmic, etc.).  Default 20.
+    z_score : bool
+        Z-score each gene across its timepoint means before plotting
+        (default True).
+    method : str
+        Linkage method for within-group hierarchical clustering
+        (default ``'ward'``).
+    cmap : str
+        Matplotlib colormap name (default ``'RdBu_r'``).
+    show_gene_labels : bool or None
+        Whether to draw gene-ID tick labels.  Auto-detects: shown when
+        ≤ 40 genes, hidden otherwise.
+    colorbar : bool
+        Draw a colorbar for the z-score scale (default True).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The main heatmap axes.
+    """
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+    from scipy.cluster.hierarchy import linkage, leaves_list
+
+    ax = _ax(ax)
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    # Average replicates → one value per gene per unique timepoint
+    tp_mat = pd.DataFrame(
+        {
+            int(tp): expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1)
+            for tp in unique_tp
+        },
+        index=expression.index,
+    ).astype(float)
+
+    # -----------------------------------------------------------------------
+    # Gene selection and ordering
+    # -----------------------------------------------------------------------
+    if classifications is not None:
+        common = tp_mat.index.intersection(classifications.index)
+        tp_mat = tp_mat.loc[common]
+        clf = classifications.loc[common]
+
+        if labels is None:
+            labels = [l for l in _LABEL_ORDER if l in clf["label"].values]
+
+        ordered_genes: list = []
+        gene_label_list: list = []
+
+        for lbl in labels:
+            mask = clf["label"] == lbl
+            genes = clf[mask].index.tolist()
+            if not genes:
+                continue
+
+            n = min(n_per_label, len(genes))
+            col, ascending = _LABEL_SELECT_COL.get(lbl, ("pirs_score", True))
+            if col and col in clf.columns and clf[col].notna().any():
+                ranked = clf.loc[genes, col].dropna()
+                genes = (
+                    ranked.nsmallest(n) if ascending else ranked.nlargest(n)
+                ).index.tolist()
+            else:
+                genes = genes[:n]
+
+            sub = tp_mat.loc[genes].values
+            if len(sub) > 2:
+                order = leaves_list(linkage(sub, method=method))
+                genes = [genes[i] for i in order]
+
+            ordered_genes.extend(genes)
+            gene_label_list.extend([lbl] * len(genes))
+    else:
+        max_genes = n_per_label * len(_LABEL_ORDER)
+        genes = tp_mat.index.tolist()
+        if len(genes) > max_genes:
+            step = max(1, len(genes) // max_genes)
+            genes = genes[::step][:max_genes]
+        sub = tp_mat.loc[genes].values
+        if len(sub) > 2:
+            order = leaves_list(linkage(sub, method=method))
+            genes = [genes[i] for i in order]
+        ordered_genes = genes
+        gene_label_list = None
+
+    if not ordered_genes:
+        ax.set_title(title)
+        ax.text(0.5, 0.5, "No genes to display", transform=ax.transAxes,
+                ha="center", va="center", color="#888888")
+        return ax
+
+    mat = tp_mat.loc[ordered_genes].values
+    n_genes, n_tp = mat.shape
+
+    # -----------------------------------------------------------------------
+    # Z-score each gene
+    # -----------------------------------------------------------------------
+    if z_score:
+        row_mean = mat.mean(axis=1, keepdims=True)
+        row_std = mat.std(axis=1, keepdims=True)
+        row_std[row_std == 0] = 1.0
+        mat = (mat - row_mean) / row_std
+
+    vmax = float(np.nanpercentile(np.abs(mat), 99))
+    vmax = max(vmax, 0.5)
+
+    # -----------------------------------------------------------------------
+    # Draw heatmap
+    # -----------------------------------------------------------------------
+    im = ax.imshow(
+        mat,
+        aspect="auto",
+        cmap=cmap,
+        vmin=-vmax,
+        vmax=vmax,
+        interpolation="nearest",
+    )
+
+    # White lines between label groups
+    if gene_label_list is not None:
+        boundary = 0
+        for lbl in (labels or []):
+            cnt = gene_label_list.count(lbl)
+            boundary += cnt
+            if 0 < boundary < n_genes:
+                ax.axhline(boundary - 0.5, color="white", lw=1.2)
+
+    # X-axis: unique timepoints
+    ax.set_xticks(range(n_tp))
+    ax.set_xticklabels([f"ZT{int(tp):02d}" for tp in unique_tp], fontsize=8)
+
+    # Y-axis: gene IDs (auto-hide above threshold)
+    show_labels = show_gene_labels if show_gene_labels is not None else (n_genes <= 40)
+    if show_labels:
+        ax.set_yticks(range(n_genes))
+        ax.set_yticklabels(ordered_genes, fontsize=7)
+    else:
+        ax.set_yticks([])
+
+    ax.set_title(title)
+
+    # -----------------------------------------------------------------------
+    # Label color strip and colorbar via AxesDivider
+    # -----------------------------------------------------------------------
+    divider = make_axes_locatable(ax)
+
+    if gene_label_list is not None:
+        cax_strip = divider.append_axes("left", size="4%", pad=0.05)
+        rgb = np.array(
+            [plt.matplotlib.colors.to_rgb(LABEL_COLORS.get(l, "#8C8C8C"))
+             for l in gene_label_list],
+            dtype=float,
+        ).reshape(n_genes, 1, 3)
+        cax_strip.imshow(rgb, aspect="auto", interpolation="nearest")
+        cax_strip.set_xticks([])
+        cax_strip.set_yticks([])
+
+    if colorbar:
+        cax_cb = divider.append_axes("right", size="4%", pad=0.08)
+        cb = plt.colorbar(im, cax=cax_cb)
+        cb.set_label("z-score" if z_score else "expression", fontsize=8)
+
     return ax
 
 

--- a/circ/visualization/interactive/__init__.py
+++ b/circ/visualization/interactive/__init__.py
@@ -46,12 +46,17 @@ from circ.visualization.interactive.classify import (
     phase_wheel,
     period_distribution,
     phase_amplitude_scatter,
+    expression_heatmap,
     top_constitutive_candidates,
     classification_summary,
 )
 from circ.visualization.interactive.benchmarks import (
     classification_pr,
     classification_roc,
+)
+from circ.visualization.interactive.compare import (
+    rhythmicity_shift_scatter,
+    delta_tau_volcano,
 )
 
 __all__ = [
@@ -66,8 +71,11 @@ __all__ = [
     "phase_wheel",
     "period_distribution",
     "phase_amplitude_scatter",
+    "expression_heatmap",
     "top_constitutive_candidates",
     "classification_summary",
     "classification_pr",
     "classification_roc",
+    "rhythmicity_shift_scatter",
+    "delta_tau_volcano",
 ]

--- a/circ/visualization/interactive/classify.py
+++ b/circ/visualization/interactive/classify.py
@@ -499,6 +499,175 @@ def phase_amplitude_scatter(
     return fig
 
 
+def expression_heatmap(
+    expression,
+    classifications=None,
+    labels=None,
+    n_per_label=20,
+    z_score=True,
+    method="ward",
+    title="Expression heatmap",
+):
+    """Interactive clustered heatmap of gene expression grouped by label.
+
+    Hover over any cell to see the gene ID, timepoint, and z-score value.
+    Genes are subsampled per label, z-scored, and sorted by within-group
+    hierarchical clustering.  A label color annotation trace is drawn on
+    the right y-axis.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``.
+    labels : list of str, optional
+    n_per_label : int
+        Maximum genes per label (default 20).
+    z_score : bool
+        Z-score each gene before plotting (default True).
+    method : str
+        Linkage method for clustering (default ``'ward'``).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    from circ.visualization.classify import (
+        _zt_timepoints,
+        _LABEL_ORDER,
+        _LABEL_SELECT_COL,
+        LABEL_COLORS,
+    )
+    from scipy.cluster.hierarchy import linkage, leaves_list
+
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    tp_mat = np.array([
+        expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1).values
+        for tp in unique_tp
+    ]).T  # shape (n_genes, n_tp)
+    gene_index = expression.index.tolist()
+
+    if classifications is not None:
+        common = [g for g in gene_index if g in classifications.index]
+        clf = classifications.loc[common]
+        mat_sub = tp_mat[[gene_index.index(g) for g in common], :]
+        gene_index = common
+
+        if labels is None:
+            labels = [l for l in _LABEL_ORDER if l in clf["label"].values]
+
+        ordered_genes: list = []
+        gene_label_list: list = []
+
+        for lbl in labels:
+            genes = clf[clf["label"] == lbl].index.tolist()
+            if not genes:
+                continue
+            n = min(n_per_label, len(genes))
+            col, ascending = _LABEL_SELECT_COL.get(lbl, ("pirs_score", True))
+            if col and col in clf.columns and clf[col].notna().any():
+                ranked = clf.loc[genes, col].dropna()
+                genes = (ranked.nsmallest(n) if ascending else ranked.nlargest(n)).index.tolist()
+            else:
+                genes = genes[:n]
+
+            idx_in_sub = [common.index(g) for g in genes]
+            sub = mat_sub[idx_in_sub, :]
+            if len(sub) > 2:
+                order = leaves_list(linkage(sub, method=method))
+                genes = [genes[i] for i in order]
+
+            ordered_genes.extend(genes)
+            gene_label_list.extend([lbl] * len(genes))
+
+        final_idx = [common.index(g) for g in ordered_genes]
+        mat = mat_sub[final_idx, :]
+    else:
+        max_genes = n_per_label * len(_LABEL_ORDER)
+        if len(gene_index) > max_genes:
+            step = max(1, len(gene_index) // max_genes)
+            gene_index = gene_index[::step][:max_genes]
+            tp_mat = tp_mat[[expression.index.tolist().index(g) for g in gene_index], :]
+        if len(gene_index) > 2:
+            order = leaves_list(linkage(tp_mat.astype(float), method=method))
+            gene_index = [gene_index[i] for i in order]
+            tp_mat = tp_mat[order, :]
+        ordered_genes = gene_index
+        gene_label_list = None
+        mat = tp_mat
+
+    mat = mat.astype(float)
+
+    if z_score:
+        row_mean = mat.mean(axis=1, keepdims=True)
+        row_std = mat.std(axis=1, keepdims=True)
+        row_std[row_std == 0] = 1.0
+        mat = (mat - row_mean) / row_std
+
+    vmax = float(np.percentile(np.abs(mat), 99))
+    vmax = max(vmax, 0.5)
+
+    x_labels = [f"ZT{int(tp):02d}" for tp in unique_tp]
+
+    # Build hover text matrix
+    hover = np.array([
+        [
+            f"<b>{gene}</b><br>ZT: {x_labels[j]}<br>z-score: {mat[i, j]:.2f}"
+            for j in range(mat.shape[1])
+        ]
+        for i, gene in enumerate(ordered_genes)
+    ])
+
+    fig = go.Figure(
+        go.Heatmap(
+            z=mat,
+            x=x_labels,
+            y=ordered_genes,
+            colorscale="RdBu",
+            reversescale=True,
+            zmin=-vmax,
+            zmax=vmax,
+            text=hover,
+            hovertemplate="%{text}<extra></extra>",
+            colorbar=dict(title="z-score" if z_score else "expression"),
+        )
+    )
+
+    # Label color annotation traces on the right y-axis (as a thin bar)
+    if gene_label_list is not None:
+        fig.update_layout(yaxis2=dict(overlaying="y", side="right", showticklabels=False))
+        for lbl in (labels or []):
+            idxs = [i for i, l in enumerate(gene_label_list) if l == lbl]
+            if not idxs:
+                continue
+            fig.add_trace(
+                go.Bar(
+                    x=[0.5] * len(idxs),
+                    y=[ordered_genes[i] for i in idxs],
+                    orientation="h",
+                    name=lbl,
+                    marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                    width=0.9,
+                    yaxis="y2",
+                    showlegend=True,
+                    hovertemplate=f"label: {lbl}<extra></extra>",
+                    visible=True,
+                )
+            )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title="Timepoint",
+        yaxis_title="Gene",
+        yaxis=dict(autorange="reversed"),
+        height=max(400, len(ordered_genes) * 14 + 100),
+    )
+    return fig
+
+
 def top_constitutive_candidates(
     classifications,
     n_top=20,

--- a/circ/visualization/interactive/compare.py
+++ b/circ/visualization/interactive/compare.py
@@ -1,0 +1,200 @@
+"""Interactive (Plotly) visualizations for condition comparison results."""
+
+import numpy as np
+import plotly.graph_objects as go
+
+from circ.visualization.compare import _STATUS_COLORS, _STATUS_ORDER
+
+
+def rhythmicity_shift_scatter(
+    comparison,
+    alpha=0.05,
+    title="Rhythmicity shift: TauMean per condition",
+):
+    """Interactive scatter of tau_mean_A vs tau_mean_B, colored by status.
+
+    Each point is a shared gene.  Hover shows gene ID, tau values, Δ tau,
+    rhythmicity status, and FDR p-value when available.  When ``tau_padj``
+    is present, significant genes (padj < *alpha*) are drawn larger and
+    more opaque than the non-significant background.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold for distinguishing significant genes (default 0.05).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    has_padj = "tau_padj" in comparison.columns
+    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
+
+    extra_cols = [c for c in ["delta_tau", "tau_padj"] if c in comparison.columns]
+
+    def _hover(sub):
+        parts = [
+            "<b>%{text}</b>",
+            "TauMean A: %{x:.3f}",
+            "TauMean B: %{y:.3f}",
+        ]
+        for i, col in enumerate(extra_cols):
+            if col == "delta_tau":
+                parts.append("Δ tau: %{customdata[" + str(i) + "]:+.3f}")
+            elif col == "tau_padj":
+                parts.append("FDR: %{customdata[" + str(i) + "]:.3g}")
+        return "<br>".join(parts) + "<extra></extra>"
+
+    traces = []
+    for status in _STATUS_ORDER:
+        sub = comparison[comparison["rhythmicity_status"] == status]
+        if sub.empty:
+            continue
+        color = _STATUS_COLORS[status]
+        hovertemplate = _hover(sub)
+
+        if has_padj:
+            sig = sub["tau_padj"] < alpha
+            for mask, name_suffix, size, opacity, show_legend in [
+                (sig, f" (FDR<{alpha})", 7, 0.85, True),
+                (~sig, "", 4, 0.35, not sig.any()),
+            ]:
+                if not mask.any():
+                    continue
+                s = sub[mask]
+                traces.append(
+                    go.Scatter(
+                        x=s["tau_mean_A"],
+                        y=s["tau_mean_B"],
+                        mode="markers",
+                        name=f"{status}{name_suffix}",
+                        text=s.index.tolist(),
+                        customdata=s[extra_cols].values if extra_cols else None,
+                        hovertemplate=hovertemplate,
+                        marker=dict(
+                            color=color,
+                            size=size,
+                            opacity=opacity,
+                            line=dict(width=0.5, color="white") if name_suffix else dict(width=0),
+                        ),
+                        legendgroup=status,
+                        showlegend=show_legend,
+                    )
+                )
+        else:
+            traces.append(
+                go.Scatter(
+                    x=sub["tau_mean_A"],
+                    y=sub["tau_mean_B"],
+                    mode="markers",
+                    name=f"{status} (n={len(sub)})",
+                    text=sub.index.tolist(),
+                    customdata=sub[extra_cols].values if extra_cols else None,
+                    hovertemplate=hovertemplate,
+                    marker=dict(color=color, size=5, opacity=0.7),
+                )
+            )
+
+    traces.append(
+        go.Scatter(
+            x=[0, lim],
+            y=[0, lim],
+            mode="lines",
+            line=dict(color="#999999", dash="dash", width=1),
+            name="y = x",
+            hoverinfo="skip",
+        )
+    )
+
+    fig = go.Figure(traces)
+    fig.update_layout(
+        title=title,
+        xaxis_title="TauMean — condition A",
+        yaxis_title="TauMean — condition B",
+        xaxis=dict(range=[0, lim]),
+        yaxis=dict(range=[0, lim]),
+    )
+    return fig
+
+
+def delta_tau_volcano(
+    comparison,
+    alpha=0.05,
+    title="Rhythmicity change: Δ TauMean vs significance",
+):
+    """Interactive volcano plot of Δ TauMean vs −log₁₀(tau_padj).
+
+    Hover shows gene ID, Δ tau, p-value, condition tau values, and status.
+
+    Requires ``tau_padj`` column.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold drawn as a horizontal reference line (default 0.05).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    if "tau_padj" not in comparison.columns:
+        raise ValueError(
+            "'tau_padj' column missing — run compare_conditions() with result "
+            "DataFrames that include tau_std and n_boots."
+        )
+
+    df = comparison.dropna(subset=["delta_tau", "tau_padj"]).copy()
+    df["_neg_log_p"] = -np.log10(df["tau_padj"].clip(lower=1e-300))
+
+    extra_cols = [c for c in ["tau_mean_A", "tau_mean_B", "tau_padj"] if c in df.columns]
+
+    hover_parts = [
+        "<b>%{text}</b>",
+        "Δ tau: %{x:+.3f}",
+        "−log₁₀(FDR): %{y:.2f}",
+    ]
+    for i, col in enumerate(extra_cols):
+        label = {"tau_mean_A": "TauMean A", "tau_mean_B": "TauMean B", "tau_padj": "FDR"}[col]
+        fmt = ".3f" if col.startswith("tau_mean") else ".3g"
+        hover_parts.append(f"{label}: %{{customdata[{i}]:{fmt}}}")
+    hovertemplate = "<br>".join(hover_parts) + "<extra></extra>"
+
+    traces = []
+    for status in _STATUS_ORDER:
+        sub = df[df["rhythmicity_status"] == status]
+        if sub.empty:
+            continue
+        traces.append(
+            go.Scatter(
+                x=sub["delta_tau"],
+                y=sub["_neg_log_p"],
+                mode="markers",
+                name=status,
+                text=sub.index.tolist(),
+                customdata=sub[extra_cols].values if extra_cols else None,
+                hovertemplate=hovertemplate,
+                marker=dict(color=_STATUS_COLORS[status], size=5, opacity=0.7),
+            )
+        )
+
+    fig = go.Figure(traces)
+    fig.add_hline(
+        y=-np.log10(alpha),
+        line_dash="dash",
+        line_color="#333333",
+        annotation_text=f"FDR = {alpha}",
+        annotation_position="top right",
+    )
+    fig.add_vline(x=0, line_dash="dot", line_color="#999999", opacity=0.5)
+    fig.update_layout(
+        title=title,
+        xaxis_title="Δ TauMean (B − A)",
+        yaxis_title="−log₁₀(tau_padj)",
+    )
+    return fig

--- a/examples/01_classify_and_explore.py
+++ b/examples/01_classify_and_explore.py
@@ -22,7 +22,6 @@ import matplotlib
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
 from circ.simulations import simulate
@@ -64,9 +63,10 @@ print()
 # ---------------------------------------------------------------------------
 # 2. Overview — what did my experiment produce?
 #
-# These three plots answer the first question after any classification run:
-# how are my genes distributed, how do the PIRS scores separate, and does
-# the mean time-series profile for each label look biologically sensible?
+# These four plots answer the first question after any classification run:
+# how are my genes distributed, how do the PIRS scores separate, does the
+# mean time-series profile for each label look biologically sensible, and
+# what does the full expression landscape look like across all labels?
 # ---------------------------------------------------------------------------
 print("Group 1: Overview …")
 
@@ -81,6 +81,19 @@ viz.mean_expression_profiles(expression, result, ax=axes[2])
 
 plt.tight_layout()
 out = FIGURES / "01_overview.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# Clustered expression heatmap — shows the most representative genes per
+# label sorted within each group by hierarchical clustering.  The color
+# strip on the left encodes the expression label.
+print("Group 1b: Expression heatmap …")
+
+fig, ax = plt.subplots(figsize=(8, 7))
+viz.expression_heatmap(expression, result, n_per_label=15, ax=ax)
+plt.tight_layout()
+out = FIGURES / "01b_expression_heatmap.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")
 plt.close(fig)
 print(f"  saved → {out}")

--- a/examples/05_gene_inspection.py
+++ b/examples/05_gene_inspection.py
@@ -26,10 +26,7 @@ import matplotlib
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
-import numpy as np
 import pandas as pd
-import seaborn as sns
 
 from circ.simulations import simulate
 from circ.expression_classification.classify import Classifier
@@ -68,11 +65,6 @@ result = clf.run_all(
 )
 print(result["label"].value_counts().to_string(), "\n")
 
-# Timepoint metadata — reused across all profile plots
-zt_cols    = [c for c in expression.columns if c.startswith(("ZT", "CT"))]
-timepoints = [int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in zt_cols]
-unique_tp  = sorted(set(timepoints))
-
 # ---------------------------------------------------------------------------
 # 2. Select top hits
 # ---------------------------------------------------------------------------
@@ -86,31 +78,6 @@ top_constitutive = const_genes.nsmallest(9, "pirs_score")
 
 print(f"Top 9 rhythmic genes (by TauMean):     {top_rhythmic.index.tolist()}")
 print(f"Top 9 constitutive genes (by PIRS):    {top_constitutive.index.tolist()}\n")
-
-
-# ---------------------------------------------------------------------------
-# Helper — plot one gene's time-series (replicates + mean line)
-# ---------------------------------------------------------------------------
-def _gene_profile(ax, gene_id, color):
-    vals    = expression.loc[gene_id, zt_cols].astype(float).values
-    scatter = ax.scatter(timepoints, vals, color=color, s=14, alpha=0.55, zorder=3)
-    means   = [vals[[i for i, t in enumerate(timepoints) if t == tp]].mean()
-               for tp in unique_tp]
-    ax.plot(unique_tp, means, color=color, lw=1.5, zorder=2)
-
-    row   = result.loc[gene_id]
-    title = gene_id
-    if "tau_mean" in row.index and pd.notna(row["tau_mean"]):
-        title += f"\nτ={row['tau_mean']:.2f}"
-    if "phase_mean" in row.index and pd.notna(row["phase_mean"]):
-        title += f"  φ={row['phase_mean']:.1f} h"
-    if "pirs_score" in row.index and pd.notna(row["pirs_score"]):
-        title += f"\nPIRS={row['pirs_score']:.3f}"
-
-    ax.set_title(title, fontsize=7)
-    ax.set_xlabel("ZT (h)", fontsize=7)
-    ax.tick_params(labelsize=6)
-    sns.despine(ax=ax)
 
 
 # ---------------------------------------------------------------------------
@@ -132,11 +99,13 @@ viz.mean_expression_profiles(expression, result, ax=ax_mean,
 # Right 4 columns (2×4 = 8 panels, but we only have 9 genes; reshape to 3×3)
 # Use a nested gridspec for the gallery
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
-color = LABEL_COLORS["rhythmic"]
 for idx, gene_id in enumerate(top_rhythmic.index):
     r, c = divmod(idx, 3)
     ax   = fig.add_subplot(gs_gallery[r, c])
-    _gene_profile(ax, gene_id, color)
+    viz.gene_profile(expression, gene_id, result, ax=ax)
+    ax.set_title(ax.get_title(), fontsize=7)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=7)
+    ax.tick_params(labelsize=6)
 
 fig.suptitle("Top rhythmic genes — individual profiles (τ ranked)", fontsize=11)
 fig.tight_layout(rect=[0, 0, 1, 0.95])
@@ -164,11 +133,13 @@ viz.mean_expression_profiles(expression, result,
                               title="Mean profile\n(constitutive / variable)")
 
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
-color = LABEL_COLORS["constitutive"]
 for idx, gene_id in enumerate(top_constitutive.index):
     r, c = divmod(idx, 3)
     ax   = fig.add_subplot(gs_gallery[r, c])
-    _gene_profile(ax, gene_id, color)
+    viz.gene_profile(expression, gene_id, result, ax=ax)
+    ax.set_title(ax.get_title(), fontsize=7)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=7)
+    ax.tick_params(labelsize=6)
 
 fig.suptitle("Top constitutive gene candidates — individual profiles (PIRS ranked)",
              fontsize=11)
@@ -179,7 +150,29 @@ plt.close(fig)
 print(f"  saved → {out}")
 
 # ---------------------------------------------------------------------------
-# 5. Annotated decision space
+# 5. Expression heatmap — population-level view grouped by label
+#
+# Complements the individual profile galleries by showing all representative
+# genes in a single heatmap.  Within each label group genes are sorted by
+# hierarchical clustering on their z-scored expression patterns.
+# ---------------------------------------------------------------------------
+print("Section 3: Expression heatmap …")
+
+fig, ax = plt.subplots(figsize=(8, 9))
+viz.expression_heatmap(
+    expression, result,
+    n_per_label=12,
+    ax=ax,
+    title="Clustered expression by label",
+)
+fig.tight_layout()
+out = FIGURES / "23_expression_heatmap.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# ---------------------------------------------------------------------------
+# 6. Annotated decision space
 #
 # Overlays gene-ID labels for the top hits on the pirs_vs_tau plot, so you
 # can see exactly where each candidate sits relative to the decision boundaries.

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -40,11 +40,9 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import numpy as np
 import pandas as pd
-import seaborn as sns
 
 from circ.simulations import simulate
 from circ.expression_classification.classify import Classifier
-from circ.visualization import LABEL_COLORS
 import circ.visualization as viz
 from circ.compare import compare_conditions, label_change_table
 
@@ -124,13 +122,13 @@ print(result_B["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Label distribution comparison …")
 
+xmax = max(
+    result_A["label"].value_counts().max(),
+    result_B["label"].value_counts().max(),
+) * 1.15
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
-viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0])
-viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1])
-
-xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
-axes[0].set_xlim(0, xmax)
-axes[1].set_xlim(0, xmax)
+viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0], xlim=xmax)
+viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1], xlim=xmax)
 
 plt.tight_layout()
 out = FIGURES / "26_label_comparison.png"
@@ -272,46 +270,12 @@ if "phase_padj" in comparison.columns:
 if _HAS_PLOTLY:
     print("\nSection 6: Interactive figure …")
 
-    hover_texts = [
-        f"<b>{g}</b><br>"
-        f"TauMean A: {row['tau_mean_A']:.3f}<br>"
-        f"TauMean B: {row['tau_mean_B']:.3f}<br>"
-        f"Δ tau: {row['delta_tau']:+.3f}<br>"
-        f"{row['rhythmicity_status']}"
-        for g, row in comparison.iterrows()
-    ]
-
-    import plotly.graph_objects as go
-
-    _STATUS_COLORS = {
-        'maintained_rhythmic':    '#6ACC65',
-        'gained':                 '#D65F5F',
-        'lost':                   '#4878CF',
-        'maintained_nonrhythmic': '#CCCCCC',
-    }
-    traces = []
-    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
-    for status, color in _STATUS_COLORS.items():
-        sub  = comparison[comparison["rhythmicity_status"] == status]
-        htxt = [hover_texts[comparison.index.get_loc(g)] for g in sub.index]
-        if sub.empty:
-            continue
-        traces.append(go.Scatter(
-            x=sub["tau_mean_A"], y=sub["tau_mean_B"],
-            mode="markers",
-            name=f"{status} (n={len(sub)})",
-            marker=dict(color=color, size=5, opacity=0.7),
-            hovertext=htxt,
-            hovertemplate="%{hovertext}<extra></extra>",
-        ))
-    traces.append(go.Scatter(
-        x=[0, lim], y=[0, lim], mode="lines",
-        line=dict(color="#999999", dash="dash", width=1),
-        name="y = x", hoverinfo="skip",
-    ))
-    fig_html = go.Figure(traces)
+    fig_html = iviz.rhythmicity_shift_scatter(
+        comparison,
+        title=f"Rhythmicity shift — hover to identify genes<br>"
+              f"{COND_LABELS[0]} → {COND_LABELS[1]}",
+    )
     fig_html.update_layout(
-        title="Rhythmicity shift — hover to identify genes",
         xaxis_title=f"TauMean — {COND_LABELS[0]}",
         yaxis_title=f"TauMean — {COND_LABELS[1]}",
     )

--- a/examples/07_compare_proteomics_vs_expression.py
+++ b/examples/07_compare_proteomics_vs_expression.py
@@ -122,12 +122,13 @@ print(result_rna["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Per-layer label distributions …")
 
+xmax = max(
+    result_prot["label"].value_counts().max(),
+    result_rna["label"].value_counts().max(),
+) * 1.15
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
-viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0])
-viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1])
-xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
-for ax in axes:
-    ax.set_xlim(0, xmax)
+viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0], xlim=xmax)
+viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1], xlim=xmax)
 plt.tight_layout()
 out = FIGURES / "31_layer_label_distributions.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")

--- a/tests/visualization/test_classify_plots.py
+++ b/tests/visualization/test_classify_plots.py
@@ -19,6 +19,8 @@ from circ.visualization.classify import (
     slope_vs_rhythm,
     phase_wheel,
     period_distribution,
+    gene_profile,
+    expression_heatmap,
     classification_summary,
 )
 
@@ -66,6 +68,15 @@ def with_linear(full_clf):
     extra.index = [f'lin{i}' for i in range(10)]
     extra['label'] = 'linear'
     return pd.concat([full_clf, extra])
+
+
+@pytest.fixture
+def expression_df(minimal_clf):
+    """Tiny expression matrix with ZT columns aligned to minimal_clf index."""
+    rng = np.random.default_rng(5)
+    n = len(minimal_clf)
+    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=minimal_clf.index, columns=cols)
 
 
 @pytest.fixture(autouse=True)
@@ -299,13 +310,13 @@ class TestClassificationSummary:
         fig = classification_summary(minimal_clf)
         assert isinstance(fig, plt.Figure)
         # always: label_distribution + pirs_vs_tau + pirs_score_distribution
-        #         + top_constitutive_candidates = 4
-        assert len(fig.axes) == 4
+        #         + top_constitutive_candidates + threshold_sensitivity = 5
+        assert len(fig.axes) == 5
 
     def test_returns_figure_full(self, full_clf):
         fig = classification_summary(full_clf)
         assert isinstance(fig, plt.Figure)
-        assert len(fig.axes) > 4
+        assert len(fig.axes) > 5
 
     def test_saves_to_file(self, full_clf, tmp_path):
         out = str(tmp_path / 'summary.png')
@@ -316,13 +327,132 @@ class TestClassificationSummary:
     def test_minimal_has_correct_panel_count(self, minimal_clf):
         fig = classification_summary(minimal_clf)
         # label_distribution + pirs_vs_tau + pirs_score_distribution
-        # + top_constitutive_candidates = 4
-        assert len(fig.axes) == 4
+        # + top_constitutive_candidates + threshold_sensitivity = 5
+        assert len(fig.axes) == 5
 
     def test_with_emp_p_adds_two_panels(self, minimal_clf):
         df = minimal_clf.copy()
         rng = np.random.default_rng(2)
         df['emp_p'] = rng.uniform(0, 1, len(df))
         fig = classification_summary(df)
-        # 4 base + 2 (volcano + tau_pval_scatter) = 6
-        assert len(fig.axes) == 6
+        # 5 base + 2 (volcano + tau_pval_scatter) = 7
+        assert len(fig.axes) == 7
+
+
+# ---------------------------------------------------------------------------
+# label_distribution xlim
+# ---------------------------------------------------------------------------
+
+class TestLabelDistributionXlim:
+    def test_xlim_applied(self, minimal_clf):
+        ax = label_distribution(minimal_clf, xlim=500)
+        assert ax.get_xlim()[1] == pytest.approx(500)
+
+    def test_xlim_none_leaves_default(self, minimal_clf):
+        ax = label_distribution(minimal_clf)
+        assert ax.get_xlim()[1] != pytest.approx(500)
+
+
+# ---------------------------------------------------------------------------
+# gene_profile
+# ---------------------------------------------------------------------------
+
+class TestGeneProfile:
+    def test_returns_axes(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_accepts_explicit_ax(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        gene = expression_df.index[0]
+        returned = gene_profile(expression_df, gene, minimal_clf, ax=ax)
+        assert returned is ax
+
+    def test_title_contains_gene_id(self, expression_df, minimal_clf):
+        gene = expression_df.index[3]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert gene in ax.get_title()
+
+    def test_custom_title(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf, title="My title")
+        assert ax.get_title() == "My title"
+
+    def test_raises_on_missing_gene(self, expression_df, minimal_clf):
+        with pytest.raises(ValueError, match='not found'):
+            gene_profile(expression_df, 'nonexistent_gene', minimal_clf)
+
+    def test_works_without_classifications(self, expression_df):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_scatter_and_line_drawn(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert len(ax.collections) >= 1   # scatter
+        assert len(ax.lines) >= 1         # mean line
+
+    def test_color_from_label(self, expression_df, minimal_clf):
+        gene = minimal_clf[minimal_clf['label'] == 'rhythmic'].index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        scatter_color = ax.collections[0].get_facecolors()[0][:3]  # RGB only; alpha set by scatter
+        expected = plt.matplotlib.colors.to_rgb(LABEL_COLORS['rhythmic'])
+        np.testing.assert_allclose(scatter_color, expected, atol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# expression_heatmap
+# ---------------------------------------------------------------------------
+
+class TestExpressionHeatmap:
+    def test_returns_axes(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_works_without_classifications(self, expression_df):
+        ax = expression_heatmap(expression_df)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_accepts_explicit_ax(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        returned = expression_heatmap(expression_df, minimal_clf, ax=ax)
+        assert returned is ax
+
+    def test_heatmap_drawn(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf)
+        # imshow produces an AxesImage in ax.images
+        assert len(ax.images) >= 1
+
+    def test_n_per_label_limits_rows(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, n_per_label=3)
+        img = ax.images[0]
+        n_labels = minimal_clf['label'].nunique()
+        assert img.get_array().shape[0] <= 3 * n_labels
+
+    def test_colorbar_present(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, colorbar=True)
+        fig = ax.get_figure()
+        # colorbar creates an extra axes in the figure
+        assert len(fig.axes) >= 2
+
+    def test_no_colorbar(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        expression_heatmap(expression_df, minimal_clf, colorbar=False)
+        fig = ax.get_figure()
+        # label strip adds one extra axes, but no colorbar
+        assert len(fig.axes) <= 2
+
+    def test_custom_title(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, title="My heatmap")
+        assert ax.get_title() == "My heatmap"
+
+    def test_raises_on_no_zt_columns(self, minimal_clf):
+        bad_expr = pd.DataFrame(
+            np.ones((10, 4)),
+            index=minimal_clf.index[:10],
+            columns=['A', 'B', 'C', 'D'],
+        )
+        with pytest.raises(ValueError, match='ZT/CT'):
+            expression_heatmap(bad_expr, minimal_clf)

--- a/tests/visualization/test_interactive.py
+++ b/tests/visualization/test_interactive.py
@@ -22,6 +22,10 @@ from circ.visualization.interactive.benchmarks import (
     classification_pr,
     classification_roc,
 )
+from circ.visualization.interactive.compare import (
+    rhythmicity_shift_scatter,
+    delta_tau_volcano,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -314,3 +318,138 @@ class TestClassificationRoc:
         tc.index = [f'other_{i}' for i in range(len(tc))]
         fig = classification_roc(clf_df, tc)
         assert _is_figure(fig)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared by compare tests
+# ---------------------------------------------------------------------------
+
+def _make_compare_result(rseed=0, with_uncertainty=False, n=80):
+    from circ.compare import compare_conditions
+    rng = np.random.default_rng(rseed)
+    idx = pd.Index([f'gene_{i:04d}' for i in range(n)], name='#')
+    tau   = rng.uniform(0.0, 1.0, n)
+    emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
+    pirs  = rng.uniform(0.0, 2.0, n)
+    phase = rng.uniform(0.0, 24.0, n)
+    labels = np.where(
+        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
+        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+    )
+    df = pd.DataFrame({
+        'tau_mean': tau, 'emp_p': emp_p, 'pirs_score': pirs,
+        'phase_mean': phase, 'label': labels,
+    }, index=idx)
+    if with_uncertainty:
+        df['tau_std']   = rng.uniform(0.05, 0.2, n)
+        df['phase_std'] = rng.uniform(0.5, 2.0, n)
+        df['n_boots']   = 50
+    return df
+
+
+@pytest.fixture
+def comp_basic():
+    from circ.compare import compare_conditions
+    return compare_conditions(_make_compare_result(0), _make_compare_result(1))
+
+
+@pytest.fixture
+def comp_with_uncertainty():
+    from circ.compare import compare_conditions
+    return compare_conditions(
+        _make_compare_result(0, with_uncertainty=True),
+        _make_compare_result(1, with_uncertainty=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# rhythmicity_shift_scatter (interactive)
+# ---------------------------------------------------------------------------
+
+class TestInteractiveRhythmicityShiftScatter:
+    def test_returns_figure(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        assert _is_figure(fig)
+
+    def test_gene_ids_in_hover(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        assert len(all_text) > 0
+
+    def test_diagonal_trace_present(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        line_traces = [t for t in fig.data if t.mode == 'lines']
+        assert len(line_traces) >= 1
+
+    def test_with_padj_splits_sig_nonsig(self, comp_with_uncertainty):
+        fig = rhythmicity_shift_scatter(comp_with_uncertainty)
+        names = [t.name for t in fig.data]
+        assert any('FDR<' in n for n in names)
+
+    def test_custom_title(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic, title='My title')
+        assert fig.layout.title.text == 'My title'
+
+
+# ---------------------------------------------------------------------------
+# delta_tau_volcano (interactive)
+# ---------------------------------------------------------------------------
+
+class TestInteractiveDeltaTauVolcano:
+    def test_returns_figure(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        assert _is_figure(fig)
+
+    def test_gene_ids_in_hover(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        assert len(all_text) > 0
+
+    def test_raises_without_tau_padj(self, comp_basic):
+        assert 'tau_padj' not in comp_basic.columns
+        with pytest.raises(ValueError, match='tau_padj'):
+            delta_tau_volcano(comp_basic)
+
+    def test_hline_present(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        assert len(fig.layout.shapes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# expression_heatmap (interactive)
+# ---------------------------------------------------------------------------
+
+from circ.visualization.interactive.classify import expression_heatmap as iviz_expression_heatmap
+
+
+@pytest.fixture
+def expr_df(clf_df):
+    """Tiny expression matrix aligned to clf_df."""
+    rng = np.random.default_rng(10)
+    n = len(clf_df)
+    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=clf_df.index, columns=cols)
+
+
+class TestInteractiveExpressionHeatmap:
+    def test_returns_figure(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        assert _is_figure(fig)
+
+    def test_heatmap_trace_present(self, expr_df, clf_df):
+        import plotly.graph_objects as go
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        assert any(isinstance(t, go.Heatmap) for t in fig.data)
+
+    def test_gene_ids_in_y(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        heatmap = next(t for t in fig.data if isinstance(t, go.Heatmap))
+        assert len(heatmap.y) > 0
+
+    def test_works_without_classifications(self, expr_df):
+        fig = iviz_expression_heatmap(expr_df)
+        assert _is_figure(fig)
+
+    def test_custom_title(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df, title='My title')
+        assert fig.layout.title.text == 'My title'


### PR DESCRIPTION
## Summary

- **`gene_profile`** — new public plot function in `circ.visualization` that renders a single gene's time-series (all replicates as scatter + per-timepoint mean line), color-coded by classification label and annotated with τ, phase, and PIRS score in the title. Replaces the local `_gene_profile` helper in example 05.
- **`expression_heatmap`** (static + interactive) — clustered heatmap of representative genes grouped by label. Genes are ranked per-label by the most informative score, z-scored across timepoints, and sorted by within-group hierarchical clustering. The static version adds a label color strip via `AxesDivider`; the interactive Plotly version adds hover-over tooltips and a right-axis label annotation bar.
- **`circ.visualization.interactive.compare`** (new module) — `rhythmicity_shift_scatter` and `delta_tau_volcano` Plotly figures extracted from inline code in example 06 into a reusable module, now exposed through `circ.visualization.interactive`.
- **`label_distribution` `xlim` param** — optional fixed upper limit for the x-axis, used in examples 06 and 07 so side-by-side comparison charts share a common scale.
- **`volcano` quadrant labels** — italic corner text annotations labeling the four expression zones (constitutive / variable / noisy_rhythmic / rhythmic).
- **`classification_summary` improvements** — `threshold_sensitivity` is now always included; `slope_pval_scatter` is added whenever slope data is present (not gated on `emp_p`); fixed `has_slope_emp` logic.
- **Internal clean-ups** — `_zt_timepoints` helper extracted and shared across `mean_expression_profiles`, `gene_profile`, and `expression_heatmap`; `_ax` helper deduplicated (benchmarks imports from classify).

## Test plan

- [ ] `poetry run pytest tests/visualization/test_classify_plots.py -v` — new `TestGeneProfile`, `TestExpressionHeatmap`, `TestLabelDistributionXlim`, and updated `TestClassificationSummary` panel-count assertions
- [ ] `poetry run pytest tests/visualization/test_interactive.py -v` — new `TestInteractiveRhythmicityShiftScatter`, `TestInteractiveDeltaTauVolcano`, `TestInteractiveExpressionHeatmap`
- [ ] `poetry run python examples/01_classify_and_explore.py` — check `01b_expression_heatmap.png` is generated
- [ ] `poetry run python examples/05_gene_inspection.py` — check `23_expression_heatmap.png` and individual profile galleries still render correctly
- [ ] `poetry run python examples/06_compare_conditions.py` — verify interactive compare section uses new module functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)