### PR TITLE
Update READMEs for ECHO and circ.rhythmicity rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ integrating four complementary tools:
 |---|---|
 | `circ.limbr` | KNN imputation + SVA-based batch effect removal |
 | `circ.pirs` | Prediction Interval Ranking Score for constitutive expression |
-| `circ.bootjtk` | Bootstrap empirical JTK circadian rhythm detection |
-| `circ.expression_classification` | Unified classifier combining PIRS and BooteJTK |
+| `circ.rhythmicity` | BooteJTK + ECHO circadian rhythmicity detection and classification |
+| `circ.expression_classification` | Unified classifier combining PIRS, BooteJTK, and ECHO |
 | `circ.visualization` | Classification, comparison, and benchmark plots |
 | `circ.compare` | Cross-condition and cross-omics comparison |
 
@@ -30,7 +30,7 @@ cd CIRC
 poetry install
 ```
 
-For optional Numba acceleration of BooteJTK:
+For optional Numba acceleration of BooteJTK (part of `circ.rhythmicity`):
 
 ```bash
 poetry install --extras fast
@@ -136,7 +136,7 @@ sva_obj.output_default("normalized.parquet")
 normalized = sva_obj.svd_norm   # DataFrame available directly after normalize()
 
 clf = Classifier(normalized, reps=2)
-result = clf.run_all(slope_pvals=True, n_permutations=1000, n_jobs=4)
+result = clf.run_all(slope_pvals=True, n_permutations=1000, n_jobs=4, echo=True)
 ```
 
 For finer control over the PIRS step (e.g. writing ranked scores to disk):
@@ -165,20 +165,22 @@ circ COMMAND [options]
 | `impute` | LIMBR | KNN imputation of missing data |
 | `normalize` | LIMBR | SVA batch effect removal |
 | `rank` | PIRS | Rank profiles by constitutiveness |
+| `classify` | PIRS + BooteJTK (+ ECHO) | Full expression classification pipeline |
 | `rhythm` | BooteJTK | Bootstrap JTK rhythm detection |
 | `rhythm-calcp` | BooteJTK | Bootstrap JTK + CalcP full pipeline |
 
 For full flag reference see the module READMEs:
 [`circ impute` / `circ normalize`](circ/limbr/README.md) ·
 [`circ rank`](circ/pirs/README.md) ·
-[`circ rhythm` / `circ rhythm-calcp`](circ/bootjtk/README.md)
+[`circ classify`](circ/expression_classification/README.md) ·
+[`circ rhythm` / `circ rhythm-calcp`](circ/rhythmicity/README.md)
 
 ## Module API
 
 Full API reference for each module lives in its own README:
 [`circ.limbr`](circ/limbr/README.md) ·
 [`circ.pirs`](circ/pirs/README.md) ·
-[`circ.bootjtk`](circ/bootjtk/README.md) ·
+[`circ.rhythmicity`](circ/rhythmicity/README.md) ·
 [`circ.expression_classification`](circ/expression_classification/README.md) ·
 [`circ.visualization`](circ/visualization/README.md)
 
@@ -277,8 +279,8 @@ Full license texts and attribution details are in `NOTICE`.
 |---|---|---|
 | `circ.limbr` | Alexander M. Crowell (2017) | BSD 3-Clause |
 | `circ.pirs` | Alexander M. Crowell (2017) | BSD 3-Clause |
-| `circ.bootjtk` | Alan L. Hutchison (2016) | MIT |
-| `circ/bootjtk/mpfit.py` | More' et al. → C. Markwardt → M. Rivers | — |
+| `circ.rhythmicity` (BooteJTK) | Alan L. Hutchison (2016) | MIT |
+| `circ/rhythmicity/mpfit.py` | More' et al. → C. Markwardt → M. Rivers | — |
 
 ### Key publications
 
@@ -291,3 +293,7 @@ Full license texts and attribution details are in `NOTICE`.
   11(3): e1004094. doi:10.1371/journal.pcbi.1004094
 - **BooteJTK (bootstrap extension)**: Hutchison AL et al. "BooteJTK:
   Improved Rhythm Detection via Bootstrapping." *bioRxiv* 2016.
+- **ECHO**: De los Santos H et al. "ECHO: an application for detection
+  and analysis of oscillators identifies metabolic regulation on genome-wide
+  circadian output." *Bioinformatics* 2019 36(3): 773–781.
+  doi:10.1093/bioinformatics/btz617

--- a/circ/expression_classification/README.md
+++ b/circ/expression_classification/README.md
@@ -1,7 +1,8 @@
-# circ.expression_classification — Unified PIRS + BooteJTK classifier
+# circ.expression_classification — Unified PIRS + BooteJTK + ECHO classifier
 
-Combines PIRS scores and BooteJTK rhythmicity results to classify every gene
-into one of five expression patterns.
+Combines PIRS constitutiveness scores, BooteJTK rhythmicity results, and
+optionally ECHO amplitude-aware fitting to classify every gene into one of
+five expression patterns.
 
 ## Expression labels
 
@@ -25,29 +26,93 @@ from circ.expression_classification.classify import Classifier
 
 # Accepts a file path (TSV or Parquet) or a DataFrame
 clf = Classifier("normalized.parquet", anova=False, reps=2, size=50, workers=1)
+```
 
-# Step-by-step
+#### Step-by-step
+
+```python
+# 1. PIRS constitutiveness scores
 clf.run_pirs(pvals=True, slope_pvals=True, n_permutations=1000, n_jobs=4)
+
+# 2. BooteJTK rhythmicity detection
 clf.run_bootjtk()
+
+# 3. (Optional) ECHO amplitude-aware fitting
+clf.run_echo(workers=4)
+
+# 4. Classify — pass echo=True to include echo_amplitude_class in output
 result = clf.classify(
     pirs_percentile=50,       # genes at/below this PIRS percentile are "stable"
     slope_pval_threshold=0.05,
     tau_threshold=0.5,
     emp_p_threshold=0.05,
+    echo=True,
+    echo_p_threshold=0.05,    # amplitude class masked for genes above this BH p-value
 )
+```
 
-# Or in a single call
+#### Single-call convenience
+
+```python
 result = clf.run_all(
     slope_pvals=True,
     n_permutations=1000,
     n_jobs=4,
+    echo=True,                # also runs run_echo() and includes ECHO columns
 )
 ```
 
-`result` is a DataFrame indexed by gene ID with columns `pirs_score`,
-`slope_pval` / `slope_pval_bh` (when computed), `tau_mean`, `emp_p`,
-`period_mean`, `phase_mean`, and `label`.
+`result` is a DataFrame indexed by gene ID.  Core columns:
 
-When `slope_pvals=False` (default), `run_pirs` computes only the raw PIRS
-score and `classify` falls back to the four-label scheme.  This keeps the
-default path fast for exploratory use.
+| Column | Description |
+|---|---|
+| `pirs_score` | Raw PIRS constitutiveness score |
+| `slope_pval` / `slope_pval_bh` | Slope p-values (when `slope_pvals=True`) |
+| `tau_mean` | BooteJTK mean Kendall's τ across bootstraps |
+| `emp_p` | BH-corrected BooteJTK empirical p-value |
+| `period_mean` | Estimated period (hours) |
+| `phase_mean` | Estimated phase (hours) |
+| `label` | Expression class (see table above) |
+
+Additional ECHO columns (present when `echo=True`):
+
+| Column | Description |
+|---|---|
+| `echo_amplitude_class` | `'damped'`, `'harmonic'`, or `'forced'`; `None` if not significant |
+| `echo_gamma` | Amplitude change coefficient |
+| `echo_period` | ECHO-fitted period (hours) |
+| `echo_phase` | ECHO-fitted phase (hours) |
+| `echo_tau` | Kendall's τ goodness-of-fit |
+| `echo_p_bh` | BH-corrected ECHO p-value |
+
+## CLI
+
+### `circ classify`
+
+```bash
+circ classify -f normalized.parquet -o classified.txt \
+    --reps 2 --size 50 --workers 4 \
+    --pirs-percentile 50 \
+    --tau-threshold 0.5 \
+    --emp-p-threshold 0.05
+
+# With ECHO amplitude-aware classification
+circ classify -f normalized.parquet -o classified.txt \
+    --reps 2 --size 50 --workers 4 \
+    --echo --echo-p-threshold 0.05
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `-f FILE` | required | Input expression file (TSV or Parquet) |
+| `-o FILE` | required | Output file path |
+| `--anova` | off | ANOVA-filter differentially expressed genes before PIRS |
+| `--pirs-percentile` | 50 | PIRS percentile cutoff for "stable" genes |
+| `--tau-threshold` | 0.5 | Minimum TauMean for rhythmicity call |
+| `--emp-p-threshold` | 0.05 | Maximum FDR-corrected p-value for rhythmicity |
+| `-r / --reps` | 2 | Replicates per timepoint (BooteJTK) |
+| `-z / --size` | 50 | Bootstrap iterations per gene (BooteJTK) |
+| `-j / --workers` | 1 | Parallel worker processes |
+| `--limma` | off | Apply Limma/Vash variance shrinkage before BooteJTK |
+| `--echo` | off | Run ECHO amplitude-aware fitting |
+| `--echo-p-threshold` | 0.05 | BH p-value cutoff for ECHO amplitude classification |

--- a/circ/rhythmicity/README.md
+++ b/circ/rhythmicity/README.md
@@ -1,8 +1,12 @@
-# circ.bootjtk — Bootstrap empirical JTK rhythm detection
+# circ.rhythmicity — Circadian rhythmicity detection and classification
 
-BooteJTK detects circadian rhythms in expression data using a bootstrapped
-extension of the JTK_CYCLE algorithm, providing empirical p-values for each
-gene's rhythmicity.
+`circ.rhythmicity` provides two complementary algorithms for detecting and
+characterising circadian rhythms in expression data:
+
+- **BooteJTK** — non-parametric, bootstrap-based rhythm detection using
+  Kendall's τ against reference waveforms; robust to noise and missing data
+- **ECHO** — parametric amplitude-aware fitting; classifies oscillations as
+  *damped*, *harmonic*, or *forced* based on how amplitude changes over time
 
 ## CLI
 
@@ -27,8 +31,74 @@ Key BooteJTK flags:
 |---|---|
 | `-f FILE` | Input file |
 | `-x PREFIX` | Output file prefix |
-| `-r INT` | Number of bootstrap resampling iterations |
-| `-z INT` | Number of permutation iterations for empirical p-values |
-| `-p PERIODS` | Comma-separated list of periods to test (default: 24) |
-| `-a ASYMMETRIES` | Asymmetry values to test |
-| `-s PHASES` | Phase offsets to test |
+| `-r INT` | Replicates per timepoint |
+| `-z INT` | Bootstrap iterations per gene |
+| `-j INT` | Parallel worker processes (0 = all CPUs) |
+| `-p FILE` | Periods to test (default: 24 h) |
+| `-a FILE` | Asymmetry (waveform width) values |
+| `-s FILE` | Phase offsets |
+
+## Python API
+
+### BooteJTK — `circ.rhythmicity.pipeline`
+
+Used internally by `Classifier.run_bootjtk()`.  Can also be called directly:
+
+```python
+import types
+from circ.rhythmicity.pipeline import main as pipeline_main
+
+args = types.SimpleNamespace(
+    filename="normalized.txt",
+    output="DEFAULT",
+    prefix="run",
+    reps=2,
+    size=50,
+    workers=1,
+    basic=True,
+    ...
+)
+pipeline_main(args)
+```
+
+### ECHO — `circ.rhythmicity.echo_fit.EchoFitter`
+
+Fits the ECHO amplitude-aware oscillator model per gene:
+
+    x(t̂) = A · exp(−γt̂²) · cos(ωt̂ + φ) + y
+
+where t̂ is time normalised to [0, 1].  The amplitude change coefficient γ
+classifies each oscillation:
+
+| Class | Condition | Interpretation |
+|---|---|---|
+| `damped` | γ > 0.03 | Amplitude decreases over the data window |
+| `harmonic` | \|γ\| ≤ 0.03 | Approximately constant amplitude |
+| `forced` | γ < −0.03 | Amplitude increases over the data window |
+
+```python
+from circ.rhythmicity.echo_fit import EchoFitter
+
+# Accepts a file path (TSV or Parquet) or a DataFrame
+fitter = EchoFitter("normalized.parquet", reps=2)
+result = fitter.fit(workers=4)
+```
+
+`result` is a DataFrame indexed by gene ID with columns:
+
+| Column | Description |
+|---|---|
+| `echo_A` | Fitted amplitude |
+| `echo_gamma` | Amplitude change coefficient (normalised time) |
+| `echo_period` | Fitted period (hours) |
+| `echo_phase` | Fitted phase (hours) |
+| `echo_baseline` | Fitted y-intercept |
+| `echo_tau` | Kendall's τ goodness-of-fit |
+| `echo_p` | p-value for τ |
+| `echo_p_bh` | BH-corrected p-value |
+| `echo_amplitude_class` | `'damped'`, `'harmonic'`, or `'forced'` |
+| `echo_converged` | Whether the optimisation converged |
+
+The most convenient way to run ECHO alongside BooteJTK is through
+`Classifier.run_echo()` — see
+[`circ/expression_classification/README.md`](../expression_classification/README.md).


### PR DESCRIPTION
## Summary

- **`README.md`**: updates module table (`circ.bootjtk` → `circ.rhythmicity`), adds `circ classify` to CLI table, fixes module API links, adds `echo=True` to in-memory pipeline example, fixes license table paths, and adds the ECHO publication reference
- **`circ/rhythmicity/README.md`**: full rewrite — now documents both BooteJTK (CLI and pipeline API) and the new `EchoFitter` class (algorithm, output columns, usage)
- **`circ/expression_classification/README.md`**: adds `run_echo()` to the step-by-step API, updates `run_all()` example with `echo=True`, adds `--echo` and `--echo-p-threshold` to the CLI flag table, and documents the new ECHO output columns

## Test plan

- Docs-only change; CI lint/test/typecheck unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)