### PR TITLE
Support 3+ digit ZT/CT time values throughout the pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Expression inputs and outputs support two formats, detected by file extension:
 Column convention for expression data:
 - First column: gene/peptide ID (header cell is `#` or `ID`)
 - Remaining columns: ZT- or CT-prefixed sample names, e.g. `ZT02_1`, `ZT04_2`
+- Time values can be any non-negative integer; 3+ digit times (`ZT100_1`, `ZT120_2`) are fully supported throughout the pipeline
 
 All module constructors (`ranker`, `sva`, `imputable`, `Classifier`) accept either a file path
 or a `pd.DataFrame` directly.  Use `circ.io.read_expression` / `write_expression` for

--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ poetry install --extras fast
 
 ## Data format
 
-All tools expect expression data with samples as columns named `ZT{HH}_{rep}`
-(zero-padded two-digit Zeitgeber Time, underscore, replicate number):
+All tools expect expression data with samples as columns named `ZT{time}_{rep}`
+(Zeitgeber Time as any non-negative integer, underscore, replicate number).
+Short experiments typically use two-digit times; longer time series (> 99 h)
+use three or more digits — all are handled identically:
 
 ```
 #       ZT02_1  ZT02_2  ZT04_1  ZT04_2  ZT06_1  ZT06_2
 gene_a  1.23    1.19    0.95    1.01    0.88    0.92
+gene_b  ...
+```
+
+```
+#       ZT100_1  ZT100_2  ZT104_1  ZT104_2  ZT108_1  ZT108_2
+gene_a  1.23     1.19     0.95     1.01     0.88     0.92
 gene_b  ...
 ```
 

--- a/circ/bootjtk/BooteJTK.py
+++ b/circ/bootjtk/BooteJTK.py
@@ -772,7 +772,8 @@ def __create_parser__():
         default="DEFAULT",
         type=str,
         help="Tab-delimited input file. Header row must start with # or ID "
-        "followed by timepoints in ZTn or CTn format. "
+        "followed by timepoints in ZT{n} or CT{n} format, where {n} is any "
+        "non-negative integer (e.g. ZT0, ZT4, ZT100). "
         "Use NA for missing values.",
     )
 

--- a/circ/bootjtk/pipeline.py
+++ b/circ/bootjtk/pipeline.py
@@ -351,7 +351,7 @@ def __create_parser__():
         type=str,
         default="DEFAULT",
         help="This is the filename of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0, ZT4, or ZT100 for longer time series). The prefix must be exactly CT or ZT; the numeric part can be any non-negative integer. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
     )
     analysis.add_argument(
         "-F",
@@ -362,7 +362,7 @@ def __create_parser__():
         default="DEFAULT",
         type=str,
         help="This is the filename of the time point means of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0, ZT4, or ZT100 for longer time series). The prefix must be exactly CT or ZT; the numeric part can be any non-negative integer. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
     )
 
     analysis.add_argument(
@@ -374,7 +374,7 @@ def __create_parser__():
         default="DEFAULT",
         type=str,
         help="This is the filename of the time point standard devations of the data series you wish to analyze.\
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0, ZT4, or ZT100 for longer time series). The prefix must be exactly CT or ZT; the numeric part can be any non-negative integer. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
     )
 
     analysis.add_argument(
@@ -386,7 +386,7 @@ def __create_parser__():
         default="DEFAULT",
         type=str,
         help="This is the filename of the time point replicate numbers of the data series you wish to analyze.                         \
-                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0 or ZT4). Longer or shorter prefixes will not work. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
+                   The data should be tab-spaced. The first row should contain a # sign followed by the time points with either CT or ZT preceding the time point (such as ZT0, ZT4, or ZT100 for longer time series). The prefix must be exactly CT or ZT; the numeric part can be any non-negative integer. The following rows should contain the gene/series ID followed by the values for every time point. Where values are not available NA should be put in it's place.",
     )
 
     analysis.add_argument(

--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -92,7 +92,7 @@ class simulate:
         self.nrows = int(nrows)
         self.tpoint_space = int(tpoint_space)
 
-        # Column names: ZT{HH}_{rep}
+        # Column names: ZT{time}_{rep}  (time zero-padded to ≥2 digits)
         self.cols = [
             "ZT{:02d}_{}".format(tpoint_space * i + tpoint_space, j + 1)
             for i in range(self.tpoints)

--- a/tests/bootjtk/test_limma_preprocess.py
+++ b/tests/bootjtk/test_limma_preprocess.py
@@ -1,4 +1,5 @@
 """Tests for bootjtk/limma_preprocess.py — Python data-plumbing functions."""
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -17,35 +18,46 @@ from circ.bootjtk.limma_preprocess import (
 # parse_timepoint_label
 # ---------------------------------------------------------------------------
 
+
 class TestParseTimepointLabel:
     def test_zt_prefix(self):
-        assert parse_timepoint_label('ZT4') == 4.0
+        assert parse_timepoint_label("ZT4") == 4.0
 
     def test_ct_prefix(self):
-        assert parse_timepoint_label('CT12') == 12.0
+        assert parse_timepoint_label("CT12") == 12.0
 
     def test_x_prefix(self):
-        assert parse_timepoint_label('X8') == 8.0
+        assert parse_timepoint_label("X8") == 8.0
 
     def test_bare_number(self):
-        assert parse_timepoint_label('0') == 0.0
+        assert parse_timepoint_label("0") == 0.0
 
     def test_float_string(self):
-        assert parse_timepoint_label('2.5') == 2.5
+        assert parse_timepoint_label("2.5") == 2.5
 
     def test_leading_whitespace_stripped(self):
-        assert parse_timepoint_label(' ZT6') == 6.0
+        assert parse_timepoint_label(" ZT6") == 6.0
 
     def test_zt_zero(self):
-        assert parse_timepoint_label('ZT0') == 0.0
+        assert parse_timepoint_label("ZT0") == 0.0
 
     def test_large_value(self):
-        assert parse_timepoint_label('ZT46') == 46.0
+        assert parse_timepoint_label("ZT46") == 46.0
+
+    def test_three_digit_zt(self):
+        assert parse_timepoint_label("ZT100") == 100.0
+
+    def test_three_digit_ct(self):
+        assert parse_timepoint_label("CT120") == 120.0
+
+    def test_three_digit_with_replicate(self):
+        assert parse_timepoint_label("ZT100_2") == 100.0
 
 
 # ---------------------------------------------------------------------------
 # deduplicate_timepoints
 # ---------------------------------------------------------------------------
+
 
 class TestDeduplicateTimepoints:
     def test_no_duplicates_unchanged(self):
@@ -94,72 +106,74 @@ class TestDeduplicateTimepoints:
 # deduplicate_rownames
 # ---------------------------------------------------------------------------
 
+
 class TestDeduplicateRownames:
     def test_no_duplicates_unchanged(self):
-        names = ['a', 'b', 'c']
-        assert deduplicate_rownames(names) == ['a', 'b', 'c']
+        names = ["a", "b", "c"]
+        assert deduplicate_rownames(names) == ["a", "b", "c"]
 
     def test_single_duplicate_appends_suffix(self):
-        result = deduplicate_rownames(['a', 'b', 'a'])
-        assert result == ['a', 'b', 'a-xxx1']
+        result = deduplicate_rownames(["a", "b", "a"])
+        assert result == ["a", "b", "a-xxx1"]
 
     def test_three_of_same(self):
-        result = deduplicate_rownames(['a', 'a', 'a'])
+        result = deduplicate_rownames(["a", "a", "a"])
         assert len(set(result)) == 3
-        assert result[0] == 'a'
+        assert result[0] == "a"
 
     def test_all_unique_after_dedup(self):
-        names = ['gene1', 'gene2', 'gene1', 'gene3', 'gene2']
+        names = ["gene1", "gene2", "gene1", "gene3", "gene2"]
         result = deduplicate_rownames(names)
         assert len(result) == len(set(result))
 
     def test_length_preserved(self):
-        names = ['a', 'b', 'a', 'c', 'a']
+        names = ["a", "b", "a", "c", "a"]
         result = deduplicate_rownames(names)
         assert len(result) == len(names)
 
     def test_first_occurrence_unchanged(self):
-        result = deduplicate_rownames(['x', 'y', 'x'])
-        assert result[0] == 'x'
-        assert result[1] == 'y'
+        result = deduplicate_rownames(["x", "y", "x"])
+        assert result[0] == "x"
+        assert result[1] == "y"
 
 
 # ---------------------------------------------------------------------------
 # read_timeseries
 # ---------------------------------------------------------------------------
 
+
 class TestReadTimeseries:
     def test_hash_header(self, tmp_path):
-        f = tmp_path / 'data.txt'
-        f.write_text('#\tZT0\tZT2\tZT4\ngene1\t1.0\t2.0\t3.0\n')
+        f = tmp_path / "data.txt"
+        f.write_text("#\tZT0\tZT2\tZT4\ngene1\t1.0\t2.0\t3.0\n")
         df, raw_cols = read_timeseries(str(f))
-        assert raw_cols == ['ZT0', 'ZT2', 'ZT4']
-        assert 'gene1' in df.index
+        assert raw_cols == ["ZT0", "ZT2", "ZT4"]
+        assert "gene1" in df.index
 
     def test_id_header(self, tmp_path):
-        f = tmp_path / 'data.txt'
-        f.write_text('ID\tZT0\tZT2\ngeneA\t5.0\t6.0\ngeneB\t7.0\t8.0\n')
+        f = tmp_path / "data.txt"
+        f.write_text("ID\tZT0\tZT2\ngeneA\t5.0\t6.0\ngeneB\t7.0\t8.0\n")
         df, raw_cols = read_timeseries(str(f))
-        assert raw_cols == ['ZT0', 'ZT2']
-        assert list(df.index) == ['geneA', 'geneB']
+        assert raw_cols == ["ZT0", "ZT2"]
+        assert list(df.index) == ["geneA", "geneB"]
 
     def test_na_values_are_nan(self, tmp_path):
-        f = tmp_path / 'data.txt'
-        f.write_text('#\tZT0\tZT2\ngene1\tNA\t2.0\n')
+        f = tmp_path / "data.txt"
+        f.write_text("#\tZT0\tZT2\ngene1\tNA\t2.0\n")
         df, _ = read_timeseries(str(f))
         assert np.isnan(df.iloc[0, 0])
 
     def test_values_are_numeric(self, tmp_path):
-        f = tmp_path / 'data.txt'
-        f.write_text('#\tZT0\tZT2\ngene1\t1.5\t2.5\n')
+        f = tmp_path / "data.txt"
+        f.write_text("#\tZT0\tZT2\ngene1\t1.5\t2.5\n")
         df, _ = read_timeseries(str(f))
-        assert df.dtypes.iloc[0] == float
+        assert np.issubdtype(df.dtypes.iloc[0], np.floating)
 
     def test_multiple_genes(self, tmp_path):
-        lines = '#\t' + '\t'.join(f'ZT{i}' for i in range(0, 24, 2)) + '\n'
+        lines = "#\t" + "\t".join(f"ZT{i}" for i in range(0, 24, 2)) + "\n"
         for i in range(5):
-            lines += f'gene{i}\t' + '\t'.join(['1.0'] * 12) + '\n'
-        f = tmp_path / 'data.txt'
+            lines += f"gene{i}\t" + "\t".join(["1.0"] * 12) + "\n"
+        f = tmp_path / "data.txt"
         f.write_text(lines)
         df, raw_cols = read_timeseries(str(f))
         assert len(df) == 5
@@ -170,57 +184,63 @@ class TestReadTimeseries:
 # prepare_timeseries
 # ---------------------------------------------------------------------------
 
+
 class TestPrepareTimeseries:
     def _make_file(self, tmp_path, content):
-        f = tmp_path / 'data.txt'
+        f = tmp_path / "data.txt"
         f.write_text(content)
         return str(f)
 
     def test_column_names_are_float(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT0\tZT2\tZT4\ngene1\t1.0\t2.0\t3.0\n')
+        fn = self._make_file(tmp_path, "#\tZT0\tZT2\tZT4\ngene1\t1.0\t2.0\t3.0\n")
         df, _ = prepare_timeseries(fn, 24.0)
         assert all(isinstance(c, float) for c in df.columns)
 
     def test_zt_prefix_stripped(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT0\tZT4\ngene1\t1.0\t2.0\n')
+        fn = self._make_file(tmp_path, "#\tZT0\tZT4\ngene1\t1.0\t2.0\n")
         df, _ = prepare_timeseries(fn, 24.0)
         assert list(df.columns) == [0.0, 4.0]
 
     def test_unique_times_sorted(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT4\tZT0\tZT2\ngene1\t1.0\t2.0\t3.0\n')
+        fn = self._make_file(tmp_path, "#\tZT4\tZT0\tZT2\ngene1\t1.0\t2.0\t3.0\n")
         _, unique_times = prepare_timeseries(fn, 24.0)
         assert unique_times == sorted(unique_times)
 
     def test_unique_times_mod_period(self, tmp_path):
         # ZT0..ZT46 step 2 → unique times 0..22 step 2
-        cols = '\t'.join(f'ZT{i}' for i in range(0, 48, 2))
-        fn = self._make_file(tmp_path, f'#\t{cols}\ngene1\t' + '\t'.join(['1.0'] * 24) + '\n')
+        cols = "\t".join(f"ZT{i}" for i in range(0, 48, 2))
+        fn = self._make_file(
+            tmp_path, f"#\t{cols}\ngene1\t" + "\t".join(["1.0"] * 24) + "\n"
+        )
         _, unique_times = prepare_timeseries(fn, 24.0)
         assert unique_times == list(range(0, 24, 2))
 
     def test_duplicate_columns_deduplicated(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT0\tZT0\tZT2\ngene1\t1.0\t2.0\t3.0\n')
+        fn = self._make_file(tmp_path, "#\tZT0\tZT0\tZT2\ngene1\t1.0\t2.0\t3.0\n")
         df, _ = prepare_timeseries(fn, 24.0)
         assert len(df.columns) == len(set(df.columns))
 
     def test_duplicate_rows_deduplicated(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT0\tZT2\ngene1\t1.0\t2.0\ngene1\t3.0\t4.0\n')
+        fn = self._make_file(
+            tmp_path, "#\tZT0\tZT2\ngene1\t1.0\t2.0\ngene1\t3.0\t4.0\n"
+        )
         df, _ = prepare_timeseries(fn, 24.0)
         assert len(df.index) == len(set(df.index))
 
     def test_index_name_is_id(self, tmp_path):
-        fn = self._make_file(tmp_path, '#\tZT0\ngene1\t1.0\n')
+        fn = self._make_file(tmp_path, "#\tZT0\ngene1\t1.0\n")
         df, _ = prepare_timeseries(fn, 24.0)
-        assert df.index.name == 'ID'
+        assert df.index.name == "ID"
 
     def test_example_file(self):
         import os
+
         example = os.path.join(
-            os.path.dirname(__file__), '..', 'example', 'TestInput4.txt'
+            os.path.dirname(__file__), "..", "example", "TestInput4.txt"
         )
         df, unique_times = prepare_timeseries(example, 24.0)
         assert list(unique_times) == list(range(0, 24, 2))
-        assert len(df.columns) == 24   # ZT0..ZT46 → 24 unique deduplicated cols
+        assert len(df.columns) == 24  # ZT0..ZT46 → 24 unique deduplicated cols
         assert len(df) > 0
 
 
@@ -228,50 +248,56 @@ class TestPrepareTimeseries:
 # write_limma_outputs
 # ---------------------------------------------------------------------------
 
+
 class TestWriteLimmaOutputs:
     @pytest.fixture()
     def long_df(self):
-        return pd.DataFrame({
-            'ID':    ['g1', 'g1', 'g2', 'g2'],
-            'Time':  [0.0, 2.0, 0.0, 2.0],
-            'Mean':  [1.0, 2.0, 3.0, 4.0],
-            'SD':    [0.1, 0.2, 0.3, 0.4],
-            'SDpre': [0.5, 0.6, 0.7, 0.8],
-            'N':     [2.0, 2.0, 2.0, 2.0],
-        })
+        return pd.DataFrame(
+            {
+                "ID": ["g1", "g1", "g2", "g2"],
+                "Time": [0.0, 2.0, 0.0, 2.0],
+                "Mean": [1.0, 2.0, 3.0, 4.0],
+                "SD": [0.1, 0.2, 0.3, 0.4],
+                "SDpre": [0.5, 0.6, 0.7, 0.8],
+                "N": [2.0, 2.0, 2.0, 2.0],
+            }
+        )
 
     def test_means_file_created(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 'sample'), 'postLimma')
-        assert (tmp_path / 'sample_Means_postLimma.txt').exists()
+        write_limma_outputs(long_df, str(tmp_path / "sample"), "postLimma")
+        assert (tmp_path / "sample_Means_postLimma.txt").exists()
 
     def test_sds_file_created(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 'sample'), 'postLimma')
-        assert (tmp_path / 'sample_Sds_postLimma.txt').exists()
+        write_limma_outputs(long_df, str(tmp_path / "sample"), "postLimma")
+        assert (tmp_path / "sample_Sds_postLimma.txt").exists()
 
     def test_ns_file_created(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 'sample'), 'postLimma')
-        assert (tmp_path / 'sample_Ns_postLimma.txt').exists()
+        write_limma_outputs(long_df, str(tmp_path / "sample"), "postLimma")
+        assert (tmp_path / "sample_Ns_postLimma.txt").exists()
 
     def test_sdspre_file_created(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 'sample'), 'postLimma')
-        assert (tmp_path / 'sample_Sds-pre_postLimma.txt').exists()
+        write_limma_outputs(long_df, str(tmp_path / "sample"), "postLimma")
+        assert (tmp_path / "sample_Sds-pre_postLimma.txt").exists()
 
     def test_means_values_correct(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 'sample'), 'postLimma')
-        result = pd.read_table(str(tmp_path / 'sample_Means_postLimma.txt'), index_col='ID')
-        assert result.loc['g1'].iloc[0] == pytest.approx(1.0)
-        assert result.loc['g2'].iloc[1] == pytest.approx(4.0)
+        write_limma_outputs(long_df, str(tmp_path / "sample"), "postLimma")
+        result = pd.read_table(
+            str(tmp_path / "sample_Means_postLimma.txt"), index_col="ID"
+        )
+        assert result.loc["g1"].iloc[0] == pytest.approx(1.0)
+        assert result.loc["g2"].iloc[1] == pytest.approx(4.0)
 
     def test_wide_shape(self, tmp_path, long_df):
-        write_limma_outputs(long_df, str(tmp_path / 's'), 'postVash')
-        means = pd.read_table(str(tmp_path / 's_Means_postVash.txt'), index_col='ID')
-        assert means.shape == (2, 2)   # 2 genes × 2 time points
+        write_limma_outputs(long_df, str(tmp_path / "s"), "postVash")
+        means = pd.read_table(str(tmp_path / "s_Means_postVash.txt"), index_col="ID")
+        assert means.shape == (2, 2)  # 2 genes × 2 time points
 
     def test_readable_by_bootjtk_read_in(self, tmp_path, long_df):
         from circ.bootjtk.BooteJTK import read_in
-        write_limma_outputs(long_df, str(tmp_path / 's'), 'postLimma')
-        header, data = read_in(str(tmp_path / 's_Means_postLimma.txt'))
-        assert len(header) == 2       # two time points
-        assert len(data) == 2         # two genes
-        assert data[0][0] == 'g1'
-        assert data[1][0] == 'g2'
+
+        write_limma_outputs(long_df, str(tmp_path / "s"), "postLimma")
+        header, data = read_in(str(tmp_path / "s_Means_postLimma.txt"))
+        assert len(header) == 2  # two time points
+        assert len(data) == 2  # two genes
+        assert data[0][0] == "g1"
+        assert data[1][0] == "g2"

--- a/tests/pirs/test_rank.py
+++ b/tests/pirs/test_rank.py
@@ -4,7 +4,6 @@ import pandas as pd
 import os
 
 from circ.pirs.rank import ranker, rsd_ranker
-from tests.pirs.conftest import make_ranker_tsv
 
 
 class TestRankerInit:
@@ -57,6 +56,19 @@ class TestGetTpoints:
         r.get_tpoints()
         for t in np.unique(r.tpoints):
             assert np.sum(r.tpoints == t) == 3
+
+    def test_three_digit_zt_columns(self):
+        df = pd.DataFrame(
+            {
+                "ZT100_1": [1.0, 2.0],
+                "ZT104_1": [1.5, 2.5],
+                "ZT108_1": [2.0, 3.0],
+            },
+            index=pd.Index(["gene_a", "gene_b"], name="#"),
+        )
+        r = ranker(df)
+        r.get_tpoints()
+        assert sorted(np.unique(r.tpoints).tolist()) == [100, 104, 108]
 
 
 class TestRemoveAnova:
@@ -249,8 +261,8 @@ class TestCalculateSlopePvals:
         tpoints = [2, 4, 6, 8, 10, 12]
         n_reps = 3
         cols = [f"CT{t:02d}_{r}" for t in tpoints for r in range(1, n_reps + 1)]
-        flat    = rng.normal(5.0, 0.05, len(cols))
-        sloped  = np.array(
+        flat = rng.normal(5.0, 0.05, len(cols))
+        sloped = np.array(
             [float(t * 3) + rng.normal(0, 0.1) for t in tpoints for _ in range(n_reps)]
         )
         df = pd.DataFrame({"flat": flat, "sloped": sloped}, index=cols).T
@@ -278,7 +290,9 @@ class TestCalculateSlopePvals:
         r = self._make_slope_ranker(tmp_path)
         result = r.calculate_slope_pvals(n_permutations=99)
         assert (result["slope_pval"] >= 0).all() and (result["slope_pval"] <= 1).all()
-        assert (result["slope_pval_bh"] >= 0).all() and (result["slope_pval_bh"] <= 1).all()
+        assert (result["slope_pval_bh"] >= 0).all() and (
+            result["slope_pval_bh"] <= 1
+        ).all()
 
     def test_sloped_lower_pval_than_flat(self, tmp_path):
         r = self._make_slope_ranker(tmp_path)
@@ -292,7 +306,7 @@ class TestCalculateSlopePvals:
         n_reps = 3
         cols = [f"CT{t:02d}_{r}" for t in tpoints for r in range(1, n_reps + 1)]
         noisy_flat = rng.normal(5.0, 2.0, len(cols))
-        sloped     = np.array(
+        sloped = np.array(
             [float(t * 3) + rng.normal(0, 0.1) for t in tpoints for _ in range(n_reps)]
         )
         df = pd.DataFrame({"noisy_flat": noisy_flat, "sloped": sloped}, index=cols).T
@@ -303,7 +317,9 @@ class TestCalculateSlopePvals:
         r.get_tpoints()
         r.calculate_scores()
         result = r.calculate_slope_pvals(n_permutations=199)
-        assert result.loc["sloped", "slope_pval"] < result.loc["noisy_flat", "slope_pval"]
+        assert (
+            result.loc["sloped", "slope_pval"] < result.loc["noisy_flat", "slope_pval"]
+        )
 
     def test_pirs_sort_with_slope_pvals_writes_columns(self, tmp_path):
         rng = np.random.default_rng(3)

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,4 +1,5 @@
 """Tests for the unified circ.simulations.simulate class."""
+
 import os
 import numpy as np
 import pandas as pd
@@ -10,6 +11,7 @@ from circ.simulations import simulate
 # ---------------------------------------------------------------------------
 # Construction and core attributes
 # ---------------------------------------------------------------------------
+
 
 class TestConstruction:
     def test_default_instantiation(self):
@@ -39,6 +41,12 @@ class TestConstruction:
         assert sim.cols[0] == "ZT04_1"
         assert sim.cols[2] == "ZT08_1"
 
+    def test_three_digit_column_names(self):
+        # tpoint_space=4, 25 tpoints → last time = 4*25 = 100 → ZT100
+        sim = simulate(tpoints=25, nrows=10, nreps=2, tpoint_space=4)
+        assert "ZT100_1" in sim.cols
+        assert "ZT100_2" in sim.cols
+
     def test_sim_row_scaled(self):
         sim = simulate(nrows=50, rseed=7)
         stds = np.std(sim.sim, axis=1)
@@ -63,6 +71,7 @@ class TestConstruction:
 # ---------------------------------------------------------------------------
 # Three-class labels
 # ---------------------------------------------------------------------------
+
 
 class TestClassLabels:
     def test_classes_array_length(self):
@@ -127,6 +136,7 @@ class TestClassLabels:
 # Batch effects
 # ---------------------------------------------------------------------------
 
+
 class TestBatchEffects:
     def test_no_batch_effects_by_default(self):
         sim = simulate(nrows=50, rseed=0)
@@ -153,6 +163,7 @@ class TestBatchEffects:
 # Missing data
 # ---------------------------------------------------------------------------
 
+
 class TestMissingData:
     def test_no_missing_by_default(self):
         sim = simulate(nrows=50, rseed=0)
@@ -172,14 +183,13 @@ class TestMissingData:
     def test_missing_reproducible(self):
         sim1 = simulate(nrows=30, p_miss=0.3, rseed=9)
         sim2 = simulate(nrows=30, p_miss=0.3, rseed=9)
-        np.testing.assert_array_equal(
-            np.isnan(sim1.sim_miss), np.isnan(sim2.sim_miss)
-        )
+        np.testing.assert_array_equal(np.isnan(sim1.sim_miss), np.isnan(sim2.sim_miss))
 
 
 # ---------------------------------------------------------------------------
 # write_output (expression format)
 # ---------------------------------------------------------------------------
+
 
 class TestWriteOutput:
     def test_creates_data_file(self, tmp_path):
@@ -228,6 +238,7 @@ class TestWriteOutput:
 # ---------------------------------------------------------------------------
 # write_proteomics
 # ---------------------------------------------------------------------------
+
 
 class TestWriteProteomics:
     def test_creates_all_three_files(self, tmp_path):

--- a/tests/visualization/test_classify_plots.py
+++ b/tests/visualization/test_classify_plots.py
@@ -11,6 +11,7 @@ import matplotlib.axes
 
 from circ.visualization.classify import (
     LABEL_COLORS,
+    _zt_timepoints,
     label_distribution,
     pirs_vs_tau,
     volcano,
@@ -490,3 +491,47 @@ class TestExpressionHeatmap:
         )
         with pytest.raises(ValueError, match="ZT/CT"):
             expression_heatmap(bad_expr, minimal_clf)
+
+
+# ---------------------------------------------------------------------------
+# 3+ digit ZT/CT time support
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def three_digit_expr(minimal_clf):
+    """Expression matrix with 3-digit ZT time columns (ZT100–ZT120)."""
+    rng = np.random.default_rng(99)
+    n = len(minimal_clf)
+    cols = [f"ZT{h}_{r}" for h in [100, 104, 108, 112, 116, 120] for r in [1, 2]]
+    return pd.DataFrame(
+        rng.normal(5, 1, (n, len(cols))),
+        index=minimal_clf.index,
+        columns=cols,
+    )
+
+
+class TestThreeDigitTimepoints:
+    def test_zt_timepoints_parses_three_digits(self, three_digit_expr):
+        _, tp, unique_tp = _zt_timepoints(three_digit_expr)
+        assert set(unique_tp.tolist()) == {100, 104, 108, 112, 116, 120}
+
+    def test_zt_timepoints_parses_ct_three_digits(self, minimal_clf):
+        rng = np.random.default_rng(7)
+        n = len(minimal_clf)
+        cols = [f"CT{h}_{r}" for h in [100, 108] for r in [1, 2]]
+        expr = pd.DataFrame(
+            rng.normal(5, 1, (n, len(cols))), index=minimal_clf.index, columns=cols
+        )
+        _, tp, unique_tp = _zt_timepoints(expr)
+        assert set(unique_tp.tolist()) == {100, 108}
+
+    def test_gene_profile_three_digit(self, three_digit_expr, minimal_clf):
+        gene = three_digit_expr.index[0]
+        ax = gene_profile(three_digit_expr, gene, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_expression_heatmap_three_digit(self, three_digit_expr, minimal_clf):
+        ax = expression_heatmap(three_digit_expr, minimal_clf)
+        assert isinstance(ax, matplotlib.axes.Axes)
+        assert len(ax.images) >= 1


### PR DESCRIPTION
Closes #24.

## What was wrong

The documentation said "zero-padded two-digit Zeitgeber Time" and the BooteJTK CLI help and pipeline docstrings echoed the same restriction. There were no tests covering time values ≥ 100.

## What actually needed to change

All parsing code already handled arbitrary digit counts correctly:
- `h[2:].split("_")[0]` in BooteJTK strips the 2-char "ZT"/"CT" prefix and reads any number of digits
- `re.sub(r"^ZT", ...)` in `limma_preprocess` is prefix-length-independent
- `.replace("ZT", "").split("_")[0]` in `pirs/rank.py` and `visualization/classify.py` likewise

The simulation format string `{:02d}` pads to a minimum of 2 digits but never truncates — it already produces `ZT100` when the time value reaches 100.

So the fix is: remove the documented restriction and add tests that prove the full pipeline handles 3+ digit columns.

## Changes

**Documentation:**
- `README.md` — replace "zero-padded two-digit" with "any non-negative integer"; add a 3-digit column example
- `CLAUDE.md` — note that `ZT100_1`, `ZT120_2` etc. are fully supported
- `circ/simulations.py` — update column-format comment
- `circ/bootjtk/pipeline.py` — clarify that CT/ZT is a fixed 2-char prefix but the numeric part is unrestricted
- `circ/bootjtk/BooteJTK.py` — update CLI `--filename` help text

**New tests:**
- `test_simulations.py` — `simulate(tpoints=25, tpoint_space=4)` produces `ZT100_1`/`ZT100_2`
- `test_limma_preprocess.py` — `parse_timepoint_label` handles `ZT100`, `CT120`, `ZT100_2`
- `test_rank.py` — `ranker.get_tpoints()` correctly extracts `[100, 104, 108]` from 3-digit columns
- `test_classify_plots.py` — `_zt_timepoints`, `gene_profile`, and `expression_heatmap` all work with 3-digit ZT and CT columns

Two pre-existing lint errors in touched files also fixed: unused import in `test_rank.py` and `== float` type comparison in `test_limma_preprocess.py`.

## Test plan

CI runs the full suite. All 195 tests in the affected files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)