### PR TITLE
Add gene_profile, expression_heatmap, and interactive compare plots

### DIFF
--- a/circ/visualization/__init__.py
+++ b/circ/visualization/__init__.py
@@ -52,6 +52,8 @@ from circ.visualization.classify import (
     phase_amplitude_scatter,
     top_constitutive_candidates,
     mean_expression_profiles,
+    gene_profile,
+    expression_heatmap,
     threshold_sensitivity,
     classification_summary,
 )
@@ -86,6 +88,8 @@ __all__ = [
     "phase_amplitude_scatter",
     "top_constitutive_candidates",
     "mean_expression_profiles",
+    "gene_profile",
+    "expression_heatmap",
     "threshold_sensitivity",
     "classification_summary",
     # compare

--- a/circ/visualization/benchmarks.py
+++ b/circ/visualization/benchmarks.py
@@ -7,7 +7,6 @@ called directly with pre-computed data.
 Metric-only functions (no matplotlib) live in ``circ.evaluation``.
 """
 
-import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.metrics import (
     average_precision_score,
@@ -16,14 +15,7 @@ from sklearn.metrics import (
     auc,
 )
 
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _ax(ax):
-    return ax if ax is not None else plt.subplots()[1]
+from circ.visualization.classify import _ax
 
 
 # ---------------------------------------------------------------------------

--- a/circ/visualization/classify.py
+++ b/circ/visualization/classify.py
@@ -73,7 +73,9 @@ def _zt_timepoints(expression):
     cols = [c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")]
     if not cols:
         raise ValueError("No ZT/CT columns found in expression DataFrame.")
-    tp = np.array([int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in cols])
+    tp = np.array(
+        [int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in cols]
+    )
     return cols, tp, np.sort(np.unique(tp))
 
 
@@ -962,7 +964,9 @@ def classification_summary(
     has_phase = _has(classifications, "phase_mean")
     has_period = _has(classifications, "period_mean")
     has_pval = _has(classifications, "pval") or _has(classifications, "pval_bh")
-    has_slope = _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
+    has_slope = _has(classifications, "slope_pval") or _has(
+        classifications, "slope_pval_bh"
+    )
     has_slope_emp = has_slope and has_emp_p
 
     # Build ordered list of (title, callable) for each panel
@@ -1219,7 +1223,10 @@ def gene_profile(
 
     ax.scatter(timepoints, vals, color=color, s=14, alpha=0.55, zorder=3)
     means = np.array(
-        [vals[[i for i, t in enumerate(timepoints) if t == tp]].mean() for tp in unique_tp]
+        [
+            vals[[i for i, t in enumerate(timepoints) if t == tp]].mean()
+            for tp in unique_tp
+        ]
     )
     ax.plot(unique_tp, means, color=color, lw=1.5, zorder=2)
 
@@ -1247,12 +1254,12 @@ def gene_profile(
 
 # Per-label column and sort direction for representative gene selection
 _LABEL_SELECT_COL = {
-    "constitutive":   ("pirs_score", True),   # ascending PIRS → most stable
-    "rhythmic":       ("tau_mean",   False),  # descending tau → clearest rhythm
-    "noisy_rhythmic": ("tau_mean",   False),
-    "linear":         ("slope_pval", True),   # ascending slope_pval → clearest trend
-    "variable":       ("pirs_score", False),  # descending PIRS → most variable
-    "unclassified":   (None,         True),
+    "constitutive": ("pirs_score", True),  # ascending PIRS → most stable
+    "rhythmic": ("tau_mean", False),  # descending tau → clearest rhythm
+    "noisy_rhythmic": ("tau_mean", False),
+    "linear": ("slope_pval", True),  # ascending slope_pval → clearest trend
+    "variable": ("pirs_score", False),  # descending PIRS → most variable
+    "unclassified": (None, True),
 }
 
 
@@ -1322,7 +1329,9 @@ def expression_heatmap(
     # Average replicates → one value per gene per unique timepoint
     tp_mat = pd.DataFrame(
         {
-            int(tp): expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1)
+            int(tp): expression[
+                [c for c, t in zip(zt_cols, timepoints) if t == tp]
+            ].mean(axis=1)
             for tp in unique_tp
         },
         index=expression.index,
@@ -1380,8 +1389,15 @@ def expression_heatmap(
 
     if not ordered_genes:
         ax.set_title(title)
-        ax.text(0.5, 0.5, "No genes to display", transform=ax.transAxes,
-                ha="center", va="center", color="#888888")
+        ax.text(
+            0.5,
+            0.5,
+            "No genes to display",
+            transform=ax.transAxes,
+            ha="center",
+            va="center",
+            color="#888888",
+        )
         return ax
 
     mat = tp_mat.loc[ordered_genes].values
@@ -1414,7 +1430,7 @@ def expression_heatmap(
     # White lines between label groups
     if gene_label_list is not None:
         boundary = 0
-        for lbl in (labels or []):
+        for lbl in labels or []:
             cnt = gene_label_list.count(lbl)
             boundary += cnt
             if 0 < boundary < n_genes:
@@ -1442,8 +1458,10 @@ def expression_heatmap(
     if gene_label_list is not None:
         cax_strip = divider.append_axes("left", size="4%", pad=0.05)
         rgb = np.array(
-            [plt.matplotlib.colors.to_rgb(LABEL_COLORS.get(l, "#8C8C8C"))
-             for l in gene_label_list],
+            [
+                plt.matplotlib.colors.to_rgb(LABEL_COLORS.get(l, "#8C8C8C"))
+                for l in gene_label_list
+            ],
             dtype=float,
         ).reshape(n_genes, 1, 3)
         cax_strip.imshow(rgb, aspect="auto", interpolation="nearest")

--- a/circ/visualization/classify.py
+++ b/circ/visualization/classify.py
@@ -36,7 +36,7 @@ def _ax(ax):
 
 
 def _safe_neglog10(series, floor=1e-300):
-    return -np.log10(np.maximum(series.clip(lower=floor), floor))
+    return -np.log10(np.maximum(series, floor))
 
 
 def _has(df, col):
@@ -68,6 +68,15 @@ def _label_legend(present, ax):
         ax.legend(handles=patches, loc="best", frameon=False, fontsize=9)
 
 
+def _zt_timepoints(expression):
+    """Return (zt_cols, timepoints_array, unique_tp_array) for an expression DataFrame."""
+    cols = [c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")]
+    if not cols:
+        raise ValueError("No ZT/CT columns found in expression DataFrame.")
+    tp = np.array([int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in cols])
+    return cols, tp, np.sort(np.unique(tp))
+
+
 def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
     """Set axis limits to data percentiles so outliers don't compress the view."""
     x = x_series.dropna()
@@ -87,7 +96,9 @@ def _clip_axes_to_data(ax, x_series, y_series, x_pct=(1, 99), y_pct=(0, 99)):
 # ---------------------------------------------------------------------------
 
 
-def label_distribution(classifications, ax=None, title="Expression label counts"):
+def label_distribution(
+    classifications, ax=None, title="Expression label counts", xlim=None
+):
     """Horizontal bar chart of gene counts per expression label.
 
     Parameters
@@ -96,6 +107,14 @@ def label_distribution(classifications, ax=None, title="Expression label counts"
         Output of ``Classifier.classify()``.
     ax : matplotlib.axes.Axes, optional
     title : str, optional
+    xlim : float or None
+        If provided, fix the x-axis upper limit to this value.  Useful when
+        placing two side-by-side distribution charts on a shared scale::
+
+            xmax = max(result_A["label"].value_counts().max(),
+                       result_B["label"].value_counts().max()) * 1.15
+            viz.label_distribution(result_A, ax=axes[0], xlim=xmax)
+            viz.label_distribution(result_B, ax=axes[1], xlim=xmax)
 
     Returns
     -------
@@ -112,6 +131,8 @@ def label_distribution(classifications, ax=None, title="Expression label counts"
     ax.set_xlabel("Gene count")
     ax.set_title(title)
     ax.invert_yaxis()
+    if xlim is not None:
+        ax.set_xlim(0, xlim)
     sns.despine(ax=ax, left=True)
     return ax
 
@@ -231,6 +252,11 @@ def volcano(
         label=f"PIRS p{int(pirs_percentile)}",
     )
     _clip_axes_to_data(ax, df["pirs_score"], df["neg_log_emp_p"])
+    _qstyle = dict(transform=ax.transAxes, fontsize=7, color="#AAAAAA", style="italic")
+    ax.text(0.02, 0.04, "constitutive", va="bottom", ha="left", **_qstyle)
+    ax.text(0.98, 0.04, "variable", va="bottom", ha="right", **_qstyle)
+    ax.text(0.02, 0.96, "noisy_rhythmic", va="top", ha="left", **_qstyle)
+    ax.text(0.98, 0.96, "rhythmic", va="top", ha="right", **_qstyle)
     ax.set_xlabel("PIRS score")
     ax.set_ylabel("−log₁₀(GammaBH)")
     ax.set_title(title)
@@ -609,7 +635,7 @@ def phase_wheel(
         width=widths,
         align="edge",
         alpha=0.7,
-        color="#6ACC65",
+        color=LABEL_COLORS["rhythmic"],
         edgecolor="white",
     )
 
@@ -936,9 +962,8 @@ def classification_summary(
     has_phase = _has(classifications, "phase_mean")
     has_period = _has(classifications, "period_mean")
     has_pval = _has(classifications, "pval") or _has(classifications, "pval_bh")
-    has_slope_emp = (
-        _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
-    ) and has_emp_p
+    has_slope = _has(classifications, "slope_pval") or _has(classifications, "slope_pval_bh")
+    has_slope_emp = has_slope and has_emp_p
 
     # Build ordered list of (title, callable) for each panel
     panels = [
@@ -961,6 +986,12 @@ def classification_summary(
         (
             "top_constitutive_candidates",
             lambda ax: top_constitutive_candidates(
+                classifications, pirs_percentile=pirs_percentile, ax=ax
+            ),
+        ),
+        (
+            "threshold_sensitivity",
+            lambda ax: threshold_sensitivity(
                 classifications, pirs_percentile=pirs_percentile, ax=ax
             ),
         ),
@@ -989,6 +1020,18 @@ def classification_summary(
     if has_pval:
         panels.append(
             ("pirs_pval_scatter", lambda ax: pirs_pval_scatter(classifications, ax=ax))
+        )
+    if has_slope:
+        panels.append(
+            (
+                "slope_pval_scatter",
+                lambda ax: slope_pval_scatter(
+                    classifications,
+                    slope_pval_threshold=slope_pval_threshold,
+                    pirs_percentile=pirs_percentile,
+                    ax=ax,
+                ),
+            )
         )
     if has_slope_emp:
         panels.append(
@@ -1070,17 +1113,7 @@ def mean_expression_profiles(
     """
     ax = _ax(ax)
 
-    zt_cols = [
-        c for c in expression.columns if c.startswith("ZT") or c.startswith("CT")
-    ]
-    if not zt_cols:
-        raise ValueError("No ZT/CT columns found in expression DataFrame.")
-
-    def _parse_zt(col):
-        return int(col.replace("ZT", "").replace("CT", "").split("_")[0])
-
-    timepoints = np.array([_parse_zt(c) for c in zt_cols])
-    unique_tp = np.sort(np.unique(timepoints))
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
 
     # Average replicates → one value per gene per unique timepoint
     tp_means = pd.DataFrame(
@@ -1128,6 +1161,300 @@ def mean_expression_profiles(
     ax.set_title(title)
     ax.legend(frameon=False, fontsize=9)
     sns.despine(ax=ax)
+    return ax
+
+
+def gene_profile(
+    expression,
+    gene_id,
+    classifications=None,
+    color=None,
+    ax=None,
+    title=None,
+):
+    """Time-series profile for a single gene.
+
+    Scatter-plots all replicate sample values with the per-timepoint mean as
+    a line.  When *classifications* is provided the color is derived from the
+    gene's label and the title is annotated with τ, phase, and PIRS score.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns.
+    gene_id : str
+        Row label in *expression*.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``, indexed by the same gene IDs.
+        Used to determine label color and to annotate the title with scores.
+    color : str, optional
+        Point/line color.  Derived from the label in *classifications* when
+        omitted; falls back to ``LABEL_COLORS['constitutive']``.
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+        Defaults to *gene_id* with score annotations appended.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    ax = _ax(ax)
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    if gene_id not in expression.index:
+        raise ValueError(f"{gene_id!r} not found in expression index.")
+
+    vals = expression.loc[gene_id, zt_cols].astype(float).values
+
+    if color is None:
+        if classifications is not None and gene_id in classifications.index:
+            lbl = (
+                classifications.at[gene_id, "label"]
+                if "label" in classifications.columns
+                else None
+            )
+            color = LABEL_COLORS.get(lbl, "#8C8C8C")
+        else:
+            color = LABEL_COLORS["constitutive"]
+
+    ax.scatter(timepoints, vals, color=color, s=14, alpha=0.55, zorder=3)
+    means = np.array(
+        [vals[[i for i, t in enumerate(timepoints) if t == tp]].mean() for tp in unique_tp]
+    )
+    ax.plot(unique_tp, means, color=color, lw=1.5, zorder=2)
+
+    if title is None:
+        title = gene_id
+        if classifications is not None and gene_id in classifications.index:
+            row = classifications.loc[gene_id]
+            parts = []
+            if "tau_mean" in row.index and pd.notna(row["tau_mean"]):
+                parts.append(f"τ={row['tau_mean']:.2f}")
+            if "phase_mean" in row.index and pd.notna(row["phase_mean"]):
+                parts.append(f"φ={row['phase_mean']:.1f}h")
+            if parts:
+                title += "\n" + "  ".join(parts)
+            if "pirs_score" in row.index and pd.notna(row["pirs_score"]):
+                title += f"\nPIRS={row['pirs_score']:.3f}"
+
+    ax.set_title(title)
+    ax.set_xlabel("ZT (h)")
+    ax.set_ylabel("Expression")
+    ax.set_xticks(unique_tp)
+    sns.despine(ax=ax)
+    return ax
+
+
+# Per-label column and sort direction for representative gene selection
+_LABEL_SELECT_COL = {
+    "constitutive":   ("pirs_score", True),   # ascending PIRS → most stable
+    "rhythmic":       ("tau_mean",   False),  # descending tau → clearest rhythm
+    "noisy_rhythmic": ("tau_mean",   False),
+    "linear":         ("slope_pval", True),   # ascending slope_pval → clearest trend
+    "variable":       ("pirs_score", False),  # descending PIRS → most variable
+    "unclassified":   (None,         True),
+}
+
+
+def expression_heatmap(
+    expression,
+    classifications=None,
+    labels=None,
+    n_per_label=20,
+    z_score=True,
+    method="ward",
+    cmap="RdBu_r",
+    show_gene_labels=None,
+    colorbar=True,
+    ax=None,
+    title="Expression heatmap",
+):
+    """Clustered heatmap of gene expression grouped by label.
+
+    Genes are subsampled per label (most representative first), z-scored
+    across timepoints, and sorted by within-group hierarchical clustering.
+    A narrow color strip on the left side encodes the expression label.
+    White lines separate label groups.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns, indexed by
+        gene ID.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``.  When provided, genes are
+        grouped and color-coded by label.  If omitted, all genes are
+        clustered together.
+    labels : list of str, optional
+        Labels to include, in display order.  Defaults to all labels in
+        ``_LABEL_ORDER`` present in *classifications*.
+    n_per_label : int
+        Maximum genes per label.  Genes are ranked by the most
+        informative score for each label (lowest PIRS for constitutive,
+        highest TauMean for rhythmic, etc.).  Default 20.
+    z_score : bool
+        Z-score each gene across its timepoint means before plotting
+        (default True).
+    method : str
+        Linkage method for within-group hierarchical clustering
+        (default ``'ward'``).
+    cmap : str
+        Matplotlib colormap name (default ``'RdBu_r'``).
+    show_gene_labels : bool or None
+        Whether to draw gene-ID tick labels.  Auto-detects: shown when
+        ≤ 40 genes, hidden otherwise.
+    colorbar : bool
+        Draw a colorbar for the z-score scale (default True).
+    ax : matplotlib.axes.Axes, optional
+    title : str, optional
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The main heatmap axes.
+    """
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+    from scipy.cluster.hierarchy import linkage, leaves_list
+
+    ax = _ax(ax)
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    # Average replicates → one value per gene per unique timepoint
+    tp_mat = pd.DataFrame(
+        {
+            int(tp): expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1)
+            for tp in unique_tp
+        },
+        index=expression.index,
+    ).astype(float)
+
+    # -----------------------------------------------------------------------
+    # Gene selection and ordering
+    # -----------------------------------------------------------------------
+    if classifications is not None:
+        common = tp_mat.index.intersection(classifications.index)
+        tp_mat = tp_mat.loc[common]
+        clf = classifications.loc[common]
+
+        if labels is None:
+            labels = [l for l in _LABEL_ORDER if l in clf["label"].values]
+
+        ordered_genes: list = []
+        gene_label_list: list = []
+
+        for lbl in labels:
+            mask = clf["label"] == lbl
+            genes = clf[mask].index.tolist()
+            if not genes:
+                continue
+
+            n = min(n_per_label, len(genes))
+            col, ascending = _LABEL_SELECT_COL.get(lbl, ("pirs_score", True))
+            if col and col in clf.columns and clf[col].notna().any():
+                ranked = clf.loc[genes, col].dropna()
+                genes = (
+                    ranked.nsmallest(n) if ascending else ranked.nlargest(n)
+                ).index.tolist()
+            else:
+                genes = genes[:n]
+
+            sub = tp_mat.loc[genes].values
+            if len(sub) > 2:
+                order = leaves_list(linkage(sub, method=method))
+                genes = [genes[i] for i in order]
+
+            ordered_genes.extend(genes)
+            gene_label_list.extend([lbl] * len(genes))
+    else:
+        max_genes = n_per_label * len(_LABEL_ORDER)
+        genes = tp_mat.index.tolist()
+        if len(genes) > max_genes:
+            step = max(1, len(genes) // max_genes)
+            genes = genes[::step][:max_genes]
+        sub = tp_mat.loc[genes].values
+        if len(sub) > 2:
+            order = leaves_list(linkage(sub, method=method))
+            genes = [genes[i] for i in order]
+        ordered_genes = genes
+        gene_label_list = None
+
+    if not ordered_genes:
+        ax.set_title(title)
+        ax.text(0.5, 0.5, "No genes to display", transform=ax.transAxes,
+                ha="center", va="center", color="#888888")
+        return ax
+
+    mat = tp_mat.loc[ordered_genes].values
+    n_genes, n_tp = mat.shape
+
+    # -----------------------------------------------------------------------
+    # Z-score each gene
+    # -----------------------------------------------------------------------
+    if z_score:
+        row_mean = mat.mean(axis=1, keepdims=True)
+        row_std = mat.std(axis=1, keepdims=True)
+        row_std[row_std == 0] = 1.0
+        mat = (mat - row_mean) / row_std
+
+    vmax = float(np.nanpercentile(np.abs(mat), 99))
+    vmax = max(vmax, 0.5)
+
+    # -----------------------------------------------------------------------
+    # Draw heatmap
+    # -----------------------------------------------------------------------
+    im = ax.imshow(
+        mat,
+        aspect="auto",
+        cmap=cmap,
+        vmin=-vmax,
+        vmax=vmax,
+        interpolation="nearest",
+    )
+
+    # White lines between label groups
+    if gene_label_list is not None:
+        boundary = 0
+        for lbl in (labels or []):
+            cnt = gene_label_list.count(lbl)
+            boundary += cnt
+            if 0 < boundary < n_genes:
+                ax.axhline(boundary - 0.5, color="white", lw=1.2)
+
+    # X-axis: unique timepoints
+    ax.set_xticks(range(n_tp))
+    ax.set_xticklabels([f"ZT{int(tp):02d}" for tp in unique_tp], fontsize=8)
+
+    # Y-axis: gene IDs (auto-hide above threshold)
+    show_labels = show_gene_labels if show_gene_labels is not None else (n_genes <= 40)
+    if show_labels:
+        ax.set_yticks(range(n_genes))
+        ax.set_yticklabels(ordered_genes, fontsize=7)
+    else:
+        ax.set_yticks([])
+
+    ax.set_title(title)
+
+    # -----------------------------------------------------------------------
+    # Label color strip and colorbar via AxesDivider
+    # -----------------------------------------------------------------------
+    divider = make_axes_locatable(ax)
+
+    if gene_label_list is not None:
+        cax_strip = divider.append_axes("left", size="4%", pad=0.05)
+        rgb = np.array(
+            [plt.matplotlib.colors.to_rgb(LABEL_COLORS.get(l, "#8C8C8C"))
+             for l in gene_label_list],
+            dtype=float,
+        ).reshape(n_genes, 1, 3)
+        cax_strip.imshow(rgb, aspect="auto", interpolation="nearest")
+        cax_strip.set_xticks([])
+        cax_strip.set_yticks([])
+
+    if colorbar:
+        cax_cb = divider.append_axes("right", size="4%", pad=0.08)
+        cb = plt.colorbar(im, cax=cax_cb)
+        cb.set_label("z-score" if z_score else "expression", fontsize=8)
+
     return ax
 
 

--- a/circ/visualization/interactive/__init__.py
+++ b/circ/visualization/interactive/__init__.py
@@ -46,12 +46,17 @@ from circ.visualization.interactive.classify import (
     phase_wheel,
     period_distribution,
     phase_amplitude_scatter,
+    expression_heatmap,
     top_constitutive_candidates,
     classification_summary,
 )
 from circ.visualization.interactive.benchmarks import (
     classification_pr,
     classification_roc,
+)
+from circ.visualization.interactive.compare import (
+    rhythmicity_shift_scatter,
+    delta_tau_volcano,
 )
 
 __all__ = [
@@ -66,8 +71,11 @@ __all__ = [
     "phase_wheel",
     "period_distribution",
     "phase_amplitude_scatter",
+    "expression_heatmap",
     "top_constitutive_candidates",
     "classification_summary",
     "classification_pr",
     "classification_roc",
+    "rhythmicity_shift_scatter",
+    "delta_tau_volcano",
 ]

--- a/circ/visualization/interactive/classify.py
+++ b/circ/visualization/interactive/classify.py
@@ -544,10 +544,14 @@ def expression_heatmap(
 
     zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
 
-    tp_mat = np.array([
-        expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1).values
-        for tp in unique_tp
-    ]).T  # shape (n_genes, n_tp)
+    tp_mat = np.array(
+        [
+            expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]]
+            .mean(axis=1)
+            .values
+            for tp in unique_tp
+        ]
+    ).T  # shape (n_genes, n_tp)
     gene_index = expression.index.tolist()
 
     if classifications is not None:
@@ -570,7 +574,9 @@ def expression_heatmap(
             col, ascending = _LABEL_SELECT_COL.get(lbl, ("pirs_score", True))
             if col and col in clf.columns and clf[col].notna().any():
                 ranked = clf.loc[genes, col].dropna()
-                genes = (ranked.nsmallest(n) if ascending else ranked.nlargest(n)).index.tolist()
+                genes = (
+                    ranked.nsmallest(n) if ascending else ranked.nlargest(n)
+                ).index.tolist()
             else:
                 genes = genes[:n]
 
@@ -613,13 +619,15 @@ def expression_heatmap(
     x_labels = [f"ZT{int(tp):02d}" for tp in unique_tp]
 
     # Build hover text matrix
-    hover = np.array([
+    hover = np.array(
         [
-            f"<b>{gene}</b><br>ZT: {x_labels[j]}<br>z-score: {mat[i, j]:.2f}"
-            for j in range(mat.shape[1])
+            [
+                f"<b>{gene}</b><br>ZT: {x_labels[j]}<br>z-score: {mat[i, j]:.2f}"
+                for j in range(mat.shape[1])
+            ]
+            for i, gene in enumerate(ordered_genes)
         ]
-        for i, gene in enumerate(ordered_genes)
-    ])
+    )
 
     fig = go.Figure(
         go.Heatmap(
@@ -638,8 +646,10 @@ def expression_heatmap(
 
     # Label color annotation traces on the right y-axis (as a thin bar)
     if gene_label_list is not None:
-        fig.update_layout(yaxis2=dict(overlaying="y", side="right", showticklabels=False))
-        for lbl in (labels or []):
+        fig.update_layout(
+            yaxis2=dict(overlaying="y", side="right", showticklabels=False)
+        )
+        for lbl in labels or []:
             idxs = [i for i, l in enumerate(gene_label_list) if l == lbl]
             if not idxs:
                 continue

--- a/circ/visualization/interactive/classify.py
+++ b/circ/visualization/interactive/classify.py
@@ -499,6 +499,175 @@ def phase_amplitude_scatter(
     return fig
 
 
+def expression_heatmap(
+    expression,
+    classifications=None,
+    labels=None,
+    n_per_label=20,
+    z_score=True,
+    method="ward",
+    title="Expression heatmap",
+):
+    """Interactive clustered heatmap of gene expression grouped by label.
+
+    Hover over any cell to see the gene ID, timepoint, and z-score value.
+    Genes are subsampled per label, z-scored, and sorted by within-group
+    hierarchical clustering.  A label color annotation trace is drawn on
+    the right y-axis.
+
+    Parameters
+    ----------
+    expression : pd.DataFrame
+        Expression matrix with ZT/CT-prefixed sample columns.
+    classifications : pd.DataFrame, optional
+        Output of ``Classifier.classify()``.
+    labels : list of str, optional
+    n_per_label : int
+        Maximum genes per label (default 20).
+    z_score : bool
+        Z-score each gene before plotting (default True).
+    method : str
+        Linkage method for clustering (default ``'ward'``).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    from circ.visualization.classify import (
+        _zt_timepoints,
+        _LABEL_ORDER,
+        _LABEL_SELECT_COL,
+        LABEL_COLORS,
+    )
+    from scipy.cluster.hierarchy import linkage, leaves_list
+
+    zt_cols, timepoints, unique_tp = _zt_timepoints(expression)
+
+    tp_mat = np.array([
+        expression[[c for c, t in zip(zt_cols, timepoints) if t == tp]].mean(axis=1).values
+        for tp in unique_tp
+    ]).T  # shape (n_genes, n_tp)
+    gene_index = expression.index.tolist()
+
+    if classifications is not None:
+        common = [g for g in gene_index if g in classifications.index]
+        clf = classifications.loc[common]
+        mat_sub = tp_mat[[gene_index.index(g) for g in common], :]
+        gene_index = common
+
+        if labels is None:
+            labels = [l for l in _LABEL_ORDER if l in clf["label"].values]
+
+        ordered_genes: list = []
+        gene_label_list: list = []
+
+        for lbl in labels:
+            genes = clf[clf["label"] == lbl].index.tolist()
+            if not genes:
+                continue
+            n = min(n_per_label, len(genes))
+            col, ascending = _LABEL_SELECT_COL.get(lbl, ("pirs_score", True))
+            if col and col in clf.columns and clf[col].notna().any():
+                ranked = clf.loc[genes, col].dropna()
+                genes = (ranked.nsmallest(n) if ascending else ranked.nlargest(n)).index.tolist()
+            else:
+                genes = genes[:n]
+
+            idx_in_sub = [common.index(g) for g in genes]
+            sub = mat_sub[idx_in_sub, :]
+            if len(sub) > 2:
+                order = leaves_list(linkage(sub, method=method))
+                genes = [genes[i] for i in order]
+
+            ordered_genes.extend(genes)
+            gene_label_list.extend([lbl] * len(genes))
+
+        final_idx = [common.index(g) for g in ordered_genes]
+        mat = mat_sub[final_idx, :]
+    else:
+        max_genes = n_per_label * len(_LABEL_ORDER)
+        if len(gene_index) > max_genes:
+            step = max(1, len(gene_index) // max_genes)
+            gene_index = gene_index[::step][:max_genes]
+            tp_mat = tp_mat[[expression.index.tolist().index(g) for g in gene_index], :]
+        if len(gene_index) > 2:
+            order = leaves_list(linkage(tp_mat.astype(float), method=method))
+            gene_index = [gene_index[i] for i in order]
+            tp_mat = tp_mat[order, :]
+        ordered_genes = gene_index
+        gene_label_list = None
+        mat = tp_mat
+
+    mat = mat.astype(float)
+
+    if z_score:
+        row_mean = mat.mean(axis=1, keepdims=True)
+        row_std = mat.std(axis=1, keepdims=True)
+        row_std[row_std == 0] = 1.0
+        mat = (mat - row_mean) / row_std
+
+    vmax = float(np.percentile(np.abs(mat), 99))
+    vmax = max(vmax, 0.5)
+
+    x_labels = [f"ZT{int(tp):02d}" for tp in unique_tp]
+
+    # Build hover text matrix
+    hover = np.array([
+        [
+            f"<b>{gene}</b><br>ZT: {x_labels[j]}<br>z-score: {mat[i, j]:.2f}"
+            for j in range(mat.shape[1])
+        ]
+        for i, gene in enumerate(ordered_genes)
+    ])
+
+    fig = go.Figure(
+        go.Heatmap(
+            z=mat,
+            x=x_labels,
+            y=ordered_genes,
+            colorscale="RdBu",
+            reversescale=True,
+            zmin=-vmax,
+            zmax=vmax,
+            text=hover,
+            hovertemplate="%{text}<extra></extra>",
+            colorbar=dict(title="z-score" if z_score else "expression"),
+        )
+    )
+
+    # Label color annotation traces on the right y-axis (as a thin bar)
+    if gene_label_list is not None:
+        fig.update_layout(yaxis2=dict(overlaying="y", side="right", showticklabels=False))
+        for lbl in (labels or []):
+            idxs = [i for i, l in enumerate(gene_label_list) if l == lbl]
+            if not idxs:
+                continue
+            fig.add_trace(
+                go.Bar(
+                    x=[0.5] * len(idxs),
+                    y=[ordered_genes[i] for i in idxs],
+                    orientation="h",
+                    name=lbl,
+                    marker_color=LABEL_COLORS.get(lbl, "#8C8C8C"),
+                    width=0.9,
+                    yaxis="y2",
+                    showlegend=True,
+                    hovertemplate=f"label: {lbl}<extra></extra>",
+                    visible=True,
+                )
+            )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title="Timepoint",
+        yaxis_title="Gene",
+        yaxis=dict(autorange="reversed"),
+        height=max(400, len(ordered_genes) * 14 + 100),
+    )
+    return fig
+
+
 def top_constitutive_candidates(
     classifications,
     n_top=20,

--- a/circ/visualization/interactive/compare.py
+++ b/circ/visualization/interactive/compare.py
@@ -1,0 +1,200 @@
+"""Interactive (Plotly) visualizations for condition comparison results."""
+
+import numpy as np
+import plotly.graph_objects as go
+
+from circ.visualization.compare import _STATUS_COLORS, _STATUS_ORDER
+
+
+def rhythmicity_shift_scatter(
+    comparison,
+    alpha=0.05,
+    title="Rhythmicity shift: TauMean per condition",
+):
+    """Interactive scatter of tau_mean_A vs tau_mean_B, colored by status.
+
+    Each point is a shared gene.  Hover shows gene ID, tau values, Δ tau,
+    rhythmicity status, and FDR p-value when available.  When ``tau_padj``
+    is present, significant genes (padj < *alpha*) are drawn larger and
+    more opaque than the non-significant background.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold for distinguishing significant genes (default 0.05).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    has_padj = "tau_padj" in comparison.columns
+    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
+
+    extra_cols = [c for c in ["delta_tau", "tau_padj"] if c in comparison.columns]
+
+    def _hover(sub):
+        parts = [
+            "<b>%{text}</b>",
+            "TauMean A: %{x:.3f}",
+            "TauMean B: %{y:.3f}",
+        ]
+        for i, col in enumerate(extra_cols):
+            if col == "delta_tau":
+                parts.append("Δ tau: %{customdata[" + str(i) + "]:+.3f}")
+            elif col == "tau_padj":
+                parts.append("FDR: %{customdata[" + str(i) + "]:.3g}")
+        return "<br>".join(parts) + "<extra></extra>"
+
+    traces = []
+    for status in _STATUS_ORDER:
+        sub = comparison[comparison["rhythmicity_status"] == status]
+        if sub.empty:
+            continue
+        color = _STATUS_COLORS[status]
+        hovertemplate = _hover(sub)
+
+        if has_padj:
+            sig = sub["tau_padj"] < alpha
+            for mask, name_suffix, size, opacity, show_legend in [
+                (sig, f" (FDR<{alpha})", 7, 0.85, True),
+                (~sig, "", 4, 0.35, not sig.any()),
+            ]:
+                if not mask.any():
+                    continue
+                s = sub[mask]
+                traces.append(
+                    go.Scatter(
+                        x=s["tau_mean_A"],
+                        y=s["tau_mean_B"],
+                        mode="markers",
+                        name=f"{status}{name_suffix}",
+                        text=s.index.tolist(),
+                        customdata=s[extra_cols].values if extra_cols else None,
+                        hovertemplate=hovertemplate,
+                        marker=dict(
+                            color=color,
+                            size=size,
+                            opacity=opacity,
+                            line=dict(width=0.5, color="white") if name_suffix else dict(width=0),
+                        ),
+                        legendgroup=status,
+                        showlegend=show_legend,
+                    )
+                )
+        else:
+            traces.append(
+                go.Scatter(
+                    x=sub["tau_mean_A"],
+                    y=sub["tau_mean_B"],
+                    mode="markers",
+                    name=f"{status} (n={len(sub)})",
+                    text=sub.index.tolist(),
+                    customdata=sub[extra_cols].values if extra_cols else None,
+                    hovertemplate=hovertemplate,
+                    marker=dict(color=color, size=5, opacity=0.7),
+                )
+            )
+
+    traces.append(
+        go.Scatter(
+            x=[0, lim],
+            y=[0, lim],
+            mode="lines",
+            line=dict(color="#999999", dash="dash", width=1),
+            name="y = x",
+            hoverinfo="skip",
+        )
+    )
+
+    fig = go.Figure(traces)
+    fig.update_layout(
+        title=title,
+        xaxis_title="TauMean — condition A",
+        yaxis_title="TauMean — condition B",
+        xaxis=dict(range=[0, lim]),
+        yaxis=dict(range=[0, lim]),
+    )
+    return fig
+
+
+def delta_tau_volcano(
+    comparison,
+    alpha=0.05,
+    title="Rhythmicity change: Δ TauMean vs significance",
+):
+    """Interactive volcano plot of Δ TauMean vs −log₁₀(tau_padj).
+
+    Hover shows gene ID, Δ tau, p-value, condition tau values, and status.
+
+    Requires ``tau_padj`` column.
+
+    Parameters
+    ----------
+    comparison : pd.DataFrame
+        Output of :func:`~circ.compare.compare_conditions`.
+    alpha : float
+        FDR threshold drawn as a horizontal reference line (default 0.05).
+    title : str, optional
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    if "tau_padj" not in comparison.columns:
+        raise ValueError(
+            "'tau_padj' column missing — run compare_conditions() with result "
+            "DataFrames that include tau_std and n_boots."
+        )
+
+    df = comparison.dropna(subset=["delta_tau", "tau_padj"]).copy()
+    df["_neg_log_p"] = -np.log10(df["tau_padj"].clip(lower=1e-300))
+
+    extra_cols = [c for c in ["tau_mean_A", "tau_mean_B", "tau_padj"] if c in df.columns]
+
+    hover_parts = [
+        "<b>%{text}</b>",
+        "Δ tau: %{x:+.3f}",
+        "−log₁₀(FDR): %{y:.2f}",
+    ]
+    for i, col in enumerate(extra_cols):
+        label = {"tau_mean_A": "TauMean A", "tau_mean_B": "TauMean B", "tau_padj": "FDR"}[col]
+        fmt = ".3f" if col.startswith("tau_mean") else ".3g"
+        hover_parts.append(f"{label}: %{{customdata[{i}]:{fmt}}}")
+    hovertemplate = "<br>".join(hover_parts) + "<extra></extra>"
+
+    traces = []
+    for status in _STATUS_ORDER:
+        sub = df[df["rhythmicity_status"] == status]
+        if sub.empty:
+            continue
+        traces.append(
+            go.Scatter(
+                x=sub["delta_tau"],
+                y=sub["_neg_log_p"],
+                mode="markers",
+                name=status,
+                text=sub.index.tolist(),
+                customdata=sub[extra_cols].values if extra_cols else None,
+                hovertemplate=hovertemplate,
+                marker=dict(color=_STATUS_COLORS[status], size=5, opacity=0.7),
+            )
+        )
+
+    fig = go.Figure(traces)
+    fig.add_hline(
+        y=-np.log10(alpha),
+        line_dash="dash",
+        line_color="#333333",
+        annotation_text=f"FDR = {alpha}",
+        annotation_position="top right",
+    )
+    fig.add_vline(x=0, line_dash="dot", line_color="#999999", opacity=0.5)
+    fig.update_layout(
+        title=title,
+        xaxis_title="Δ TauMean (B − A)",
+        yaxis_title="−log₁₀(tau_padj)",
+    )
+    return fig

--- a/circ/visualization/interactive/compare.py
+++ b/circ/visualization/interactive/compare.py
@@ -78,7 +78,9 @@ def rhythmicity_shift_scatter(
                             color=color,
                             size=size,
                             opacity=opacity,
-                            line=dict(width=0.5, color="white") if name_suffix else dict(width=0),
+                            line=dict(width=0.5, color="white")
+                            if name_suffix
+                            else dict(width=0),
                         ),
                         legendgroup=status,
                         showlegend=show_legend,
@@ -152,7 +154,9 @@ def delta_tau_volcano(
     df = comparison.dropna(subset=["delta_tau", "tau_padj"]).copy()
     df["_neg_log_p"] = -np.log10(df["tau_padj"].clip(lower=1e-300))
 
-    extra_cols = [c for c in ["tau_mean_A", "tau_mean_B", "tau_padj"] if c in df.columns]
+    extra_cols = [
+        c for c in ["tau_mean_A", "tau_mean_B", "tau_padj"] if c in df.columns
+    ]
 
     hover_parts = [
         "<b>%{text}</b>",
@@ -160,7 +164,11 @@ def delta_tau_volcano(
         "−log₁₀(FDR): %{y:.2f}",
     ]
     for i, col in enumerate(extra_cols):
-        label = {"tau_mean_A": "TauMean A", "tau_mean_B": "TauMean B", "tau_padj": "FDR"}[col]
+        label = {
+            "tau_mean_A": "TauMean A",
+            "tau_mean_B": "TauMean B",
+            "tau_padj": "FDR",
+        }[col]
         fmt = ".3f" if col.startswith("tau_mean") else ".3g"
         hover_parts.append(f"{label}: %{{customdata[{i}]:{fmt}}}")
     hovertemplate = "<br>".join(hover_parts) + "<extra></extra>"

--- a/examples/01_classify_and_explore.py
+++ b/examples/01_classify_and_explore.py
@@ -22,7 +22,6 @@ import matplotlib
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
 from circ.simulations import simulate
@@ -64,9 +63,10 @@ print()
 # ---------------------------------------------------------------------------
 # 2. Overview — what did my experiment produce?
 #
-# These three plots answer the first question after any classification run:
-# how are my genes distributed, how do the PIRS scores separate, and does
-# the mean time-series profile for each label look biologically sensible?
+# These four plots answer the first question after any classification run:
+# how are my genes distributed, how do the PIRS scores separate, does the
+# mean time-series profile for each label look biologically sensible, and
+# what does the full expression landscape look like across all labels?
 # ---------------------------------------------------------------------------
 print("Group 1: Overview …")
 
@@ -81,6 +81,19 @@ viz.mean_expression_profiles(expression, result, ax=axes[2])
 
 plt.tight_layout()
 out = FIGURES / "01_overview.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# Clustered expression heatmap — shows the most representative genes per
+# label sorted within each group by hierarchical clustering.  The color
+# strip on the left encodes the expression label.
+print("Group 1b: Expression heatmap …")
+
+fig, ax = plt.subplots(figsize=(8, 7))
+viz.expression_heatmap(expression, result, n_per_label=15, ax=ax)
+plt.tight_layout()
+out = FIGURES / "01b_expression_heatmap.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")
 plt.close(fig)
 print(f"  saved → {out}")

--- a/examples/01_classify_and_explore.py
+++ b/examples/01_classify_and_explore.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 import matplotlib
+
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -41,11 +42,14 @@ FIGURES.mkdir(exist_ok=True)
 
 print("Simulating data …")
 sim = simulate(
-    tpoints=8, nrows=300, nreps=2,
-    pcirc=0.25, plin=0.15,
+    tpoints=8,
+    nrows=300,
+    nreps=2,
+    pcirc=0.25,
+    plin=0.15,
     rseed=42,
 )
-gene_ids  = [f"gene_{i:04d}" for i in range(sim.nrows)]
+gene_ids = [f"gene_{i:04d}" for i in range(sim.nrows)]
 expression = pd.DataFrame(sim.sim, index=gene_ids, columns=sim.cols)
 expression.index.name = "#"
 

--- a/examples/05_gene_inspection.py
+++ b/examples/05_gene_inspection.py
@@ -26,10 +26,7 @@ import matplotlib
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
-import numpy as np
 import pandas as pd
-import seaborn as sns
 
 from circ.simulations import simulate
 from circ.expression_classification.classify import Classifier
@@ -68,11 +65,6 @@ result = clf.run_all(
 )
 print(result["label"].value_counts().to_string(), "\n")
 
-# Timepoint metadata — reused across all profile plots
-zt_cols    = [c for c in expression.columns if c.startswith(("ZT", "CT"))]
-timepoints = [int(c.replace("ZT", "").replace("CT", "").split("_")[0]) for c in zt_cols]
-unique_tp  = sorted(set(timepoints))
-
 # ---------------------------------------------------------------------------
 # 2. Select top hits
 # ---------------------------------------------------------------------------
@@ -86,31 +78,6 @@ top_constitutive = const_genes.nsmallest(9, "pirs_score")
 
 print(f"Top 9 rhythmic genes (by TauMean):     {top_rhythmic.index.tolist()}")
 print(f"Top 9 constitutive genes (by PIRS):    {top_constitutive.index.tolist()}\n")
-
-
-# ---------------------------------------------------------------------------
-# Helper — plot one gene's time-series (replicates + mean line)
-# ---------------------------------------------------------------------------
-def _gene_profile(ax, gene_id, color):
-    vals    = expression.loc[gene_id, zt_cols].astype(float).values
-    scatter = ax.scatter(timepoints, vals, color=color, s=14, alpha=0.55, zorder=3)
-    means   = [vals[[i for i, t in enumerate(timepoints) if t == tp]].mean()
-               for tp in unique_tp]
-    ax.plot(unique_tp, means, color=color, lw=1.5, zorder=2)
-
-    row   = result.loc[gene_id]
-    title = gene_id
-    if "tau_mean" in row.index and pd.notna(row["tau_mean"]):
-        title += f"\nτ={row['tau_mean']:.2f}"
-    if "phase_mean" in row.index and pd.notna(row["phase_mean"]):
-        title += f"  φ={row['phase_mean']:.1f} h"
-    if "pirs_score" in row.index and pd.notna(row["pirs_score"]):
-        title += f"\nPIRS={row['pirs_score']:.3f}"
-
-    ax.set_title(title, fontsize=7)
-    ax.set_xlabel("ZT (h)", fontsize=7)
-    ax.tick_params(labelsize=6)
-    sns.despine(ax=ax)
 
 
 # ---------------------------------------------------------------------------
@@ -132,11 +99,13 @@ viz.mean_expression_profiles(expression, result, ax=ax_mean,
 # Right 4 columns (2×4 = 8 panels, but we only have 9 genes; reshape to 3×3)
 # Use a nested gridspec for the gallery
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
-color = LABEL_COLORS["rhythmic"]
 for idx, gene_id in enumerate(top_rhythmic.index):
     r, c = divmod(idx, 3)
     ax   = fig.add_subplot(gs_gallery[r, c])
-    _gene_profile(ax, gene_id, color)
+    viz.gene_profile(expression, gene_id, result, ax=ax)
+    ax.set_title(ax.get_title(), fontsize=7)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=7)
+    ax.tick_params(labelsize=6)
 
 fig.suptitle("Top rhythmic genes — individual profiles (τ ranked)", fontsize=11)
 fig.tight_layout(rect=[0, 0, 1, 0.95])
@@ -164,11 +133,13 @@ viz.mean_expression_profiles(expression, result,
                               title="Mean profile\n(constitutive / variable)")
 
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
-color = LABEL_COLORS["constitutive"]
 for idx, gene_id in enumerate(top_constitutive.index):
     r, c = divmod(idx, 3)
     ax   = fig.add_subplot(gs_gallery[r, c])
-    _gene_profile(ax, gene_id, color)
+    viz.gene_profile(expression, gene_id, result, ax=ax)
+    ax.set_title(ax.get_title(), fontsize=7)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=7)
+    ax.tick_params(labelsize=6)
 
 fig.suptitle("Top constitutive gene candidates — individual profiles (PIRS ranked)",
              fontsize=11)
@@ -179,7 +150,29 @@ plt.close(fig)
 print(f"  saved → {out}")
 
 # ---------------------------------------------------------------------------
-# 5. Annotated decision space
+# 5. Expression heatmap — population-level view grouped by label
+#
+# Complements the individual profile galleries by showing all representative
+# genes in a single heatmap.  Within each label group genes are sorted by
+# hierarchical clustering on their z-scored expression patterns.
+# ---------------------------------------------------------------------------
+print("Section 3: Expression heatmap …")
+
+fig, ax = plt.subplots(figsize=(8, 9))
+viz.expression_heatmap(
+    expression, result,
+    n_per_label=12,
+    ax=ax,
+    title="Clustered expression by label",
+)
+fig.tight_layout()
+out = FIGURES / "23_expression_heatmap.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  saved → {out}")
+
+# ---------------------------------------------------------------------------
+# 6. Annotated decision space
 #
 # Overlays gene-ID labels for the top hits on the pirs_vs_tau plot, so you
 # can see exactly where each candidate sits relative to the decision boundaries.

--- a/examples/05_gene_inspection.py
+++ b/examples/05_gene_inspection.py
@@ -23,6 +23,7 @@ import sys
 from pathlib import Path
 
 import matplotlib
+
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -35,6 +36,7 @@ import circ.visualization as viz
 
 try:
     import circ.visualization.interactive as iviz
+
     _HAS_PLOTLY = True
 except ImportError:
     _HAS_PLOTLY = False
@@ -47,11 +49,14 @@ FIGURES.mkdir(exist_ok=True)
 # ---------------------------------------------------------------------------
 print("Simulating data …")
 sim = simulate(
-    tpoints=8, nrows=300, nreps=2,
-    pcirc=0.25, plin=0.15,
+    tpoints=8,
+    nrows=300,
+    nreps=2,
+    pcirc=0.25,
+    plin=0.15,
     rseed=42,
 )
-gene_ids   = [f"gene_{i:04d}" for i in range(sim.nrows)]
+gene_ids = [f"gene_{i:04d}" for i in range(sim.nrows)]
 expression = pd.DataFrame(sim.sim, index=gene_ids, columns=sim.cols)
 expression.index.name = "#"
 
@@ -70,10 +75,10 @@ print(result["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 # Top rhythmic: highest TauMean within the rhythmic + noisy_rhythmic labels
 rhythmic_genes = result[result["label"].isin(["rhythmic", "noisy_rhythmic"])]
-top_rhythmic   = rhythmic_genes.nlargest(9, "tau_mean")
+top_rhythmic = rhythmic_genes.nlargest(9, "tau_mean")
 
 # Top constitutive: lowest PIRS score within the constitutive label
-const_genes      = result[result["label"] == "constitutive"]
+const_genes = result[result["label"] == "constitutive"]
 top_constitutive = const_genes.nsmallest(9, "pirs_score")
 
 print(f"Top 9 rhythmic genes (by TauMean):     {top_rhythmic.index.tolist()}")
@@ -89,19 +94,20 @@ print(f"Top 9 constitutive genes (by PIRS):    {top_constitutive.index.tolist()}
 print("Section 1: Mean profiles + rhythmic gallery …")
 
 fig = plt.figure(figsize=(20, 8))
-gs  = fig.add_gridspec(2, 5, hspace=0.55, wspace=0.4)
+gs = fig.add_gridspec(2, 5, hspace=0.55, wspace=0.4)
 
 # Left column: mean profiles for all labels
 ax_mean = fig.add_subplot(gs[:, 0])
-viz.mean_expression_profiles(expression, result, ax=ax_mean,
-                              title="Mean profile\nby label")
+viz.mean_expression_profiles(
+    expression, result, ax=ax_mean, title="Mean profile\nby label"
+)
 
 # Right 4 columns (2×4 = 8 panels, but we only have 9 genes; reshape to 3×3)
 # Use a nested gridspec for the gallery
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
 for idx, gene_id in enumerate(top_rhythmic.index):
     r, c = divmod(idx, 3)
-    ax   = fig.add_subplot(gs_gallery[r, c])
+    ax = fig.add_subplot(gs_gallery[r, c])
     viz.gene_profile(expression, gene_id, result, ax=ax)
     ax.set_title(ax.get_title(), fontsize=7)
     ax.set_xlabel(ax.get_xlabel(), fontsize=7)
@@ -124,25 +130,29 @@ print(f"  saved → {out}")
 print("Section 2: Constitutive profiles …")
 
 fig = plt.figure(figsize=(20, 8))
-gs  = fig.add_gridspec(2, 5, hspace=0.55, wspace=0.4)
+gs = fig.add_gridspec(2, 5, hspace=0.55, wspace=0.4)
 
 ax_mean = fig.add_subplot(gs[:, 0])
-viz.mean_expression_profiles(expression, result,
-                              labels=["constitutive", "variable"],
-                              ax=ax_mean,
-                              title="Mean profile\n(constitutive / variable)")
+viz.mean_expression_profiles(
+    expression,
+    result,
+    labels=["constitutive", "variable"],
+    ax=ax_mean,
+    title="Mean profile\n(constitutive / variable)",
+)
 
 gs_gallery = gs[:, 1:].subgridspec(3, 3, hspace=0.6, wspace=0.4)
 for idx, gene_id in enumerate(top_constitutive.index):
     r, c = divmod(idx, 3)
-    ax   = fig.add_subplot(gs_gallery[r, c])
+    ax = fig.add_subplot(gs_gallery[r, c])
     viz.gene_profile(expression, gene_id, result, ax=ax)
     ax.set_title(ax.get_title(), fontsize=7)
     ax.set_xlabel(ax.get_xlabel(), fontsize=7)
     ax.tick_params(labelsize=6)
 
-fig.suptitle("Top constitutive gene candidates — individual profiles (PIRS ranked)",
-             fontsize=11)
+fig.suptitle(
+    "Top constitutive gene candidates — individual profiles (PIRS ranked)", fontsize=11
+)
 fig.tight_layout(rect=[0, 0, 1, 0.95])
 out = FIGURES / "22_constitutive_profiles.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")
@@ -160,7 +170,8 @@ print("Section 3: Expression heatmap …")
 
 fig, ax = plt.subplots(figsize=(8, 9))
 viz.expression_heatmap(
-    expression, result,
+    expression,
+    result,
     n_per_label=12,
     ax=ax,
     title="Clustered expression by label",
@@ -184,7 +195,7 @@ n_label = 6
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
 for ax, genes, title_suffix, color_key in [
-    (axes[0], top_rhythmic.head(n_label),   "rhythmic hits",     "rhythmic"),
+    (axes[0], top_rhythmic.head(n_label), "rhythmic hits", "rhythmic"),
     (axes[1], top_constitutive.head(n_label), "constitutive hits", "constitutive"),
 ]:
     viz.pirs_vs_tau(result, ax=ax, title=f"Decision space — {title_suffix} annotated")
@@ -194,15 +205,21 @@ for ax, genes, title_suffix, color_key in [
             (row["pirs_score"], row["tau_mean"]),
             fontsize=6,
             color=LABEL_COLORS[color_key],
-            xytext=(4, 4), textcoords="offset points",
-            arrowprops=dict(arrowstyle="-", color=LABEL_COLORS[color_key],
-                            lw=0.6, alpha=0.7),
+            xytext=(4, 4),
+            textcoords="offset points",
+            arrowprops=dict(
+                arrowstyle="-", color=LABEL_COLORS[color_key], lw=0.6, alpha=0.7
+            ),
         )
     # Highlight the annotated genes with larger markers
     ax.scatter(
-        genes["pirs_score"], genes["tau_mean"],
-        s=60, color=LABEL_COLORS[color_key],
-        edgecolors="white", linewidths=0.6, zorder=5,
+        genes["pirs_score"],
+        genes["tau_mean"],
+        s=60,
+        color=LABEL_COLORS[color_key],
+        edgecolors="white",
+        linewidths=0.6,
+        zorder=5,
     )
 
 plt.tight_layout()
@@ -220,14 +237,16 @@ print(f"  saved → {out}")
 if _HAS_PLOTLY:
     print("Section 4: Interactive gene hunt …")
 
-    fig_html = iviz.pirs_vs_tau(result,
-                                title="Hover to identify genes — PIRS vs TauMean")
+    fig_html = iviz.pirs_vs_tau(
+        result, title="Hover to identify genes — PIRS vs TauMean"
+    )
     out = FIGURES / "24_interactive_gene_hunt.html"
     fig_html.write_html(str(out))
     print(f"  saved → {out}")
 
-    fig_html = iviz.tau_pval_scatter(result,
-                                     title="Hover to identify genes — rhythmicity decision space")
+    fig_html = iviz.tau_pval_scatter(
+        result, title="Hover to identify genes — rhythmicity decision space"
+    )
     out = FIGURES / "25_interactive_rhythm_space.html"
     fig_html.write_html(str(out))
     print(f"  saved → {out}")

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -40,11 +40,9 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import numpy as np
 import pandas as pd
-import seaborn as sns
 
 from circ.simulations import simulate
 from circ.expression_classification.classify import Classifier
-from circ.visualization import LABEL_COLORS
 import circ.visualization as viz
 from circ.compare import compare_conditions, label_change_table
 
@@ -124,13 +122,13 @@ print(result_B["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Label distribution comparison …")
 
+xmax = max(
+    result_A["label"].value_counts().max(),
+    result_B["label"].value_counts().max(),
+) * 1.15
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
-viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0])
-viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1])
-
-xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
-axes[0].set_xlim(0, xmax)
-axes[1].set_xlim(0, xmax)
+viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0], xlim=xmax)
+viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1], xlim=xmax)
 
 plt.tight_layout()
 out = FIGURES / "26_label_comparison.png"
@@ -272,46 +270,12 @@ if "phase_padj" in comparison.columns:
 if _HAS_PLOTLY:
     print("\nSection 6: Interactive figure …")
 
-    hover_texts = [
-        f"<b>{g}</b><br>"
-        f"TauMean A: {row['tau_mean_A']:.3f}<br>"
-        f"TauMean B: {row['tau_mean_B']:.3f}<br>"
-        f"Δ tau: {row['delta_tau']:+.3f}<br>"
-        f"{row['rhythmicity_status']}"
-        for g, row in comparison.iterrows()
-    ]
-
-    import plotly.graph_objects as go
-
-    _STATUS_COLORS = {
-        'maintained_rhythmic':    '#6ACC65',
-        'gained':                 '#D65F5F',
-        'lost':                   '#4878CF',
-        'maintained_nonrhythmic': '#CCCCCC',
-    }
-    traces = []
-    lim = max(comparison["tau_mean_A"].max(), comparison["tau_mean_B"].max()) * 1.05
-    for status, color in _STATUS_COLORS.items():
-        sub  = comparison[comparison["rhythmicity_status"] == status]
-        htxt = [hover_texts[comparison.index.get_loc(g)] for g in sub.index]
-        if sub.empty:
-            continue
-        traces.append(go.Scatter(
-            x=sub["tau_mean_A"], y=sub["tau_mean_B"],
-            mode="markers",
-            name=f"{status} (n={len(sub)})",
-            marker=dict(color=color, size=5, opacity=0.7),
-            hovertext=htxt,
-            hovertemplate="%{hovertext}<extra></extra>",
-        ))
-    traces.append(go.Scatter(
-        x=[0, lim], y=[0, lim], mode="lines",
-        line=dict(color="#999999", dash="dash", width=1),
-        name="y = x", hoverinfo="skip",
-    ))
-    fig_html = go.Figure(traces)
+    fig_html = iviz.rhythmicity_shift_scatter(
+        comparison,
+        title=f"Rhythmicity shift — hover to identify genes<br>"
+              f"{COND_LABELS[0]} → {COND_LABELS[1]}",
+    )
     fig_html.update_layout(
-        title="Rhythmicity shift — hover to identify genes",
         xaxis_title=f"TauMean — {COND_LABELS[0]}",
         yaxis_title=f"TauMean — {COND_LABELS[1]}",
     )

--- a/examples/06_compare_conditions.py
+++ b/examples/06_compare_conditions.py
@@ -34,6 +34,7 @@ import sys
 from pathlib import Path
 
 import matplotlib
+
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -48,6 +49,7 @@ from circ.compare import compare_conditions, label_change_table
 
 try:
     import circ.visualization.interactive as iviz
+
     _HAS_PLOTLY = True
 except ImportError:
     _HAS_PLOTLY = False
@@ -77,8 +79,12 @@ COND_COLORS = ("#4878CF", "#D65F5F")
 # the rhythmic gene sets rarely overlap at typical detection thresholds.
 # ---------------------------------------------------------------------------
 print("Simulating shared rhythmic core …")
-sim_core_A = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=10, amp_noise=0.35)
-sim_core_B = simulate(tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=11, amp_noise=0.35)
+sim_core_A = simulate(
+    tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=10, amp_noise=0.35
+)
+sim_core_B = simulate(
+    tpoints=8, nrows=60, nreps=2, pcirc=1.0, plin=0.0, rseed=11, amp_noise=0.35
+)
 
 print("Simulating condition-specific backgrounds …")
 sim_bg_A = simulate(tpoints=8, nrows=240, nreps=2, pcirc=0.20, plin=0.10, rseed=1)
@@ -89,13 +95,15 @@ cols = sim_core_A.cols
 
 expr_A = pd.DataFrame(
     np.vstack([sim_core_A.sim, sim_bg_A.sim]),
-    index=gene_ids, columns=cols,
+    index=gene_ids,
+    columns=cols,
 )
 expr_A.index.name = "#"
 
 expr_B = pd.DataFrame(
     np.vstack([sim_core_B.sim, sim_bg_B.sim]),
-    index=gene_ids, columns=cols,
+    index=gene_ids,
+    columns=cols,
 )
 expr_B.index.name = "#"
 
@@ -122,10 +130,13 @@ print(result_B["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Label distribution comparison …")
 
-xmax = max(
-    result_A["label"].value_counts().max(),
-    result_B["label"].value_counts().max(),
-) * 1.15
+xmax = (
+    max(
+        result_A["label"].value_counts().max(),
+        result_B["label"].value_counts().max(),
+    )
+    * 1.15
+)
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
 viz.label_distribution(result_A, ax=axes[0], title=COND_LABELS[0], xlim=xmax)
 viz.label_distribution(result_B, ax=axes[1], title=COND_LABELS[1], xlim=xmax)
@@ -168,19 +179,21 @@ print("Section 3: Constitutive gene overlap …")
 
 const_A = set(result_A[result_A["label"] == "constitutive"].index)
 const_B = set(result_B[result_B["label"] == "constitutive"].index)
-both    = const_A & const_B
-only_A  = const_A - const_B
-only_B  = const_B - const_A
+both = const_A & const_B
+only_A = const_A - const_B
+only_B = const_B - const_A
 
 print(f"  Constitutive in A only : {len(only_A)}")
 print(f"  Constitutive in both   : {len(both)}")
 print(f"  Constitutive in B only : {len(only_B)}\n")
 
 fig, axes = plt.subplots(1, 2, figsize=(14, 6))
-viz.top_constitutive_candidates(result_A, n_top=15, ax=axes[0],
-                                title=f"Top candidates — {COND_LABELS[0]}")
-viz.top_constitutive_candidates(result_B, n_top=15, ax=axes[1],
-                                title=f"Top candidates — {COND_LABELS[1]}")
+viz.top_constitutive_candidates(
+    result_A, n_top=15, ax=axes[0], title=f"Top candidates — {COND_LABELS[0]}"
+)
+viz.top_constitutive_candidates(
+    result_B, n_top=15, ax=axes[1], title=f"Top candidates — {COND_LABELS[1]}"
+)
 
 top15_A = set(result_A.dropna(subset=["pirs_score"]).nsmallest(15, "pirs_score").index)
 top15_B = set(result_B.dropna(subset=["pirs_score"]).nsmallest(15, "pirs_score").index)
@@ -192,10 +205,17 @@ if shared_top:
                 tick.set_fontweight("bold")
                 tick.set_color("#2E8B57")
 
-shared_patch = mpatches.Patch(color="#2E8B57",
-                              label=f"In both top-15 ({len(shared_top)} genes)")
-fig.legend(handles=[shared_patch], loc="lower center", ncol=1,
-           frameon=False, fontsize=9, bbox_to_anchor=(0.5, -0.02))
+shared_patch = mpatches.Patch(
+    color="#2E8B57", label=f"In both top-15 ({len(shared_top)} genes)"
+)
+fig.legend(
+    handles=[shared_patch],
+    loc="lower center",
+    ncol=1,
+    frameon=False,
+    fontsize=9,
+    bbox_to_anchor=(0.5, -0.02),
+)
 plt.tight_layout()
 out = FIGURES / "28_constitutive_overlap.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")
@@ -218,8 +238,10 @@ comparison = compare_conditions(result_A, result_B)
 print("\nRhythmicity status breakdown:")
 print(comparison["rhythmicity_status"].value_counts().to_string())
 
-sig_tau   = comparison["tau_padj"].lt(0.05).sum()
-sig_phase = comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+sig_tau = comparison["tau_padj"].lt(0.05).sum()
+sig_phase = (
+    comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+)
 print(f"\nSignificant tau changes  (tau_padj < 0.05) : {sig_tau}")
 print(f"Significant phase shifts (phase_padj < 0.05): {sig_phase}")
 
@@ -254,15 +276,17 @@ if not gained.empty:
 
 if "phase_padj" in comparison.columns:
     sig_phase_df = comparison[
-        comparison["phase_padj"].lt(0.05) &
-        comparison["rhythmicity_status"].eq("maintained_rhythmic")
+        comparison["phase_padj"].lt(0.05)
+        & comparison["rhythmicity_status"].eq("maintained_rhythmic")
     ].copy()
     if not sig_phase_df.empty:
         sig_phase_df["abs_shift"] = sig_phase_df["delta_phase"].abs()
         print("\nTop genes with significant phase shifts (phase_padj < 0.05):")
-        print(sig_phase_df.nlargest(5, "abs_shift")[
-            ["phase_A", "phase_B", "delta_phase", "phase_padj"]
-        ].to_string())
+        print(
+            sig_phase_df.nlargest(5, "abs_shift")[
+                ["phase_A", "phase_B", "delta_phase", "phase_padj"]
+            ].to_string()
+        )
 
 # ---------------------------------------------------------------------------
 # 7. Interactive condition comparison
@@ -273,7 +297,7 @@ if _HAS_PLOTLY:
     fig_html = iviz.rhythmicity_shift_scatter(
         comparison,
         title=f"Rhythmicity shift — hover to identify genes<br>"
-              f"{COND_LABELS[0]} → {COND_LABELS[1]}",
+        f"{COND_LABELS[0]} → {COND_LABELS[1]}",
     )
     fig_html.update_layout(
         xaxis_title=f"TauMean — {COND_LABELS[0]}",

--- a/examples/07_compare_proteomics_vs_expression.py
+++ b/examples/07_compare_proteomics_vs_expression.py
@@ -122,12 +122,13 @@ print(result_rna["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Per-layer label distributions …")
 
+xmax = max(
+    result_prot["label"].value_counts().max(),
+    result_rna["label"].value_counts().max(),
+) * 1.15
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
-viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0])
-viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1])
-xmax = max(axes[0].get_xlim()[1], axes[1].get_xlim()[1])
-for ax in axes:
-    ax.set_xlim(0, xmax)
+viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0], xlim=xmax)
+viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1], xlim=xmax)
 plt.tight_layout()
 out = FIGURES / "31_layer_label_distributions.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")

--- a/examples/07_compare_proteomics_vs_expression.py
+++ b/examples/07_compare_proteomics_vs_expression.py
@@ -35,6 +35,7 @@ import sys
 from pathlib import Path
 
 import matplotlib
+
 if "--show" not in sys.argv:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -67,37 +68,55 @@ LAYER_LABELS = ("Proteomics", "RNA-seq")
 # ---------------------------------------------------------------------------
 print("Simulating multi-omic datasets …")
 
-sim_core_prot      = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=20, amp_noise=0.35)
-sim_core_rna       = simulate(tpoints=8, nrows=40,  nreps=2, pcirc=1.0, plin=0.0, rseed=21, amp_noise=0.35)
-sim_prot_only_rhy  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=22, amp_noise=0.35)
-sim_prot_only_flat = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=26)
-sim_rna_only_flat  = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=0.0, plin=0.0, rseed=27)
-sim_rna_only_rhy   = simulate(tpoints=8, nrows=20,  nreps=2, pcirc=1.0, plin=0.0, rseed=23, amp_noise=0.35)
-sim_bg_prot        = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=24)
-sim_bg_rna         = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=25)
+sim_core_prot = simulate(
+    tpoints=8, nrows=40, nreps=2, pcirc=1.0, plin=0.0, rseed=20, amp_noise=0.35
+)
+sim_core_rna = simulate(
+    tpoints=8, nrows=40, nreps=2, pcirc=1.0, plin=0.0, rseed=21, amp_noise=0.35
+)
+sim_prot_only_rhy = simulate(
+    tpoints=8, nrows=20, nreps=2, pcirc=1.0, plin=0.0, rseed=22, amp_noise=0.35
+)
+sim_prot_only_flat = simulate(
+    tpoints=8, nrows=20, nreps=2, pcirc=0.0, plin=0.0, rseed=26
+)
+sim_rna_only_flat = simulate(
+    tpoints=8, nrows=20, nreps=2, pcirc=0.0, plin=0.0, rseed=27
+)
+sim_rna_only_rhy = simulate(
+    tpoints=8, nrows=20, nreps=2, pcirc=1.0, plin=0.0, rseed=23, amp_noise=0.35
+)
+sim_bg_prot = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=24)
+sim_bg_rna = simulate(tpoints=8, nrows=120, nreps=2, pcirc=0.0, plin=0.05, rseed=25)
 
 feature_ids = [f"feat_{i:04d}" for i in range(200)]
 cols = sim_core_prot.cols
 
 prot_expr = pd.DataFrame(
-    np.vstack([
-        sim_core_prot.sim,       # feat_0000–0039: rhythmic in both
-        sim_prot_only_rhy.sim,   # feat_0040–0059: prot-only rhythmic
-        sim_rna_only_flat.sim,   # feat_0060–0079: non-rhythmic at protein level
-        sim_bg_prot.sim,         # feat_0080–0199: background
-    ]),
-    index=feature_ids, columns=cols,
+    np.vstack(
+        [
+            sim_core_prot.sim,  # feat_0000–0039: rhythmic in both
+            sim_prot_only_rhy.sim,  # feat_0040–0059: prot-only rhythmic
+            sim_rna_only_flat.sim,  # feat_0060–0079: non-rhythmic at protein level
+            sim_bg_prot.sim,  # feat_0080–0199: background
+        ]
+    ),
+    index=feature_ids,
+    columns=cols,
 )
 prot_expr.index.name = "#"
 
 rna_expr = pd.DataFrame(
-    np.vstack([
-        sim_core_rna.sim,        # feat_0000–0039: rhythmic in both
-        sim_prot_only_flat.sim,  # feat_0040–0059: non-rhythmic in RNA
-        sim_rna_only_rhy.sim,    # feat_0060–0079: rna-only rhythmic
-        sim_bg_rna.sim,          # feat_0080–0199: background
-    ]),
-    index=feature_ids, columns=cols,
+    np.vstack(
+        [
+            sim_core_rna.sim,  # feat_0000–0039: rhythmic in both
+            sim_prot_only_flat.sim,  # feat_0040–0059: non-rhythmic in RNA
+            sim_rna_only_rhy.sim,  # feat_0060–0079: rna-only rhythmic
+            sim_bg_rna.sim,  # feat_0080–0199: background
+        ]
+    ),
+    index=feature_ids,
+    columns=cols,
 )
 rna_expr.index.name = "#"
 
@@ -105,11 +124,13 @@ rna_expr.index.name = "#"
 # 2. Classify each molecular layer independently
 # ---------------------------------------------------------------------------
 print("Classifying proteomics layer …")
-clf_prot    = Classifier(prot_expr, reps=2)
-result_prot = clf_prot.run_all(pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1)
+clf_prot = Classifier(prot_expr, reps=2)
+result_prot = clf_prot.run_all(
+    pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1
+)
 
 print("Classifying RNA-seq layer …")
-clf_rna    = Classifier(rna_expr, reps=2)
+clf_rna = Classifier(rna_expr, reps=2)
 result_rna = clf_rna.run_all(pvals=True, slope_pvals=True, n_permutations=200, n_jobs=1)
 
 print("\nProteomics labels:")
@@ -122,13 +143,16 @@ print(result_rna["label"].value_counts().to_string(), "\n")
 # ---------------------------------------------------------------------------
 print("Section 1: Per-layer label distributions …")
 
-xmax = max(
-    result_prot["label"].value_counts().max(),
-    result_rna["label"].value_counts().max(),
-) * 1.15
+xmax = (
+    max(
+        result_prot["label"].value_counts().max(),
+        result_rna["label"].value_counts().max(),
+    )
+    * 1.15
+)
 fig, axes = plt.subplots(1, 2, figsize=(10, 4), sharey=False)
 viz.label_distribution(result_prot, ax=axes[0], title=LAYER_LABELS[0], xlim=xmax)
-viz.label_distribution(result_rna,  ax=axes[1], title=LAYER_LABELS[1], xlim=xmax)
+viz.label_distribution(result_rna, ax=axes[1], title=LAYER_LABELS[1], xlim=xmax)
 plt.tight_layout()
 out = FIGURES / "31_layer_label_distributions.png"
 fig.savefig(out, dpi=150, bbox_inches="tight")
@@ -155,8 +179,10 @@ print(comparison["rhythmicity_status"].value_counts().to_string())
 print("\nLabel transition table (proteomics → RNA-seq):")
 print(label_change_table(comparison).to_string())
 
-sig_tau   = comparison["tau_padj"].lt(0.05).sum()
-sig_phase = comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+sig_tau = comparison["tau_padj"].lt(0.05).sum()
+sig_phase = (
+    comparison["phase_padj"].lt(0.05).sum() if "phase_padj" in comparison.columns else 0
+)
 print(f"\nSignificant τ changes   (tau_padj  < 0.05): {sig_tau}")
 print(f"Significant phase shifts (phase_padj < 0.05): {sig_phase}\n")
 
@@ -173,15 +199,23 @@ print(f"  saved → {FIGURES / '32_cross_layer_summary.png'}")
 print("Section 3: Divergent features …")
 
 prot_only = comparison[comparison["rhythmicity_status"] == "lost"]
-rna_only  = comparison[comparison["rhythmicity_status"] == "gained"]
+rna_only = comparison[comparison["rhythmicity_status"] == "gained"]
 
 print(f"\n  Rhythmic at protein level only ({len(prot_only)} features):")
 if not prot_only.empty:
-    print(prot_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].head(5).to_string())
+    print(
+        prot_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]]
+        .head(5)
+        .to_string()
+    )
 
 print(f"\n  Rhythmic at mRNA level only ({len(rna_only)} features):")
 if not rna_only.empty:
-    print(rna_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]].head(5).to_string())
+    print(
+        rna_only[["tau_mean_A", "tau_mean_B", "delta_tau", "tau_padj"]]
+        .head(5)
+        .to_string()
+    )
 
 fig, ax = plt.subplots(figsize=(5, 5))
 viz.rhythmicity_shift_scatter(comparison, ax=ax)
@@ -221,7 +255,7 @@ for col in ("tau_mean", "pirs_score"):
     peptide_result[col] = (peptide_result[col].values + noise).clip(min=0)
 
 prot_ids = peptide_result.index
-pep_ids  = [f"pep_{i:04d}" for i in range(len(peptide_result))]
+pep_ids = [f"pep_{i:04d}" for i in range(len(peptide_result))]
 peptide_result.index = pd.MultiIndex.from_arrays(
     [pep_ids, prot_ids], names=["Peptide", "Protein"]
 )
@@ -237,8 +271,10 @@ except ValueError as e:
 # Aggregate to protein level, then compare:
 prot_agg = aggregate_to_protein(peptide_result)
 comparison_from_pep = compare_conditions(prot_agg, result_rna)
-print(f"  aggregate_to_protein + compare_conditions: "
-      f"{len(comparison_from_pep)} features compared successfully")
+print(
+    f"  aggregate_to_protein + compare_conditions: "
+    f"{len(comparison_from_pep)} features compared successfully"
+)
 
 if "--show" in sys.argv:
     plt.show()

--- a/tests/visualization/test_benchmarks.py
+++ b/tests/visualization/test_benchmarks.py
@@ -3,13 +3,15 @@
 Metric correctness tests (roc_auc, classification_auc, classification_ap)
 live in tests/test_evaluation.py.
 """
+
 import re
 
 import numpy as np
 import pandas as pd
 import pytest
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.axes
 
@@ -25,10 +27,11 @@ from circ.visualization.benchmarks import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def close_figures():
     yield
-    plt.close('all')
+    plt.close("all")
 
 
 @pytest.fixture
@@ -36,13 +39,13 @@ def curves_df():
     """Synthetic PR curves DataFrame."""
     rng = np.random.default_rng(0)
     rows = []
-    for method in ['PIRS', 'RSD']:
+    for method in ["PIRS", "RSD"]:
         for rep in range(3):
             n = 20
             recall = np.linspace(0, 1, n)
             precision = np.clip(rng.uniform(0.3, 1.0, n) - recall * 0.3, 0, 1)
             for r, p in zip(recall, precision):
-                rows.append({'recall': r, 'precision': p, 'method': method, 'rep': rep})
+                rows.append({"recall": r, "precision": p, "method": method, "rep": rep})
     return pd.DataFrame(rows)
 
 
@@ -53,8 +56,8 @@ def merged_dict():
     n = 100
     truth = rng.integers(0, 2, n)
     return {
-        'method_a': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
-        'method_b': pd.DataFrame({'Circadian': truth, 'GammaBH': rng.uniform(0, 1, n)}),
+        "method_a": pd.DataFrame({"Circadian": truth, "GammaBH": rng.uniform(0, 1, n)}),
+        "method_b": pd.DataFrame({"Circadian": truth, "GammaBH": rng.uniform(0, 1, n)}),
     }
 
 
@@ -63,15 +66,23 @@ def classification_df():
     """Synthetic classification output."""
     rng = np.random.default_rng(2)
     n = 80
-    labels = ['constitutive'] * 20 + ['rhythmic'] * 20 + ['variable'] * 20 + ['noisy_rhythmic'] * 20
-    return pd.DataFrame({
-        'pirs_score': np.abs(rng.normal(0, 1, n)),
-        'tau_mean':   rng.uniform(0, 1, n),
-        'emp_p':      rng.uniform(0, 1, n),
-        'pval':       rng.uniform(0, 1, n),
-        'slope_pval': rng.uniform(0, 1, n),
-        'label':      labels,
-    }, index=[f'g{i}' for i in range(n)])
+    labels = (
+        ["constitutive"] * 20
+        + ["rhythmic"] * 20
+        + ["variable"] * 20
+        + ["noisy_rhythmic"] * 20
+    )
+    return pd.DataFrame(
+        {
+            "pirs_score": np.abs(rng.normal(0, 1, n)),
+            "tau_mean": rng.uniform(0, 1, n),
+            "emp_p": rng.uniform(0, 1, n),
+            "pval": rng.uniform(0, 1, n),
+            "slope_pval": rng.uniform(0, 1, n),
+            "label": labels,
+        },
+        index=[f"g{i}" for i in range(n)],
+    )
 
 
 @pytest.fixture
@@ -79,16 +90,20 @@ def true_classes(classification_df):
     """Simulated ground-truth binary labels aligned with classification_df."""
     rng = np.random.default_rng(3)
     n = len(classification_df)
-    return pd.DataFrame({
-        'Const':     rng.integers(0, 2, n),
-        'Circadian': rng.integers(0, 2, n),
-        'Linear':    rng.integers(0, 2, n),
-    }, index=classification_df.index)
+    return pd.DataFrame(
+        {
+            "Const": rng.integers(0, 2, n),
+            "Circadian": rng.integers(0, 2, n),
+            "Linear": rng.integers(0, 2, n),
+        },
+        index=classification_df.index,
+    )
 
 
 # ---------------------------------------------------------------------------
 # pr_curve
 # ---------------------------------------------------------------------------
+
 
 class TestPrCurve:
     def test_returns_axes(self, curves_df):
@@ -103,11 +118,12 @@ class TestPrCurve:
     def test_baseline_drawn(self, curves_df):
         ax = pr_curve(curves_df, baseline=0.4)
         _, labels = ax.get_legend_handles_labels()
-        assert 'random classifier' in labels
+        assert "random classifier" in labels
 
     def test_saves_to_file(self, curves_df, tmp_path):
         import os
-        out = str(tmp_path / 'pr.png')
+
+        out = str(tmp_path / "pr.png")
         pr_curve(curves_df, outpath=out)
         assert os.path.exists(out)
 
@@ -115,6 +131,7 @@ class TestPrCurve:
 # ---------------------------------------------------------------------------
 # roc_curve_plot
 # ---------------------------------------------------------------------------
+
 
 class TestRocCurvePlot:
     def test_returns_axes(self, merged_dict):
@@ -130,7 +147,11 @@ class TestRocCurvePlot:
     def test_accepts_truth_score_columns(self):
         rng = np.random.default_rng(4)
         n = 50
-        d = {'m1': pd.DataFrame({'truth': rng.integers(0, 2, n), 'score': rng.uniform(0, 1, n)})}
+        d = {
+            "m1": pd.DataFrame(
+                {"truth": rng.integers(0, 2, n), "score": rng.uniform(0, 1, n)}
+            )
+        }
         ax = roc_curve_plot(d)
         assert isinstance(ax, matplotlib.axes.Axes)
 
@@ -138,6 +159,7 @@ class TestRocCurvePlot:
 # ---------------------------------------------------------------------------
 # classification_pr
 # ---------------------------------------------------------------------------
+
 
 class TestClassificationPr:
     def test_returns_axes(self, classification_df, true_classes):
@@ -151,14 +173,17 @@ class TestClassificationPr:
 
     def test_circadian_truth_col(self, classification_df, true_classes):
         ax = classification_pr(
-            classification_df, true_classes,
-            ground_truth_col='Circadian', score_col='tau_mean', invert_score=False,
+            classification_df,
+            true_classes,
+            ground_truth_col="Circadian",
+            score_col="tau_mean",
+            invert_score=False,
         )
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_empty_intersection_no_crash(self, classification_df, true_classes):
         tc = true_classes.copy()
-        tc.index = [f'other_{i}' for i in range(len(tc))]
+        tc.index = [f"other_{i}" for i in range(len(tc))]
         ax = classification_pr(classification_df, tc)
         assert isinstance(ax, matplotlib.axes.Axes)
 
@@ -166,6 +191,7 @@ class TestClassificationPr:
 # ---------------------------------------------------------------------------
 # classification_roc — rendering
 # ---------------------------------------------------------------------------
+
 
 class TestClassificationRoc:
     def test_returns_axes(self, classification_df, true_classes):
@@ -179,7 +205,7 @@ class TestClassificationRoc:
         assert len(ax.lines) >= 3
 
     def test_explicit_tasks(self, classification_df, true_classes):
-        tasks = [('pirs_score', 'Const', True)]
+        tasks = [("pirs_score", "Const", True)]
         ax = classification_roc(classification_df, true_classes, tasks=tasks)
         # 1 method line + diagonal
         assert len(ax.lines) == 2
@@ -189,13 +215,14 @@ class TestClassificationRoc:
 # classification_roc — AUC values embedded in legend labels
 # ---------------------------------------------------------------------------
 
+
 class TestClassificationRocValues:
     """AUC values written into classification_roc() legend labels should be correct."""
 
     def _extract_auc(self, ax):
         """Return the first AUC value found in any line label on the axes."""
         for line in ax.lines:
-            m = re.search(r'AUC=([0-9.]+)', line.get_label())
+            m = re.search(r"AUC=([0-9.]+)", line.get_label())
             if m:
                 return float(m.group(1))
         return None
@@ -204,16 +231,20 @@ class TestClassificationRocValues:
         """A score that perfectly separates Linear genes should appear as AUC ≈ 1.0."""
         n = 100
         clf_df = pd.DataFrame(
-            {'slope_pval': np.array([0.001] * 25 + [0.99] * 75)},
-            index=[f'g{i}' for i in range(n)],
+            {"slope_pval": np.array([0.001] * 25 + [0.99] * 75)},
+            index=[f"g{i}" for i in range(n)],
         )
         truth_df = pd.DataFrame(
-            {'Linear': np.array([1] * 25 + [0] * 75)},
+            {"Linear": np.array([1] * 25 + [0] * 75)},
             index=clf_df.index,
         )
-        ax = classification_roc(clf_df, truth_df, tasks=[('slope_pval', 'Linear', True)])
+        ax = classification_roc(
+            clf_df, truth_df, tasks=[("slope_pval", "Linear", True)]
+        )
         auc_val = self._extract_auc(ax)
-        assert auc_val is not None, "AUC value not found in classification_roc legend labels"
+        assert auc_val is not None, (
+            "AUC value not found in classification_roc legend labels"
+        )
         assert auc_val > 0.99, (
             f"Perfect slope_pval should give AUC > 0.99; got {auc_val:.3f}"
         )
@@ -223,16 +254,18 @@ class TestClassificationRocValues:
         rng = np.random.default_rng(55)
         n = 300
         clf_df = pd.DataFrame(
-            {'pirs_score': rng.uniform(0, 1, n)},
-            index=[f'g{i}' for i in range(n)],
+            {"pirs_score": rng.uniform(0, 1, n)},
+            index=[f"g{i}" for i in range(n)],
         )
         truth_df = pd.DataFrame(
-            {'Const': rng.integers(0, 2, n)},
+            {"Const": rng.integers(0, 2, n)},
             index=clf_df.index,
         )
-        ax = classification_roc(clf_df, truth_df, tasks=[('pirs_score', 'Const', True)])
+        ax = classification_roc(clf_df, truth_df, tasks=[("pirs_score", "Const", True)])
         auc_val = self._extract_auc(ax)
-        assert auc_val is not None, "AUC value not found in classification_roc legend labels"
+        assert auc_val is not None, (
+            "AUC value not found in classification_roc legend labels"
+        )
         assert abs(auc_val - 0.5) < 0.1, (
             f"Random pirs_score AUC={auc_val:.3f} should be near 0.5"
         )
@@ -241,9 +274,10 @@ class TestClassificationRocValues:
         """All auto-detected tasks should embed an AUC value in their legend label."""
         ax = classification_roc(classification_df, true_classes)
         auc_labels = [
-            l for line in ax.lines
+            l
+            for line in ax.lines
             for l in [line.get_label()]
-            if re.search(r'AUC=([0-9.]+)', l)
+            if re.search(r"AUC=([0-9.]+)", l)
         ]
         # Should have at least one labelled task line (random diagonal also has AUC=0.5)
         assert len(auc_labels) >= 2, (

--- a/tests/visualization/test_classify_plots.py
+++ b/tests/visualization/test_classify_plots.py
@@ -1,9 +1,11 @@
 """Tests for circ.visualization.classify — expression classification plots."""
+
 import numpy as np
 import pandas as pd
 import pytest
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.axes
 
@@ -29,20 +31,26 @@ from circ.visualization.classify import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def minimal_clf():
     """Minimal classification DataFrame: only the columns always present."""
     rng = np.random.default_rng(0)
     n = 60
     labels = (
-        ['constitutive'] * 15 + ['rhythmic'] * 15 +
-        ['variable'] * 15 + ['noisy_rhythmic'] * 15
+        ["constitutive"] * 15
+        + ["rhythmic"] * 15
+        + ["variable"] * 15
+        + ["noisy_rhythmic"] * 15
     )
-    return pd.DataFrame({
-        'pirs_score': np.abs(rng.normal(0, 1, n)),
-        'tau_mean':   rng.uniform(0, 1, n),
-        'label':      labels,
-    }, index=[f'g{i}' for i in range(n)])
+    return pd.DataFrame(
+        {
+            "pirs_score": np.abs(rng.normal(0, 1, n)),
+            "tau_mean": rng.uniform(0, 1, n),
+            "label": labels,
+        },
+        index=[f"g{i}" for i in range(n)],
+    )
 
 
 @pytest.fixture
@@ -51,13 +59,13 @@ def full_clf(minimal_clf):
     rng = np.random.default_rng(1)
     n = len(minimal_clf)
     df = minimal_clf.copy()
-    df['emp_p']           = rng.uniform(0, 1, n)
-    df['pval']            = rng.uniform(0, 1, n)
-    df['pval_bh']         = rng.uniform(0, 1, n)
-    df['slope_pval']      = rng.uniform(0, 1, n)
-    df['slope_pval_bh']   = rng.uniform(0, 1, n)
-    df['phase_mean']      = rng.uniform(0, 24, n)
-    df['period_mean']     = rng.normal(24, 1, n)
+    df["emp_p"] = rng.uniform(0, 1, n)
+    df["pval"] = rng.uniform(0, 1, n)
+    df["pval_bh"] = rng.uniform(0, 1, n)
+    df["slope_pval"] = rng.uniform(0, 1, n)
+    df["slope_pval_bh"] = rng.uniform(0, 1, n)
+    df["phase_mean"] = rng.uniform(0, 24, n)
+    df["period_mean"] = rng.normal(24, 1, n)
     return df
 
 
@@ -65,8 +73,8 @@ def full_clf(minimal_clf):
 def with_linear(full_clf):
     """Adds linear genes so all five labels are present."""
     extra = full_clf.iloc[:10].copy()
-    extra.index = [f'lin{i}' for i in range(10)]
-    extra['label'] = 'linear'
+    extra.index = [f"lin{i}" for i in range(10)]
+    extra["label"] = "linear"
     return pd.concat([full_clf, extra])
 
 
@@ -75,30 +83,40 @@ def expression_df(minimal_clf):
     """Tiny expression matrix with ZT columns aligned to minimal_clf index."""
     rng = np.random.default_rng(5)
     n = len(minimal_clf)
-    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
-    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=minimal_clf.index, columns=cols)
+    cols = [f"ZT{h:02d}_{r}" for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(
+        rng.normal(5, 1, (n, len(cols))), index=minimal_clf.index, columns=cols
+    )
 
 
 @pytest.fixture(autouse=True)
 def close_figures():
     yield
-    plt.close('all')
+    plt.close("all")
 
 
 # ---------------------------------------------------------------------------
 # LABEL_COLORS
 # ---------------------------------------------------------------------------
 
+
 def test_label_colors_has_all_labels():
-    for lbl in ('constitutive', 'rhythmic', 'linear', 'variable',
-                'noisy_rhythmic', 'unclassified'):
+    for lbl in (
+        "constitutive",
+        "rhythmic",
+        "linear",
+        "variable",
+        "noisy_rhythmic",
+        "unclassified",
+    ):
         assert lbl in LABEL_COLORS
-        assert LABEL_COLORS[lbl].startswith('#')
+        assert LABEL_COLORS[lbl].startswith("#")
 
 
 # ---------------------------------------------------------------------------
 # label_distribution
 # ---------------------------------------------------------------------------
+
 
 class TestLabelDistribution:
     def test_returns_axes(self, minimal_clf):
@@ -107,7 +125,7 @@ class TestLabelDistribution:
 
     def test_bar_count_matches_labels(self, minimal_clf):
         ax = label_distribution(minimal_clf)
-        assert len(ax.patches) == minimal_clf['label'].nunique()
+        assert len(ax.patches) == minimal_clf["label"].nunique()
 
     def test_accepts_explicit_ax(self, minimal_clf):
         _, ax = plt.subplots()
@@ -122,6 +140,7 @@ class TestLabelDistribution:
 # ---------------------------------------------------------------------------
 # pirs_vs_tau
 # ---------------------------------------------------------------------------
+
 
 class TestPirsVsTau:
     def test_returns_axes(self, minimal_clf):
@@ -143,13 +162,14 @@ class TestPirsVsTau:
 # volcano
 # ---------------------------------------------------------------------------
 
+
 class TestVolcano:
     def test_returns_axes(self, full_clf):
         ax = volcano(full_clf)
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_emp_p(self, minimal_clf):
-        with pytest.raises(ValueError, match='emp_p'):
+        with pytest.raises(ValueError, match="emp_p"):
             volcano(minimal_clf)
 
     def test_accepts_explicit_ax(self, full_clf):
@@ -161,6 +181,7 @@ class TestVolcano:
 # ---------------------------------------------------------------------------
 # pirs_score_distribution
 # ---------------------------------------------------------------------------
+
 
 class TestPirsScoreDistribution:
     def test_returns_axes(self, minimal_clf):
@@ -177,13 +198,14 @@ class TestPirsScoreDistribution:
 # tau_pval_scatter
 # ---------------------------------------------------------------------------
 
+
 class TestTauPvalScatter:
     def test_returns_axes(self, full_clf):
         ax = tau_pval_scatter(full_clf)
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_emp_p(self, minimal_clf):
-        with pytest.raises(ValueError, match='emp_p'):
+        with pytest.raises(ValueError, match="emp_p"):
             tau_pval_scatter(minimal_clf)
 
 
@@ -191,23 +213,25 @@ class TestTauPvalScatter:
 # pirs_pval_scatter
 # ---------------------------------------------------------------------------
 
+
 class TestPirsPvalScatter:
     def test_returns_axes(self, full_clf):
         ax = pirs_pval_scatter(full_clf)
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_pval(self, minimal_clf):
-        with pytest.raises(ValueError, match='pval'):
+        with pytest.raises(ValueError, match="pval"):
             pirs_pval_scatter(minimal_clf)
 
     def test_prefers_bh_corrected(self, full_clf):
         ax = pirs_pval_scatter(full_clf)
-        assert 'pval_bh' in ax.get_ylabel()
+        assert "pval_bh" in ax.get_ylabel()
 
 
 # ---------------------------------------------------------------------------
 # slope_pval_scatter
 # ---------------------------------------------------------------------------
+
 
 class TestSlopePvalScatter:
     def test_returns_axes(self, full_clf):
@@ -215,7 +239,7 @@ class TestSlopePvalScatter:
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_slope_pval(self, minimal_clf):
-        with pytest.raises(ValueError, match='slope_pval'):
+        with pytest.raises(ValueError, match="slope_pval"):
             slope_pval_scatter(minimal_clf)
 
 
@@ -223,19 +247,20 @@ class TestSlopePvalScatter:
 # slope_vs_rhythm
 # ---------------------------------------------------------------------------
 
+
 class TestSlopeVsRhythm:
     def test_returns_axes(self, full_clf):
         ax = slope_vs_rhythm(full_clf)
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_slope_pval(self, full_clf):
-        df = full_clf.drop(columns=['slope_pval', 'slope_pval_bh'])
-        with pytest.raises(ValueError, match='slope_pval'):
+        df = full_clf.drop(columns=["slope_pval", "slope_pval_bh"])
+        with pytest.raises(ValueError, match="slope_pval"):
             slope_vs_rhythm(df)
 
     def test_raises_without_emp_p(self, full_clf):
-        df = full_clf.drop(columns=['emp_p'])
-        with pytest.raises(ValueError, match='emp_p'):
+        df = full_clf.drop(columns=["emp_p"])
+        with pytest.raises(ValueError, match="emp_p"):
             slope_vs_rhythm(df)
 
 
@@ -243,32 +268,34 @@ class TestSlopeVsRhythm:
 # phase_wheel
 # ---------------------------------------------------------------------------
 
+
 class TestPhaseWheel:
     def test_returns_polar_axes(self, full_clf):
         ax = phase_wheel(full_clf)
-        assert ax.name == 'polar'
+        assert ax.name == "polar"
 
     def test_raises_without_phase_mean(self, minimal_clf):
-        with pytest.raises(ValueError, match='phase_mean'):
+        with pytest.raises(ValueError, match="phase_mean"):
             phase_wheel(minimal_clf)
 
     def test_accepts_explicit_polar_ax(self, full_clf):
-        _, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+        _, ax = plt.subplots(subplot_kw={"projection": "polar"})
         returned = phase_wheel(full_clf, ax=ax)
         assert returned is ax
 
     def test_fallback_to_all_genes_when_no_rhythmic(self, full_clf):
         """When no genes carry a rhythmic label, fall back to all genes."""
         df = full_clf.copy()
-        df['label'] = 'constitutive'  # strip all rhythmic labels
+        df["label"] = "constitutive"  # strip all rhythmic labels
         ax = phase_wheel(df)
-        assert ax.name == 'polar'
-        assert 'all genes' in ax.get_title()
+        assert ax.name == "polar"
+        assert "all genes" in ax.get_title()
 
 
 # ---------------------------------------------------------------------------
 # period_distribution
 # ---------------------------------------------------------------------------
+
 
 class TestPeriodDistribution:
     def test_returns_axes(self, full_clf):
@@ -276,7 +303,7 @@ class TestPeriodDistribution:
         assert isinstance(ax, matplotlib.axes.Axes)
 
     def test_raises_without_period_mean(self, minimal_clf):
-        with pytest.raises(ValueError, match='period_mean'):
+        with pytest.raises(ValueError, match="period_mean"):
             period_distribution(minimal_clf)
 
     def test_reference_line_present(self, full_clf):
@@ -287,16 +314,16 @@ class TestPeriodDistribution:
     def test_fallback_to_all_genes_when_no_rhythmic(self, full_clf):
         """When no genes carry a rhythmic label, fall back to all genes."""
         df = full_clf.copy()
-        df['label'] = 'constitutive'
+        df["label"] = "constitutive"
         ax = period_distribution(df)
         assert isinstance(ax, matplotlib.axes.Axes)
-        assert 'all genes' in ax.get_title()
+        assert "all genes" in ax.get_title()
         assert len(ax.patches) > 0  # histogram bars drawn
 
     def test_constant_period_shows_bars(self, full_clf):
         """Constant period_mean (all 24 h) must still produce visible bars."""
         df = full_clf.copy()
-        df['period_mean'] = 24.0
+        df["period_mean"] = 24.0
         ax = period_distribution(df)
         assert len(ax.patches) > 0
 
@@ -304,6 +331,7 @@ class TestPeriodDistribution:
 # ---------------------------------------------------------------------------
 # classification_summary
 # ---------------------------------------------------------------------------
+
 
 class TestClassificationSummary:
     def test_returns_figure_minimal(self, minimal_clf):
@@ -319,9 +347,10 @@ class TestClassificationSummary:
         assert len(fig.axes) > 5
 
     def test_saves_to_file(self, full_clf, tmp_path):
-        out = str(tmp_path / 'summary.png')
+        out = str(tmp_path / "summary.png")
         classification_summary(full_clf, outpath=out)
         import os
+
         assert os.path.exists(out)
 
     def test_minimal_has_correct_panel_count(self, minimal_clf):
@@ -333,7 +362,7 @@ class TestClassificationSummary:
     def test_with_emp_p_adds_two_panels(self, minimal_clf):
         df = minimal_clf.copy()
         rng = np.random.default_rng(2)
-        df['emp_p'] = rng.uniform(0, 1, len(df))
+        df["emp_p"] = rng.uniform(0, 1, len(df))
         fig = classification_summary(df)
         # 5 base + 2 (volcano + tau_pval_scatter) = 7
         assert len(fig.axes) == 7
@@ -342,6 +371,7 @@ class TestClassificationSummary:
 # ---------------------------------------------------------------------------
 # label_distribution xlim
 # ---------------------------------------------------------------------------
+
 
 class TestLabelDistributionXlim:
     def test_xlim_applied(self, minimal_clf):
@@ -356,6 +386,7 @@ class TestLabelDistributionXlim:
 # ---------------------------------------------------------------------------
 # gene_profile
 # ---------------------------------------------------------------------------
+
 
 class TestGeneProfile:
     def test_returns_axes(self, expression_df, minimal_clf):
@@ -380,8 +411,8 @@ class TestGeneProfile:
         assert ax.get_title() == "My title"
 
     def test_raises_on_missing_gene(self, expression_df, minimal_clf):
-        with pytest.raises(ValueError, match='not found'):
-            gene_profile(expression_df, 'nonexistent_gene', minimal_clf)
+        with pytest.raises(ValueError, match="not found"):
+            gene_profile(expression_df, "nonexistent_gene", minimal_clf)
 
     def test_works_without_classifications(self, expression_df):
         gene = expression_df.index[0]
@@ -391,20 +422,23 @@ class TestGeneProfile:
     def test_scatter_and_line_drawn(self, expression_df, minimal_clf):
         gene = expression_df.index[0]
         ax = gene_profile(expression_df, gene, minimal_clf)
-        assert len(ax.collections) >= 1   # scatter
-        assert len(ax.lines) >= 1         # mean line
+        assert len(ax.collections) >= 1  # scatter
+        assert len(ax.lines) >= 1  # mean line
 
     def test_color_from_label(self, expression_df, minimal_clf):
-        gene = minimal_clf[minimal_clf['label'] == 'rhythmic'].index[0]
+        gene = minimal_clf[minimal_clf["label"] == "rhythmic"].index[0]
         ax = gene_profile(expression_df, gene, minimal_clf)
-        scatter_color = ax.collections[0].get_facecolors()[0][:3]  # RGB only; alpha set by scatter
-        expected = plt.matplotlib.colors.to_rgb(LABEL_COLORS['rhythmic'])
+        scatter_color = ax.collections[0].get_facecolors()[0][
+            :3
+        ]  # RGB only; alpha set by scatter
+        expected = plt.matplotlib.colors.to_rgb(LABEL_COLORS["rhythmic"])
         np.testing.assert_allclose(scatter_color, expected, atol=0.01)
 
 
 # ---------------------------------------------------------------------------
 # expression_heatmap
 # ---------------------------------------------------------------------------
+
 
 class TestExpressionHeatmap:
     def test_returns_axes(self, expression_df, minimal_clf):
@@ -428,7 +462,7 @@ class TestExpressionHeatmap:
     def test_n_per_label_limits_rows(self, expression_df, minimal_clf):
         ax = expression_heatmap(expression_df, minimal_clf, n_per_label=3)
         img = ax.images[0]
-        n_labels = minimal_clf['label'].nunique()
+        n_labels = minimal_clf["label"].nunique()
         assert img.get_array().shape[0] <= 3 * n_labels
 
     def test_colorbar_present(self, expression_df, minimal_clf):
@@ -452,7 +486,7 @@ class TestExpressionHeatmap:
         bad_expr = pd.DataFrame(
             np.ones((10, 4)),
             index=minimal_clf.index[:10],
-            columns=['A', 'B', 'C', 'D'],
+            columns=["A", "B", "C", "D"],
         )
-        with pytest.raises(ValueError, match='ZT/CT'):
+        with pytest.raises(ValueError, match="ZT/CT"):
             expression_heatmap(bad_expr, minimal_clf)

--- a/tests/visualization/test_classify_plots.py
+++ b/tests/visualization/test_classify_plots.py
@@ -19,6 +19,8 @@ from circ.visualization.classify import (
     slope_vs_rhythm,
     phase_wheel,
     period_distribution,
+    gene_profile,
+    expression_heatmap,
     classification_summary,
 )
 
@@ -66,6 +68,15 @@ def with_linear(full_clf):
     extra.index = [f'lin{i}' for i in range(10)]
     extra['label'] = 'linear'
     return pd.concat([full_clf, extra])
+
+
+@pytest.fixture
+def expression_df(minimal_clf):
+    """Tiny expression matrix with ZT columns aligned to minimal_clf index."""
+    rng = np.random.default_rng(5)
+    n = len(minimal_clf)
+    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=minimal_clf.index, columns=cols)
 
 
 @pytest.fixture(autouse=True)
@@ -299,13 +310,13 @@ class TestClassificationSummary:
         fig = classification_summary(minimal_clf)
         assert isinstance(fig, plt.Figure)
         # always: label_distribution + pirs_vs_tau + pirs_score_distribution
-        #         + top_constitutive_candidates = 4
-        assert len(fig.axes) == 4
+        #         + top_constitutive_candidates + threshold_sensitivity = 5
+        assert len(fig.axes) == 5
 
     def test_returns_figure_full(self, full_clf):
         fig = classification_summary(full_clf)
         assert isinstance(fig, plt.Figure)
-        assert len(fig.axes) > 4
+        assert len(fig.axes) > 5
 
     def test_saves_to_file(self, full_clf, tmp_path):
         out = str(tmp_path / 'summary.png')
@@ -316,13 +327,132 @@ class TestClassificationSummary:
     def test_minimal_has_correct_panel_count(self, minimal_clf):
         fig = classification_summary(minimal_clf)
         # label_distribution + pirs_vs_tau + pirs_score_distribution
-        # + top_constitutive_candidates = 4
-        assert len(fig.axes) == 4
+        # + top_constitutive_candidates + threshold_sensitivity = 5
+        assert len(fig.axes) == 5
 
     def test_with_emp_p_adds_two_panels(self, minimal_clf):
         df = minimal_clf.copy()
         rng = np.random.default_rng(2)
         df['emp_p'] = rng.uniform(0, 1, len(df))
         fig = classification_summary(df)
-        # 4 base + 2 (volcano + tau_pval_scatter) = 6
-        assert len(fig.axes) == 6
+        # 5 base + 2 (volcano + tau_pval_scatter) = 7
+        assert len(fig.axes) == 7
+
+
+# ---------------------------------------------------------------------------
+# label_distribution xlim
+# ---------------------------------------------------------------------------
+
+class TestLabelDistributionXlim:
+    def test_xlim_applied(self, minimal_clf):
+        ax = label_distribution(minimal_clf, xlim=500)
+        assert ax.get_xlim()[1] == pytest.approx(500)
+
+    def test_xlim_none_leaves_default(self, minimal_clf):
+        ax = label_distribution(minimal_clf)
+        assert ax.get_xlim()[1] != pytest.approx(500)
+
+
+# ---------------------------------------------------------------------------
+# gene_profile
+# ---------------------------------------------------------------------------
+
+class TestGeneProfile:
+    def test_returns_axes(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_accepts_explicit_ax(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        gene = expression_df.index[0]
+        returned = gene_profile(expression_df, gene, minimal_clf, ax=ax)
+        assert returned is ax
+
+    def test_title_contains_gene_id(self, expression_df, minimal_clf):
+        gene = expression_df.index[3]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert gene in ax.get_title()
+
+    def test_custom_title(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf, title="My title")
+        assert ax.get_title() == "My title"
+
+    def test_raises_on_missing_gene(self, expression_df, minimal_clf):
+        with pytest.raises(ValueError, match='not found'):
+            gene_profile(expression_df, 'nonexistent_gene', minimal_clf)
+
+    def test_works_without_classifications(self, expression_df):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_scatter_and_line_drawn(self, expression_df, minimal_clf):
+        gene = expression_df.index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        assert len(ax.collections) >= 1   # scatter
+        assert len(ax.lines) >= 1         # mean line
+
+    def test_color_from_label(self, expression_df, minimal_clf):
+        gene = minimal_clf[minimal_clf['label'] == 'rhythmic'].index[0]
+        ax = gene_profile(expression_df, gene, minimal_clf)
+        scatter_color = ax.collections[0].get_facecolors()[0][:3]  # RGB only; alpha set by scatter
+        expected = plt.matplotlib.colors.to_rgb(LABEL_COLORS['rhythmic'])
+        np.testing.assert_allclose(scatter_color, expected, atol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# expression_heatmap
+# ---------------------------------------------------------------------------
+
+class TestExpressionHeatmap:
+    def test_returns_axes(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_works_without_classifications(self, expression_df):
+        ax = expression_heatmap(expression_df)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_accepts_explicit_ax(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        returned = expression_heatmap(expression_df, minimal_clf, ax=ax)
+        assert returned is ax
+
+    def test_heatmap_drawn(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf)
+        # imshow produces an AxesImage in ax.images
+        assert len(ax.images) >= 1
+
+    def test_n_per_label_limits_rows(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, n_per_label=3)
+        img = ax.images[0]
+        n_labels = minimal_clf['label'].nunique()
+        assert img.get_array().shape[0] <= 3 * n_labels
+
+    def test_colorbar_present(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, colorbar=True)
+        fig = ax.get_figure()
+        # colorbar creates an extra axes in the figure
+        assert len(fig.axes) >= 2
+
+    def test_no_colorbar(self, expression_df, minimal_clf):
+        _, ax = plt.subplots()
+        expression_heatmap(expression_df, minimal_clf, colorbar=False)
+        fig = ax.get_figure()
+        # label strip adds one extra axes, but no colorbar
+        assert len(fig.axes) <= 2
+
+    def test_custom_title(self, expression_df, minimal_clf):
+        ax = expression_heatmap(expression_df, minimal_clf, title="My heatmap")
+        assert ax.get_title() == "My heatmap"
+
+    def test_raises_on_no_zt_columns(self, minimal_clf):
+        bad_expr = pd.DataFrame(
+            np.ones((10, 4)),
+            index=minimal_clf.index[:10],
+            columns=['A', 'B', 'C', 'D'],
+        )
+        with pytest.raises(ValueError, match='ZT/CT'):
+            expression_heatmap(bad_expr, minimal_clf)

--- a/tests/visualization/test_compare_plots.py
+++ b/tests/visualization/test_compare_plots.py
@@ -1,9 +1,11 @@
 """Tests for circ.visualization.compare — condition comparison plots."""
+
 import numpy as np
 import pandas as pd
 import pytest
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.axes
 
@@ -21,25 +23,33 @@ from circ.visualization.compare import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_result(rseed=0, with_uncertainty=False, n=80):
     rng = np.random.default_rng(rseed)
-    idx = pd.Index([f'gene_{i:04d}' for i in range(n)], name='#')
-    tau   = rng.uniform(0.0, 1.0, n)
+    idx = pd.Index([f"gene_{i:04d}" for i in range(n)], name="#")
+    tau = rng.uniform(0.0, 1.0, n)
     emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
-    pirs  = rng.uniform(0.0, 2.0, n)
+    pirs = rng.uniform(0.0, 2.0, n)
     phase = rng.uniform(0.0, 24.0, n)
     labels = np.where(
-        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
-        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+        (tau > 0.5) & (emp_p < 0.05),
+        "rhythmic",
+        np.where(pirs < np.percentile(pirs, 50), "constitutive", "variable"),
     )
-    df = pd.DataFrame({
-        'tau_mean': tau, 'emp_p': emp_p, 'pirs_score': pirs,
-        'phase_mean': phase, 'label': labels,
-    }, index=idx)
+    df = pd.DataFrame(
+        {
+            "tau_mean": tau,
+            "emp_p": emp_p,
+            "pirs_score": pirs,
+            "phase_mean": phase,
+            "label": labels,
+        },
+        index=idx,
+    )
     if with_uncertainty:
-        df['tau_std']   = rng.uniform(0.05, 0.2, n)
-        df['phase_std'] = rng.uniform(0.5, 2.0, n)
-        df['n_boots']   = 50
+        df["tau_std"] = rng.uniform(0.05, 0.2, n)
+        df["phase_std"] = rng.uniform(0.5, 2.0, n)
+        df["n_boots"] = 50
     return df
 
 
@@ -60,6 +70,7 @@ def comp_with_uncertainty():
 # ---------------------------------------------------------------------------
 # rhythmicity_shift_scatter
 # ---------------------------------------------------------------------------
+
 
 class TestRhythmicityShiftScatter:
     def test_returns_axes(self, comp_basic):
@@ -84,6 +95,7 @@ class TestRhythmicityShiftScatter:
 # phase_shift_histogram
 # ---------------------------------------------------------------------------
 
+
 class TestPhaseShiftHistogram:
     def test_returns_axes(self, comp_basic):
         _, ax = plt.subplots()
@@ -92,8 +104,8 @@ class TestPhaseShiftHistogram:
         plt.close()
 
     def test_no_phase_data(self):
-        A = _make_result(rseed=0).drop(columns=['phase_mean'])
-        B = _make_result(rseed=1).drop(columns=['phase_mean'])
+        A = _make_result(rseed=0).drop(columns=["phase_mean"])
+        B = _make_result(rseed=1).drop(columns=["phase_mean"])
         comp = compare_conditions(A, B)
         _, ax = plt.subplots()
         result = phase_shift_histogram(comp, ax=ax)
@@ -103,9 +115,9 @@ class TestPhaseShiftHistogram:
     def test_no_rhythmic_genes(self):
         # Force all genes to be non-rhythmic so delta_phase is all NaN
         A = _make_result(rseed=0)
-        A['emp_p'] = 1.0   # nothing passes emp_p < 0.05
+        A["emp_p"] = 1.0  # nothing passes emp_p < 0.05
         B = _make_result(rseed=1)
-        B['emp_p'] = 1.0
+        B["emp_p"] = 1.0
         comp = compare_conditions(A, B)
         _, ax = plt.subplots()
         result = phase_shift_histogram(comp, ax=ax)
@@ -116,6 +128,7 @@ class TestPhaseShiftHistogram:
 # ---------------------------------------------------------------------------
 # label_transition_heatmap
 # ---------------------------------------------------------------------------
+
 
 class TestLabelTransitionHeatmap:
     def test_returns_axes(self, comp_basic):
@@ -129,10 +142,11 @@ class TestLabelTransitionHeatmap:
 # delta_tau_volcano
 # ---------------------------------------------------------------------------
 
+
 class TestDeltaTauVolcano:
     def test_raises_without_padj(self, comp_basic):
         _, ax = plt.subplots()
-        with pytest.raises(ValueError, match='tau_padj'):
+        with pytest.raises(ValueError, match="tau_padj"):
             delta_tau_volcano(comp_basic, ax=ax)
         plt.close()
 
@@ -147,21 +161,23 @@ class TestDeltaTauVolcano:
 # comparison_summary
 # ---------------------------------------------------------------------------
 
+
 class TestComparisonSummary:
     def test_returns_figure(self, comp_basic):
         fig = comparison_summary(comp_basic)
         assert fig is not None
-        plt.close('all')
+        plt.close("all")
 
     def test_returns_figure_with_uncertainty(self, comp_with_uncertainty):
         fig = comparison_summary(comp_with_uncertainty)
         assert fig is not None
-        plt.close('all')
+        plt.close("all")
 
     def test_saves_to_file(self, comp_basic, tmp_path):
-        out = str(tmp_path / 'test_summary.png')
+        out = str(tmp_path / "test_summary.png")
         fig = comparison_summary(comp_basic, outpath=out)
         assert fig is not None
         import os
+
         assert os.path.exists(out)
-        plt.close('all')
+        plt.close("all")

--- a/tests/visualization/test_interactive.py
+++ b/tests/visualization/test_interactive.py
@@ -22,6 +22,10 @@ from circ.visualization.interactive.benchmarks import (
     classification_pr,
     classification_roc,
 )
+from circ.visualization.interactive.compare import (
+    rhythmicity_shift_scatter,
+    delta_tau_volcano,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -314,3 +318,138 @@ class TestClassificationRoc:
         tc.index = [f'other_{i}' for i in range(len(tc))]
         fig = classification_roc(clf_df, tc)
         assert _is_figure(fig)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared by compare tests
+# ---------------------------------------------------------------------------
+
+def _make_compare_result(rseed=0, with_uncertainty=False, n=80):
+    from circ.compare import compare_conditions
+    rng = np.random.default_rng(rseed)
+    idx = pd.Index([f'gene_{i:04d}' for i in range(n)], name='#')
+    tau   = rng.uniform(0.0, 1.0, n)
+    emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
+    pirs  = rng.uniform(0.0, 2.0, n)
+    phase = rng.uniform(0.0, 24.0, n)
+    labels = np.where(
+        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
+        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+    )
+    df = pd.DataFrame({
+        'tau_mean': tau, 'emp_p': emp_p, 'pirs_score': pirs,
+        'phase_mean': phase, 'label': labels,
+    }, index=idx)
+    if with_uncertainty:
+        df['tau_std']   = rng.uniform(0.05, 0.2, n)
+        df['phase_std'] = rng.uniform(0.5, 2.0, n)
+        df['n_boots']   = 50
+    return df
+
+
+@pytest.fixture
+def comp_basic():
+    from circ.compare import compare_conditions
+    return compare_conditions(_make_compare_result(0), _make_compare_result(1))
+
+
+@pytest.fixture
+def comp_with_uncertainty():
+    from circ.compare import compare_conditions
+    return compare_conditions(
+        _make_compare_result(0, with_uncertainty=True),
+        _make_compare_result(1, with_uncertainty=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# rhythmicity_shift_scatter (interactive)
+# ---------------------------------------------------------------------------
+
+class TestInteractiveRhythmicityShiftScatter:
+    def test_returns_figure(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        assert _is_figure(fig)
+
+    def test_gene_ids_in_hover(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        assert len(all_text) > 0
+
+    def test_diagonal_trace_present(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic)
+        line_traces = [t for t in fig.data if t.mode == 'lines']
+        assert len(line_traces) >= 1
+
+    def test_with_padj_splits_sig_nonsig(self, comp_with_uncertainty):
+        fig = rhythmicity_shift_scatter(comp_with_uncertainty)
+        names = [t.name for t in fig.data]
+        assert any('FDR<' in n for n in names)
+
+    def test_custom_title(self, comp_basic):
+        fig = rhythmicity_shift_scatter(comp_basic, title='My title')
+        assert fig.layout.title.text == 'My title'
+
+
+# ---------------------------------------------------------------------------
+# delta_tau_volcano (interactive)
+# ---------------------------------------------------------------------------
+
+class TestInteractiveDeltaTauVolcano:
+    def test_returns_figure(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        assert _is_figure(fig)
+
+    def test_gene_ids_in_hover(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        assert len(all_text) > 0
+
+    def test_raises_without_tau_padj(self, comp_basic):
+        assert 'tau_padj' not in comp_basic.columns
+        with pytest.raises(ValueError, match='tau_padj'):
+            delta_tau_volcano(comp_basic)
+
+    def test_hline_present(self, comp_with_uncertainty):
+        fig = delta_tau_volcano(comp_with_uncertainty)
+        assert len(fig.layout.shapes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# expression_heatmap (interactive)
+# ---------------------------------------------------------------------------
+
+from circ.visualization.interactive.classify import expression_heatmap as iviz_expression_heatmap
+
+
+@pytest.fixture
+def expr_df(clf_df):
+    """Tiny expression matrix aligned to clf_df."""
+    rng = np.random.default_rng(10)
+    n = len(clf_df)
+    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=clf_df.index, columns=cols)
+
+
+class TestInteractiveExpressionHeatmap:
+    def test_returns_figure(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        assert _is_figure(fig)
+
+    def test_heatmap_trace_present(self, expr_df, clf_df):
+        import plotly.graph_objects as go
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        assert any(isinstance(t, go.Heatmap) for t in fig.data)
+
+    def test_gene_ids_in_y(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df)
+        heatmap = next(t for t in fig.data if isinstance(t, go.Heatmap))
+        assert len(heatmap.y) > 0
+
+    def test_works_without_classifications(self, expr_df):
+        fig = iviz_expression_heatmap(expr_df)
+        assert _is_figure(fig)
+
+    def test_custom_title(self, expr_df, clf_df):
+        fig = iviz_expression_heatmap(expr_df, clf_df, title='My title')
+        assert fig.layout.title.text == 'My title'

--- a/tests/visualization/test_interactive.py
+++ b/tests/visualization/test_interactive.py
@@ -1,11 +1,12 @@
 """Tests for circ.visualization.interactive — Plotly figure construction."""
+
 import re
 
 import numpy as np
 import pandas as pd
 import pytest
 
-plotly = pytest.importorskip('plotly')
+plotly = pytest.importorskip("plotly")
 import plotly.graph_objects as go
 
 from circ.visualization.interactive.classify import (
@@ -32,38 +33,51 @@ from circ.visualization.interactive.compare import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def clf_df():
     rng = np.random.default_rng(0)
     n = 100
-    labels = ['constitutive'] * 25 + ['rhythmic'] * 25 + ['variable'] * 25 + ['noisy_rhythmic'] * 25
-    return pd.DataFrame({
-        'pirs_score':  np.abs(rng.normal(0, 1, n)),
-        'tau_mean':    rng.uniform(0, 1, n),
-        'emp_p':       rng.uniform(0, 1, n),
-        'pval':        rng.uniform(0, 1, n),
-        'pval_bh':     rng.uniform(0, 1, n),
-        'slope_pval':  rng.uniform(0, 1, n),
-        'phase_mean':  rng.uniform(0, 24, n),
-        'period_mean': rng.uniform(20, 28, n),
-        'label':       labels,
-    }, index=[f'gene_{i}' for i in range(n)])
+    labels = (
+        ["constitutive"] * 25
+        + ["rhythmic"] * 25
+        + ["variable"] * 25
+        + ["noisy_rhythmic"] * 25
+    )
+    return pd.DataFrame(
+        {
+            "pirs_score": np.abs(rng.normal(0, 1, n)),
+            "tau_mean": rng.uniform(0, 1, n),
+            "emp_p": rng.uniform(0, 1, n),
+            "pval": rng.uniform(0, 1, n),
+            "pval_bh": rng.uniform(0, 1, n),
+            "slope_pval": rng.uniform(0, 1, n),
+            "phase_mean": rng.uniform(0, 24, n),
+            "period_mean": rng.uniform(20, 28, n),
+            "label": labels,
+        },
+        index=[f"gene_{i}" for i in range(n)],
+    )
 
 
 @pytest.fixture
 def true_classes(clf_df):
     rng = np.random.default_rng(1)
     n = len(clf_df)
-    return pd.DataFrame({
-        'Const':     rng.integers(0, 2, n),
-        'Circadian': rng.integers(0, 2, n),
-        'Linear':    rng.integers(0, 2, n),
-    }, index=clf_df.index)
+    return pd.DataFrame(
+        {
+            "Const": rng.integers(0, 2, n),
+            "Circadian": rng.integers(0, 2, n),
+            "Linear": rng.integers(0, 2, n),
+        },
+        index=clf_df.index,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _is_figure(obj):
     return isinstance(obj, go.Figure)
@@ -76,8 +90,7 @@ def _scatter_traces(fig):
 def _has_gene_ids(fig):
     """At least one Scatter trace carries gene IDs in its text field."""
     return any(
-        isinstance(t, go.Scatter) and t.text and len(t.text) > 0
-        for t in fig.data
+        isinstance(t, go.Scatter) and t.text and len(t.text) > 0 for t in fig.data
     )
 
 
@@ -89,6 +102,7 @@ def _n_shapes(fig):
 # label_distribution
 # ---------------------------------------------------------------------------
 
+
 class TestLabelDistribution:
     def test_returns_figure(self, clf_df):
         assert _is_figure(label_distribution(clf_df))
@@ -97,16 +111,17 @@ class TestLabelDistribution:
         fig = label_distribution(clf_df)
         assert len(fig.data) == 1
         bar = fig.data[0]
-        assert len(bar.y) == clf_df['label'].nunique()
+        assert len(bar.y) == clf_df["label"].nunique()
 
     def test_custom_title(self, clf_df):
-        fig = label_distribution(clf_df, title='My title')
-        assert fig.layout.title.text == 'My title'
+        fig = label_distribution(clf_df, title="My title")
+        assert fig.layout.title.text == "My title"
 
 
 # ---------------------------------------------------------------------------
 # pirs_vs_tau
 # ---------------------------------------------------------------------------
+
 
 class TestPirsVsTau:
     def test_returns_figure(self, clf_df):
@@ -114,7 +129,7 @@ class TestPirsVsTau:
 
     def test_one_trace_per_label(self, clf_df):
         fig = pirs_vs_tau(clf_df)
-        n_labels = clf_df['label'].nunique()
+        n_labels = clf_df["label"].nunique()
         assert len(_scatter_traces(fig)) == n_labels
 
     def test_gene_ids_in_hover(self, clf_df):
@@ -130,13 +145,14 @@ class TestPirsVsTau:
 # volcano
 # ---------------------------------------------------------------------------
 
+
 class TestVolcano:
     def test_returns_figure(self, clf_df):
         assert _is_figure(volcano(clf_df))
 
     def test_raises_without_emp_p(self, clf_df):
-        with pytest.raises(ValueError, match='emp_p'):
-            volcano(clf_df.drop(columns=['emp_p']))
+        with pytest.raises(ValueError, match="emp_p"):
+            volcano(clf_df.drop(columns=["emp_p"]))
 
     def test_gene_ids_in_hover(self, clf_df):
         fig = volcano(clf_df)
@@ -151,6 +167,7 @@ class TestVolcano:
 # pirs_score_distribution
 # ---------------------------------------------------------------------------
 
+
 class TestPirsScoreDistribution:
     def test_returns_figure(self, clf_df):
         assert _is_figure(pirs_score_distribution(clf_df))
@@ -158,7 +175,7 @@ class TestPirsScoreDistribution:
     def test_one_histogram_per_label(self, clf_df):
         fig = pirs_score_distribution(clf_df)
         hists = [t for t in fig.data if isinstance(t, go.Histogram)]
-        assert len(hists) == clf_df['label'].nunique()
+        assert len(hists) == clf_df["label"].nunique()
 
     def test_threshold_shape_added(self, clf_df):
         fig = pirs_score_distribution(clf_df)
@@ -169,13 +186,14 @@ class TestPirsScoreDistribution:
 # tau_pval_scatter
 # ---------------------------------------------------------------------------
 
+
 class TestTauPvalScatter:
     def test_returns_figure(self, clf_df):
         assert _is_figure(tau_pval_scatter(clf_df))
 
     def test_raises_without_emp_p(self, clf_df):
-        with pytest.raises(ValueError, match='emp_p'):
-            tau_pval_scatter(clf_df.drop(columns=['emp_p']))
+        with pytest.raises(ValueError, match="emp_p"):
+            tau_pval_scatter(clf_df.drop(columns=["emp_p"]))
 
     def test_gene_ids_in_hover(self, clf_df):
         fig = tau_pval_scatter(clf_df)
@@ -186,13 +204,14 @@ class TestTauPvalScatter:
 # phase_wheel
 # ---------------------------------------------------------------------------
 
+
 class TestPhaseWheel:
     def test_returns_figure(self, clf_df):
         assert _is_figure(phase_wheel(clf_df))
 
     def test_raises_without_phase_mean(self, clf_df):
-        with pytest.raises(ValueError, match='phase_mean'):
-            phase_wheel(clf_df.drop(columns=['phase_mean']))
+        with pytest.raises(ValueError, match="phase_mean"):
+            phase_wheel(clf_df.drop(columns=["phase_mean"]))
 
     def test_barpolar_trace_present(self, clf_df):
         fig = phase_wheel(clf_df)
@@ -205,22 +224,23 @@ class TestPhaseWheel:
 
     def test_fallback_to_all_genes_when_no_rhythmic(self, clf_df):
         df = clf_df.copy()
-        df['label'] = 'constitutive'
+        df["label"] = "constitutive"
         fig = phase_wheel(df)
-        assert 'all genes' in fig.layout.title.text
+        assert "all genes" in fig.layout.title.text
 
 
 # ---------------------------------------------------------------------------
 # period_distribution
 # ---------------------------------------------------------------------------
 
+
 class TestPeriodDistribution:
     def test_returns_figure(self, clf_df):
         assert _is_figure(period_distribution(clf_df))
 
     def test_raises_without_period_mean(self, clf_df):
-        with pytest.raises(ValueError, match='period_mean'):
-            period_distribution(clf_df.drop(columns=['period_mean']))
+        with pytest.raises(ValueError, match="period_mean"):
+            period_distribution(clf_df.drop(columns=["period_mean"]))
 
     def test_reference_line_added(self, clf_df):
         fig = period_distribution(clf_df)
@@ -230,6 +250,7 @@ class TestPeriodDistribution:
 # ---------------------------------------------------------------------------
 # classification_summary
 # ---------------------------------------------------------------------------
+
 
 class TestClassificationSummary:
     def test_returns_figure(self, clf_df):
@@ -242,11 +263,14 @@ class TestClassificationSummary:
     def test_minimal_columns_no_crash(self):
         rng = np.random.default_rng(7)
         n = 40
-        df = pd.DataFrame({
-            'pirs_score': rng.uniform(0, 1, n),
-            'tau_mean':   rng.uniform(0, 1, n),
-            'label':      ['constitutive'] * 20 + ['variable'] * 20,
-        }, index=[f'g{i}' for i in range(n)])
+        df = pd.DataFrame(
+            {
+                "pirs_score": rng.uniform(0, 1, n),
+                "tau_mean": rng.uniform(0, 1, n),
+                "label": ["constitutive"] * 20 + ["variable"] * 20,
+            },
+            index=[f"g{i}" for i in range(n)],
+        )
         fig = classification_summary(df)
         assert _is_figure(fig)
 
@@ -255,13 +279,14 @@ class TestClassificationSummary:
 # classification_pr
 # ---------------------------------------------------------------------------
 
+
 class TestClassificationPr:
     def test_returns_figure(self, clf_df, true_classes):
         assert _is_figure(classification_pr(clf_df, true_classes))
 
     def test_ap_in_trace_name(self, clf_df, true_classes):
         fig = classification_pr(clf_df, true_classes)
-        assert any('AP=' in t.name for t in fig.data if t.name)
+        assert any("AP=" in t.name for t in fig.data if t.name)
 
     def test_threshold_in_hover(self, clf_df, true_classes):
         fig = classification_pr(clf_df, true_classes)
@@ -270,7 +295,7 @@ class TestClassificationPr:
 
     def test_empty_intersection_no_crash(self, clf_df, true_classes):
         tc = true_classes.copy()
-        tc.index = [f'other_{i}' for i in range(len(tc))]
+        tc.index = [f"other_{i}" for i in range(len(tc))]
         fig = classification_pr(clf_df, tc)
         assert _is_figure(fig)
 
@@ -279,43 +304,45 @@ class TestClassificationPr:
 # classification_roc
 # ---------------------------------------------------------------------------
 
+
 class TestClassificationRoc:
     def test_returns_figure(self, clf_df, true_classes):
         assert _is_figure(classification_roc(clf_df, true_classes))
 
     def test_auc_in_trace_names(self, clf_df, true_classes):
         fig = classification_roc(clf_df, true_classes)
-        auc_labels = [t.name for t in fig.data if t.name and 'AUC=' in t.name]
+        auc_labels = [t.name for t in fig.data if t.name and "AUC=" in t.name]
         assert len(auc_labels) >= 1
 
     def test_diagonal_trace_present(self, clf_df, true_classes):
         fig = classification_roc(clf_df, true_classes)
-        assert any('random' in (t.name or '') for t in fig.data)
+        assert any("random" in (t.name or "") for t in fig.data)
 
     def test_explicit_tasks(self, clf_df, true_classes):
-        fig = classification_roc(clf_df, true_classes,
-                                 tasks=[('pirs_score', 'Const', True)])
+        fig = classification_roc(
+            clf_df, true_classes, tasks=[("pirs_score", "Const", True)]
+        )
         # one method trace + diagonal
         assert len(fig.data) == 2
 
     def test_perfect_score_auc_near_one(self):
         n = 100
         clf = pd.DataFrame(
-            {'pirs_score': np.array([0.001] * 25 + [0.99] * 75)},
-            index=[f'g{i}' for i in range(n)],
+            {"pirs_score": np.array([0.001] * 25 + [0.99] * 75)},
+            index=[f"g{i}" for i in range(n)],
         )
         truth = pd.DataFrame(
-            {'Const': np.array([1] * 25 + [0] * 75)},
+            {"Const": np.array([1] * 25 + [0] * 75)},
             index=clf.index,
         )
-        fig = classification_roc(clf, truth, tasks=[('pirs_score', 'Const', True)])
-        auc_match = re.search(r'AUC=([0-9.]+)', fig.data[0].name)
+        fig = classification_roc(clf, truth, tasks=[("pirs_score", "Const", True)])
+        auc_match = re.search(r"AUC=([0-9.]+)", fig.data[0].name)
         assert auc_match is not None
         assert float(auc_match.group(1)) > 0.99
 
     def test_empty_intersection_no_crash(self, clf_df, true_classes):
         tc = true_classes.copy()
-        tc.index = [f'other_{i}' for i in range(len(tc))]
+        tc.index = [f"other_{i}" for i in range(len(tc))]
         fig = classification_roc(clf_df, tc)
         assert _is_figure(fig)
 
@@ -324,38 +351,47 @@ class TestClassificationRoc:
 # Fixtures shared by compare tests
 # ---------------------------------------------------------------------------
 
+
 def _make_compare_result(rseed=0, with_uncertainty=False, n=80):
-    from circ.compare import compare_conditions
     rng = np.random.default_rng(rseed)
-    idx = pd.Index([f'gene_{i:04d}' for i in range(n)], name='#')
-    tau   = rng.uniform(0.0, 1.0, n)
+    idx = pd.Index([f"gene_{i:04d}" for i in range(n)], name="#")
+    tau = rng.uniform(0.0, 1.0, n)
     emp_p = np.where(tau > 0.5, rng.uniform(0.0, 0.05, n), rng.uniform(0.05, 1.0, n))
-    pirs  = rng.uniform(0.0, 2.0, n)
+    pirs = rng.uniform(0.0, 2.0, n)
     phase = rng.uniform(0.0, 24.0, n)
     labels = np.where(
-        (tau > 0.5) & (emp_p < 0.05), 'rhythmic',
-        np.where(pirs < np.percentile(pirs, 50), 'constitutive', 'variable'),
+        (tau > 0.5) & (emp_p < 0.05),
+        "rhythmic",
+        np.where(pirs < np.percentile(pirs, 50), "constitutive", "variable"),
     )
-    df = pd.DataFrame({
-        'tau_mean': tau, 'emp_p': emp_p, 'pirs_score': pirs,
-        'phase_mean': phase, 'label': labels,
-    }, index=idx)
+    df = pd.DataFrame(
+        {
+            "tau_mean": tau,
+            "emp_p": emp_p,
+            "pirs_score": pirs,
+            "phase_mean": phase,
+            "label": labels,
+        },
+        index=idx,
+    )
     if with_uncertainty:
-        df['tau_std']   = rng.uniform(0.05, 0.2, n)
-        df['phase_std'] = rng.uniform(0.5, 2.0, n)
-        df['n_boots']   = 50
+        df["tau_std"] = rng.uniform(0.05, 0.2, n)
+        df["phase_std"] = rng.uniform(0.5, 2.0, n)
+        df["n_boots"] = 50
     return df
 
 
 @pytest.fixture
 def comp_basic():
     from circ.compare import compare_conditions
+
     return compare_conditions(_make_compare_result(0), _make_compare_result(1))
 
 
 @pytest.fixture
 def comp_with_uncertainty():
     from circ.compare import compare_conditions
+
     return compare_conditions(
         _make_compare_result(0, with_uncertainty=True),
         _make_compare_result(1, with_uncertainty=True),
@@ -366,6 +402,7 @@ def comp_with_uncertainty():
 # rhythmicity_shift_scatter (interactive)
 # ---------------------------------------------------------------------------
 
+
 class TestInteractiveRhythmicityShiftScatter:
     def test_returns_figure(self, comp_basic):
         fig = rhythmicity_shift_scatter(comp_basic)
@@ -373,27 +410,33 @@ class TestInteractiveRhythmicityShiftScatter:
 
     def test_gene_ids_in_hover(self, comp_basic):
         fig = rhythmicity_shift_scatter(comp_basic)
-        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        all_text = [
+            t
+            for trace in fig.data
+            if hasattr(trace, "text") and trace.text
+            for t in trace.text
+        ]
         assert len(all_text) > 0
 
     def test_diagonal_trace_present(self, comp_basic):
         fig = rhythmicity_shift_scatter(comp_basic)
-        line_traces = [t for t in fig.data if t.mode == 'lines']
+        line_traces = [t for t in fig.data if t.mode == "lines"]
         assert len(line_traces) >= 1
 
     def test_with_padj_splits_sig_nonsig(self, comp_with_uncertainty):
         fig = rhythmicity_shift_scatter(comp_with_uncertainty)
         names = [t.name for t in fig.data]
-        assert any('FDR<' in n for n in names)
+        assert any("FDR<" in n for n in names)
 
     def test_custom_title(self, comp_basic):
-        fig = rhythmicity_shift_scatter(comp_basic, title='My title')
-        assert fig.layout.title.text == 'My title'
+        fig = rhythmicity_shift_scatter(comp_basic, title="My title")
+        assert fig.layout.title.text == "My title"
 
 
 # ---------------------------------------------------------------------------
 # delta_tau_volcano (interactive)
 # ---------------------------------------------------------------------------
+
 
 class TestInteractiveDeltaTauVolcano:
     def test_returns_figure(self, comp_with_uncertainty):
@@ -402,12 +445,17 @@ class TestInteractiveDeltaTauVolcano:
 
     def test_gene_ids_in_hover(self, comp_with_uncertainty):
         fig = delta_tau_volcano(comp_with_uncertainty)
-        all_text = [t for trace in fig.data if hasattr(trace, 'text') and trace.text for t in trace.text]
+        all_text = [
+            t
+            for trace in fig.data
+            if hasattr(trace, "text") and trace.text
+            for t in trace.text
+        ]
         assert len(all_text) > 0
 
     def test_raises_without_tau_padj(self, comp_basic):
-        assert 'tau_padj' not in comp_basic.columns
-        with pytest.raises(ValueError, match='tau_padj'):
+        assert "tau_padj" not in comp_basic.columns
+        with pytest.raises(ValueError, match="tau_padj"):
             delta_tau_volcano(comp_basic)
 
     def test_hline_present(self, comp_with_uncertainty):
@@ -419,7 +467,9 @@ class TestInteractiveDeltaTauVolcano:
 # expression_heatmap (interactive)
 # ---------------------------------------------------------------------------
 
-from circ.visualization.interactive.classify import expression_heatmap as iviz_expression_heatmap
+from circ.visualization.interactive.classify import (
+    expression_heatmap as iviz_expression_heatmap,
+)
 
 
 @pytest.fixture
@@ -427,8 +477,10 @@ def expr_df(clf_df):
     """Tiny expression matrix aligned to clf_df."""
     rng = np.random.default_rng(10)
     n = len(clf_df)
-    cols = [f'ZT{h:02d}_{r}' for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
-    return pd.DataFrame(rng.normal(5, 1, (n, len(cols))), index=clf_df.index, columns=cols)
+    cols = [f"ZT{h:02d}_{r}" for h in [0, 4, 8, 12, 16, 20] for r in [1, 2]]
+    return pd.DataFrame(
+        rng.normal(5, 1, (n, len(cols))), index=clf_df.index, columns=cols
+    )
 
 
 class TestInteractiveExpressionHeatmap:
@@ -438,6 +490,7 @@ class TestInteractiveExpressionHeatmap:
 
     def test_heatmap_trace_present(self, expr_df, clf_df):
         import plotly.graph_objects as go
+
         fig = iviz_expression_heatmap(expr_df, clf_df)
         assert any(isinstance(t, go.Heatmap) for t in fig.data)
 
@@ -451,5 +504,5 @@ class TestInteractiveExpressionHeatmap:
         assert _is_figure(fig)
 
     def test_custom_title(self, expr_df, clf_df):
-        fig = iviz_expression_heatmap(expr_df, clf_df, title='My title')
-        assert fig.layout.title.text == 'My title'
+        fig = iviz_expression_heatmap(expr_df, clf_df, title="My title")
+        assert fig.layout.title.text == "My title"


### PR DESCRIPTION
## Summary

- **`gene_profile`** — new public plot function rendering a single gene's time-series (replicates as scatter + per-timepoint mean line), color-coded by classification label and annotated with τ, phase, and PIRS score in the title. Replaces the local helper in example 05.
- **`expression_heatmap`** (static + interactive) — clustered heatmap of representative genes grouped by label. Genes are ranked per-label by the most informative score, z-scored across timepoints, and sorted by within-group hierarchical clustering. The static version adds a label color strip via `AxesDivider`; the interactive Plotly version adds hover tooltips and a right-axis label bar.
- **`circ.visualization.interactive.compare`** (new module) — `rhythmicity_shift_scatter` and `delta_tau_volcano` Plotly figures extracted from inline code in example 06 into a reusable module, exposed through `circ.visualization.interactive`.
- **`label_distribution` `xlim` param** — optional fixed upper x-limit for side-by-side comparison charts (examples 06 and 07).
- **`volcano` quadrant labels** — italic corner annotations labeling the four expression zones (constitutive / variable / noisy_rhythmic / rhythmic).
- **`classification_summary` improvements** — `threshold_sensitivity` always included; `slope_pval_scatter` added whenever slope data is present (not gated on `emp_p`); fixed `has_slope_emp` logic.
- **Internal clean-ups** — `_zt_timepoints` helper extracted and shared; `_ax` deduplicated (benchmarks imports from classify).

## Test plan

CI runs the full test suite. New coverage includes `TestGeneProfile`, `TestExpressionHeatmap`, `TestLabelDistributionXlim`, `TestInteractiveRhythmicityShiftScatter`, `TestInteractiveDeltaTauVolcano`, and `TestInteractiveExpressionHeatmap`, plus updated panel-count assertions in `TestClassificationSummary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)