### PR TITLE
Replace noqa suppression with explicit __all__ re-exports

### DIFF
--- a/circ/limbr/simulations.py
+++ b/circ/limbr/simulations.py
@@ -8,7 +8,9 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from circ.simulations import simulate  # noqa: F401  re-exported for backward compat
+from circ.simulations import simulate
+
+__all__ = ["simulate", "analyze"]
 
 
 class analyze:

--- a/circ/pirs/simulations.py
+++ b/circ/pirs/simulations.py
@@ -4,7 +4,9 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import precision_recall_curve
 
-from circ.simulations import simulate  # noqa: F401  re-exported for backward compat
+from circ.simulations import simulate
+
+__all__ = ["simulate", "analyze"]
 
 
 class analyze:


### PR DESCRIPTION
## Summary

There were 3 silenced linting suppressions in the codebase:

| File | Suppression | Resolution |
|---|---|---|
| `circ/pirs/simulations.py` | `# noqa: F401` on `simulate` re-export | Replaced with `__all__ = ["simulate", "analyze"]` |
| `circ/limbr/simulations.py` | `# noqa: F401` on `simulate` re-export | Replaced with `__all__ = ["simulate", "analyze"]` |
| `circ/visualization/interactive/__init__.py` | `# noqa: F401` on plotly availability check | Left in place — this is a genuine side-effect import inside try/except with no cleaner alternative |

`__all__` is the canonical Python way to declare an intentional re-export and lets ruff verify the intent rather than suppress it.

## Test plan

CI runs the full test suite — all 829 tests pass locally with no lint or format violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)