### PR TITLE
fix: address code review findings across core modules

### DIFF
--- a/circ/expression_classification/classify.py
+++ b/circ/expression_classification/classify.py
@@ -4,16 +4,13 @@ import os
 import shutil
 import tempfile
 import types
+from importlib.resources import files as _pkg_files
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
-_REF_DIR = os.path.normpath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "..", "rhythmicity", "ref_files"
-    )
-)
+_REF_DIR = str(_pkg_files("circ.rhythmicity").joinpath("ref_files"))
 
 # (pirs_stable, rhythmic) -> label  — used when slope p-values are not available
 _LABEL_MAP = {
@@ -76,12 +73,14 @@ class Classifier:
         size: int = 50,
         workers: int = 1,
     ) -> None:
+        from circ.io import read_expression
+
         if isinstance(source, pd.DataFrame):
-            self._source = source
+            self._source: pd.DataFrame = source.copy()
             self.filename: str | None = None
         else:
-            self._source = os.path.abspath(str(source))
-            self.filename = self._source
+            self.filename = os.path.abspath(str(source))
+            self._source = read_expression(self.filename)
         self.anova = anova
         self.reps = reps
         self.size = size
@@ -161,17 +160,8 @@ class Classifier:
 
         workdir = tempfile.mkdtemp(prefix="circ_classify_")
         try:
-            if isinstance(self._source, pd.DataFrame):
-                fn_copy = os.path.join(workdir, "input.txt")
-                self._source.to_csv(fn_copy, sep="\t")
-            else:
-                src = str(self._source)
-                if src.endswith(".parquet"):
-                    fn_copy = os.path.join(workdir, "input.txt")
-                    pd.read_parquet(src).to_csv(fn_copy, sep="\t")
-                else:
-                    fn_copy = os.path.join(workdir, os.path.basename(src))
-                    shutil.copy2(src, fn_copy)
+            fn_copy = os.path.join(workdir, "input.txt")
+            self._source.to_csv(fn_copy, sep="\t")
 
             args = _make_pipeline_args(
                 filename=fn_copy,

--- a/circ/limbr/_normalize.py
+++ b/circ/limbr/_normalize.py
@@ -1,0 +1,38 @@
+"""Shared normalization helpers used by both batch_fx.sva and old_fashioned."""
+
+import pandas as pd
+
+
+def _pool_norm(df: pd.DataFrame, dmap: dict) -> pd.DataFrame:
+    """Divide each sample column by its matched pooled-control column.
+
+    Parameters
+    ----------
+    df   : DataFrame with sample and pool columns.
+    dmap : dict mapping each sample column to its pool number (integer).
+    """
+    newdf = pd.DataFrame(index=df.index)
+    for column in df.columns.values:
+        if "pool" not in column:
+            newdf[column] = df[column].div(
+                df["pool_" + "%02d" % dmap[column]], axis="index"
+            )
+    nonpool = [i for i in newdf.columns if "pool" not in i]
+    return newdf[nonpool]
+
+
+def _qnorm(df: pd.DataFrame) -> pd.DataFrame:
+    """Quantile-normalize df column-wise to a shared rank-mean reference."""
+    ref = (
+        pd.concat(
+            [df[col].sort_values().reset_index(drop=True) for col in df],
+            axis=1,
+            ignore_index=True,
+        )
+        .mean(axis=1)
+        .values
+    )
+    for i in range(len(df.columns)):
+        df = df.sort_values(df.columns[i])
+        df[df.columns[i]] = ref
+    return df.sort_index()

--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import multiprocess as _mp
+from circ.limbr._normalize import _pool_norm, _qnorm
 
 _forkserver_pool = _mp.get_context("forkserver").Pool
 from sklearn import preprocessing
@@ -153,77 +154,8 @@ class sva:
 
         """
 
-        def pool_norm(df, dmap):
-            """
-            Pool normalizes samples in a proteomics experiment.
-
-
-            Peptide abundances of each sample are divided by corresponding pooled control abundances.
-
-
-            Parameters
-            ----------
-            df : dataframe
-                The dataframe to be pool normalized.
-            dmap : dict
-                The dictionary connecting each sample to its corresponding pooled control.
-
-
-            Returns
-            -------
-            newdf : dataframe
-                Dataframe with samples pool normalized and pooled control columns dropped.
-
-            """
-
-            newdf = pd.DataFrame(index=df.index)
-            for column in df.columns.values:
-                if "pool" not in column:
-                    newdf[column] = df[column].div(
-                        df["pool_" + "%02d" % dmap[column]], axis="index"
-                    )
-            nonpool = [i for i in newdf.columns if "pool" not in i]
-            newdf = newdf[nonpool]
-            return newdf
-
-        def qnorm(df):
-            """
-            Quantile normalizes data by columns.
-
-
-            A reference distribution is generated as the mean across rows of the dataset with all columns sorted by abundance.  Each column is then quantile normalized to this target distribution.
-
-
-            Parameters
-            ----------
-            df : dataframe
-                The dataframe to be quantile normalized
-
-
-            Returns
-            -------
-            newdf : dataframe
-                The quantile normalized dataframe.
-
-            """
-
-            ref = (
-                pd.concat(
-                    [df[col].sort_values().reset_index(drop=True) for col in df],
-                    axis=1,
-                    ignore_index=True,
-                )
-                .mean(axis=1)
-                .values
-            )
-            for i in range(0, len(df.columns)):
-                df = df.sort_values(df.columns[i])
-                df[df.columns[i]] = ref
-            newdf = df.sort_index()
-            return newdf
-
         if (self.data_type == "r") or (self.norm_map is None):
-            self.data = qnorm(self.raw_data)
+            self.data = _qnorm(self.raw_data)
             self.scaler = preprocessing.StandardScaler().fit(self.data.values.T)
             self.data = pd.DataFrame(
                 self.scaler.transform(self.data.values.T).T,
@@ -231,11 +163,11 @@ class sva:
                 index=self.data.index,
             )
         else:
-            self.data_pnorm = pool_norm(self.raw_data, self.norm_map)
+            self.data_pnorm = _pool_norm(self.raw_data, self.norm_map)
             self.data_pnorm = self.data_pnorm.replace([np.inf, -np.inf], np.nan)
             self.data_pnorm = self.data_pnorm.dropna()
             self.data_pnorm = self.data_pnorm.sort_index(axis=1)
-            self.data_pnorm = qnorm(self.data_pnorm)
+            self.data_pnorm = _qnorm(self.data_pnorm)
             self.scaler = preprocessing.StandardScaler().fit(self.data_pnorm.values.T)
             self.data = pd.DataFrame(
                 self.scaler.transform(self.data_pnorm.values.T).T,
@@ -616,7 +548,7 @@ class sva:
 
             pi_0 = est_pi_naught(probs_sig, l)
             if pi_0 > 1:
-                return "nan"
+                return np.nan
             sp = np.sort(probs_sig)
             pi_sig = sp[int(np.floor((1 - pi_0) * len(probs_sig)) - 1)]
             return pi_sig
@@ -627,7 +559,7 @@ class sva:
         for j, entry in enumerate(tqdm(self.ps)):
             sub = []
             thresh = est_pi_sig(entry, lam)
-            if thresh == "nan":
+            if np.isnan(thresh):
                 self.ts: list[np.ndarray] = trends
                 self.pepts: list[np.ndarray] = pep_trends
                 return

--- a/circ/limbr/imputation.py
+++ b/circ/limbr/imputation.py
@@ -58,7 +58,6 @@ class imputable:
         self.data = df
         self.miss = float(missingness)
         self.pats: dict[str, list[int]] = {}
-        self.notdone = True
         self.NN = neighbors
 
     def deduplicate(self) -> None:
@@ -69,6 +68,9 @@ class imputable:
         Groups rows by peptide, if a peptide appears in more than one row it is removed.
 
         """
+        # Check whether the second column's first value ends in e.g. "T4" or "T24"
+        # (a trailing digit preceded by "T"), which indicates peptides with
+        # ZT/CT-suffixed charge states that need to be stripped before grouping.
         if (self.data[self.data.columns.values[1]][0][-2] == "T") & (
             self.data[self.data.columns.values[1]][0][-1].isdigit()
         ):

--- a/circ/limbr/old_fashioned.py
+++ b/circ/limbr/old_fashioned.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from sklearn import preprocessing
 
+from circ.limbr._normalize import _pool_norm, _qnorm
+
 
 class old_fashioned:
     """
@@ -55,7 +57,6 @@ class old_fashioned:
             self.raw_data = pd.read_csv(filename, sep="\t").set_index("#")
         if pool is not None:
             self.norm_map = pd.read_parquet(pool)["pool_number"].to_dict()
-        self.notdone = True
 
     def pool_normalize(self) -> None:
         """
@@ -74,76 +75,8 @@ class old_fashioned:
 
         """
 
-        def pool_norm(df, dmap):
-            """
-            Pool normalizes samples in a proteomics experiment.
-
-
-            Peptide abundances of each sample are divided by corresponding pooled control abundances.
-
-
-            Parameters
-            ----------
-            df : dataframe
-                The dataframe to be pool normalized.
-            dmap : dict
-                The dictionary connecting each sample to its corresponding pooled control.
-
-
-            Returns
-            -------
-            newdf : dataframe
-                Dataframe with samples pool normalized and pooled control columns dropped.
-
-            """
-
-            newdf = pd.DataFrame(index=df.index)
-            for column in df.columns.values:
-                if "pool" not in column:
-                    newdf[column] = df[column].div(
-                        df["pool_" + "%02d" % dmap[column]], axis="index"
-                    )
-            nonpool = [i for i in newdf.columns if "pool" not in i]
-            newdf = newdf[nonpool]
-            return newdf
-
-        def qnorm(df):
-            """
-            Quantile normalizes data by columns.
-
-
-            A reference distribution is generated as the mean across rows of the dataset with all columns sorted by abundance.  Each column is then quantile normalized to this target distribution.
-
-
-            Parameters
-            ----------
-            df : dataframe
-                The dataframe to be quantile normalized
-
-
-            Returns
-            -------
-            newdf : dataframe
-                The quantile normalized dataframe.
-
-            """
-
-            ref = (
-                pd.concat(
-                    [df[col].sort_values().reset_index(drop=True) for col in df],
-                    axis=1,
-                    ignore_index=True,
-                )
-                .mean(axis=1)
-                .values
-            )
-            for i in range(0, len(df.columns)):
-                df = df.sort_values(df.columns[i])
-                df[df.columns[i]] = ref
-            return df.sort_index()
-
         if self.data_type == "r":
-            self.data = qnorm(self.raw_data)
+            self.data = _qnorm(self.raw_data)
             self.scaler = preprocessing.StandardScaler().fit(self.data.values.T)
             self.data = pd.DataFrame(
                 self.scaler.transform(self.data.values.T).T,
@@ -151,11 +84,11 @@ class old_fashioned:
                 index=self.data.index,
             )
         else:
-            self.data_pnorm = pool_norm(self.raw_data, self.norm_map)
+            self.data_pnorm = _pool_norm(self.raw_data, self.norm_map)
             self.data_pnorm = self.data_pnorm.replace([np.inf, -np.inf], np.nan)
             self.data_pnorm = self.data_pnorm.dropna()
             self.data_pnorm = self.data_pnorm.sort_index(axis=1)
-            self.data_pnorm = qnorm(self.data_pnorm)
+            self.data_pnorm = _qnorm(self.data_pnorm)
             self.scaler = preprocessing.StandardScaler().fit(self.data_pnorm.values.T)
             self.data = pd.DataFrame(
                 self.scaler.transform(self.data_pnorm.values.T).T,

--- a/circ/pirs/rank.py
+++ b/circ/pirs/rank.py
@@ -1,5 +1,6 @@
 import multiprocessing
 
+# forkserver avoids re-importing the full package in every worker on Linux/macOS
 _mp_ctx = multiprocessing.get_context("forkserver")
 
 from pathlib import Path
@@ -174,17 +175,26 @@ class ranker:
         from circ.io import read_expression
 
         self.data = read_expression(source)
+        # Drop all-zero rows before scoring — they produce degenerate PIRS scores
+        # (mean ≈ 0 forces the denominator clamp, making every gene look identical).
         self.data = self.data[(self.data.T != 0).any()]
         self.anova = anova
         self.errors: pd.DataFrame | None = None
 
     def get_tpoints(self) -> None:
         """Extract numeric timepoints from column headers (ZT/CT prefix)."""
-        tpoints = [
-            i.replace("ZT", "").replace("CT", "") for i in self.data.columns.values
-        ]
-        tpoints = [int(i.split("_")[0]) for i in tpoints]
-        self.tpoints = np.asarray(tpoints)
+        result = []
+        for col in self.data.columns.values:
+            stripped = str(col).replace("ZT", "").replace("CT", "")
+            try:
+                result.append(int(stripped.split("_")[0]))
+            except ValueError:
+                raise ValueError(
+                    f"Cannot parse timepoint from column {col!r}: expected a "
+                    f"ZT/CT-prefixed name like 'ZT04_1' or 'CT12', "
+                    f"got {stripped!r} after stripping the prefix"
+                )
+        self.tpoints = np.asarray(result)
 
     def remove_anova(self, alpha: float = 0.05) -> None:
         """Remove profiles with significant differential expression (one-way ANOVA).

--- a/circ/pirs/simulations.py
+++ b/circ/pirs/simulations.py
@@ -31,7 +31,6 @@ class analyze:
 
     def _build_curves(self) -> pd.DataFrame:
         """Compute per-method precision-recall curves and return as a DataFrame."""
-        curves = pd.DataFrame(columns=["precision", "recall", "method", "rep"])
         melted = (
             self.merged.pivot_table(
                 index=["rep", "method"], columns="#", values="score"
@@ -40,6 +39,7 @@ class analyze:
             .reset_index()
             .melt(id_vars=["rep", "method"], value_name="score")
         )
+        parts: list[pd.DataFrame] = []
         for rep in melted.rep.unique():
             for method in melted.method.unique():
                 pr = pd.merge(
@@ -47,19 +47,24 @@ class analyze:
                     melted[(melted.rep == rep) & (melted.method == method)],
                     on=["#", "rep"],
                 )
+                # Negate score so that smaller PIRS (more constitutive) → higher
+                # classifier confidence; avoids division by zero when score == 0.
                 precision, recall, _ = precision_recall_curve(
-                    pr["Const"].values, 1 / pr["score"].values, pos_label=1
+                    pr["Const"].values, -pr["score"].values, pos_label=1
                 )
-                temp = pd.DataFrame(
-                    {
-                        "precision": precision,
-                        "recall": recall,
-                        "method": method,
-                        "rep": rep,
-                    }
+                parts.append(
+                    pd.DataFrame(
+                        {
+                            "precision": precision,
+                            "recall": recall,
+                            "method": method,
+                            "rep": rep,
+                        }
+                    )
                 )
-                curves = pd.concat([curves, temp], sort=False)
-        return curves
+        if not parts:
+            return pd.DataFrame(columns=["precision", "recall", "method", "rep"])
+        return pd.concat(parts, sort=False)
 
     def generate_pr_curve(self, outpath: str = "PR.pdf") -> Any:
         """Build precision-recall curves and save to *outpath* (default PR.pdf)."""

--- a/circ/rhythmicity/BooteJTK.py
+++ b/circ/rhythmicity/BooteJTK.py
@@ -316,18 +316,6 @@ def read_in_EMdata(fn):
     return WT
 
 
-# def get_SD_distr(dseries,reps,size):
-#    data = np.zeros(size)
-#    for j in xrange(size):
-#        ser = []
-#        for i in xrange(len(dseries[0])):
-#            ser.append(np.random.normal(dseries[0][i],dseries[1][i],size=reps))
-#        ser = np.concatenate(ser)
-#        SD = np.std(ser)
-#        data[j] = SD
-#    return data
-
-
 def append_out(fn_out, line):
     line = [str(l) for l in line]
     with open(fn_out, "a") as g:
@@ -381,8 +369,8 @@ def dict_data(data):
 
 
 def IQR_FC(series):
-    qlo = __score_at_percentile__(series, 25)
-    qhi = __score_at_percentile__(series, 75)
+    qlo = _score_at_percentile(series, 25)
+    qhi = _score_at_percentile(series, 75)
     if not is_number(qlo) or not is_number(qhi):
         return np.nan
     elif qhi == 0:
@@ -435,7 +423,7 @@ def series_std(series):
     return np.std(series)
 
 
-def __score_at_percentile__(ser, per):
+def _score_at_percentile(ser, per):
     ser = [float(se) for se in ser[1:] if is_number(se)]
     if len(ser) < 5:
         score = "NA"

--- a/circ/rhythmicity/CalcP.py
+++ b/circ/rhythmicity/CalcP.py
@@ -53,7 +53,7 @@ def main(args):
             for _ in range(2):
                 params = GammaFit(keys, intvalues, yerr, p0, limit)
                 p0 = params[0]
-    params = p0
+        params = p0
     gd = ss.gamma(params[0], params[1], params[2])
 
     if "boot" not in fn_jtk_core:

--- a/circ/rhythmicity/arbfit.py
+++ b/circ/rhythmicity/arbfit.py
@@ -13,58 +13,58 @@ from .mpfit import mpfit
 import warnings
 
 
-def line(x, p):
+def line(x, params):
     """Parameter: Slope, Intercept\n
     Return
     ------
-    >>> p[0]*x + p[1]
+    >>> params[0]*x + params[1]
     """
-    return p[0] * x + p[1]
+    return params[0] * x + params[1]
 
 
-def line0(x, p):
+def line0(x, params):
     """Parameter: Slope\n
     Return
     ------
-    >>> p[0]*x
+    >>> params[0]*x
     """
-    return p[0] * x
+    return params[0] * x
 
 
-def sine(x, p):
+def sine(x, params):
     """Parameter: Scale, Wavelength, Phase, Offset\n
     Return
     ------
-    >>> p[0]*np.sin(2*np.pi*x/p[1]+p[2])+p[3]
+    >>> params[0]*np.sin(2*np.pi*x/params[1]+params[2])+params[3]
     """
-    return p[0] * np.sin(2 * np.pi * x / p[1] + p[2]) + p[3]
+    return params[0] * np.sin(2 * np.pi * x / params[1] + params[2]) + params[3]
 
 
-def fermi(x, p):
+def fermi(x, params):
     """Parameter: Scale, Edge Position, Width, Offset\n
     Return
     ------
-    >>> p[0]/(np.exp((x-p[1])/p[2])+1)+p[3]
+    >>> params[0]/(np.exp((x-params[1])/params[2])+1)+params[3]
     """
-    return p[0] / (np.exp((x - p[1]) / p[2]) + 1) + p[3]
+    return params[0] / (np.exp((x - params[1]) / params[2]) + 1) + params[3]
 
 
-def gauss(x, p):
+def gauss(x, params):
     """Parameter: Scale, Mean, Std, Offset\n
     Return
     ------
-    >>> p[0]*np.exp(-0.5*(x-p[1])**2/p[2]**2)+p[3]
+    >>> params[0]*np.exp(-0.5*(x-params[1])**2/params[2]**2)+params[3]
     """
-    return p[0] * np.exp(-0.5 * (x - p[1]) ** 2 / p[2] ** 2) + p[3]
+    return params[0] * np.exp(-0.5 * (x - params[1]) ** 2 / params[2] ** 2) + params[3]
 
 
-def exp(x, p):
+def exp(x, params):
     """Parameter: Scale, Decay Time, Offset\n
     Return
     ------
-    >>> p[0]*np.exp(-x*p[1])+p[2]
+    >>> params[0]*np.exp(-x*params[1])+params[2]
     """
-    return p[0] * np.exp(-x * p[1]) + p[2]
+    return params[0] * np.exp(-x * params[1]) + params[2]
 
 
 def poly(x, p, n):

--- a/circ/rhythmicity/get_stat_probs.py
+++ b/circ/rhythmicity/get_stat_probs.py
@@ -1,4 +1,7 @@
 from scipy.stats import kendalltau as kt
+
+# Clip tau before arctanh to avoid ±inf at the boundary of (-1, 1)
+_TAU_CLIP = 0.99
 from scipy.stats import circmean as sscircmean
 from scipy.stats import circstd as sscircstd
 from scipy.stats import rankdata as _rankdata
@@ -87,7 +90,7 @@ def get_stat_probs(dorder, new_header, triples, dref, ref_ranks, size):
         minloc = new_header_arr[np.argmin(kkey_arr)]
 
         raw_taus = _batch_tau(kkey_arr, ref_ranks)
-        taus = np.arctanh(np.clip(raw_taus, -0.99, 0.99))
+        taus = np.arctanh(np.clip(raw_taus, -_TAU_CLIP, _TAU_CLIP))
         abs_taus = np.abs(taus)
 
         neg_mask = taus < 0
@@ -157,7 +160,7 @@ def generate_base_reference(
 
 
 def farctanh(x):
-    return float(np.arctanh(np.clip(x, -0.99, 0.99)))
+    return float(np.arctanh(np.clip(x, -_TAU_CLIP, _TAU_CLIP)))
 
 
 def periodic(x):

--- a/circ/rhythmicity/limma_voom.py
+++ b/circ/rhythmicity/limma_voom.py
@@ -21,8 +21,6 @@ Both return a long-format DataFrame with columns:
 which is the format expected by ``limma_preprocess.write_limma_outputs``.
 """
 
-import warnings
-
 import numpy as np
 import pandas as pd
 from scipy.special import polygamma
@@ -56,10 +54,10 @@ def _vooma_stats(df_wide, period):
         vals = sub.to_numpy(dtype=float)
         n = np.sum(~np.isnan(vals), axis=1)
         means = np.nanmean(vals, axis=1)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            sds = np.nanstd(vals, axis=1, ddof=1)
-        sds[n < 2] = np.nan
+        sds = np.full(vals.shape[0], np.nan)
+        has_reps = n >= 2
+        if has_reps.any():
+            sds[has_reps] = np.nanstd(vals[has_reps], axis=1, ddof=1)
         dfs = np.where(n >= 2, n - 1, 0).astype(float)
         for i, gid in enumerate(df_wide.index):
             rows.append((gid, h, means[i], sds[i], dfs[i], int(n[i])))
@@ -196,10 +194,16 @@ def _impute_na(df):
     pd.DataFrame  – same shape, no NaN values.
     """
     vals = df.to_numpy(dtype=float).copy()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)
-        row_sds = np.nanstd(vals, axis=1, ddof=1)
-        col_means = np.nanmean(vals, axis=0)
+    non_na_counts = np.sum(~np.isnan(vals), axis=1)
+    row_sds = np.full(vals.shape[0], np.nan)
+    has_reps = non_na_counts >= 2
+    if has_reps.any():
+        row_sds[has_reps] = np.nanstd(vals[has_reps], axis=1, ddof=1)
+    non_nan_per_col = np.sum(~np.isnan(vals), axis=0)
+    col_means = np.full(vals.shape[1], np.nan)
+    has_data_col = non_nan_per_col > 0
+    if has_data_col.any():
+        col_means[has_data_col] = np.nanmean(vals[:, has_data_col], axis=0)
     grand_mean = float(np.nanmean(col_means))
     grand_sd = float(np.nanstd(col_means, ddof=1)) if len(col_means) > 1 else 0.0
     finite_row_sds = row_sds[np.isfinite(row_sds)]

--- a/circ/rhythmicity/pipeline.py
+++ b/circ/rhythmicity/pipeline.py
@@ -97,6 +97,36 @@ def _save_null_cache(key, src_path):
     shutil.copy2(src_path, _cached_null_path(key))
 
 
+def _setup_noreps_args(source_fn: str, jtk_fn: str, args) -> None:
+    """Estimate per-timepoint SD from arrhythmic genes for the no-replicates path.
+
+    Reads *source_fn*, finds arrhythmic genes from the CalcP output at *jtk_fn*,
+    estimates a single pooled SD, writes _Sds / _Ns files, and sets
+    args.means / args.sds / args.ns in-place.
+    """
+    try:
+        df = pd.read_table(source_fn, index_col="ID")
+    except ValueError:
+        try:
+            df = pd.read_table(source_fn, index_col="#")
+        except ValueError:
+            raise ValueError(
+                f'Input file header must start with "ID" or "#": {source_fn!r}'
+            )
+    j = pd.read_table(jtk_fn, index_col="ID")
+    mean = df.loc[j[j.GammaP > 0.8].index].std(axis=1).dropna().mean()
+    df_sds = pd.DataFrame(np.ones(df.shape) * mean, index=df.index, columns=df.columns)
+    fn_sds = source_fn.replace(".txt", "_Sds_noRepsEst.txt")
+    df_sds.to_csv(fn_sds, na_rep=np.nan, sep="\t")
+    fn_ns = source_fn.replace(".txt", "_Ns_noRepsEst.txt")
+    pd.DataFrame(np.ones(df.shape), index=df.index, columns=df.columns).to_csv(
+        fn_ns, na_rep=np.nan, sep="\t"
+    )
+    args.means = source_fn
+    args.sds = fn_sds
+    args.ns = fn_ns
+
+
 def main(args):
 
     fn = args.filename
@@ -118,11 +148,11 @@ def main(args):
     size = int(args.size)
     reps = int(args.reps)
 
-    try:
-        assert ".txt" in fn or ".txt" in args.means
-    except AssertionError:
-        print("Please make the suffix of your raw data file or means file .txt")
-        assert 0
+    if ".txt" not in fn and ".txt" not in args.means:
+        raise ValueError(
+            "Input file or means file must have a .txt suffix; "
+            f"got filename={fn!r}, means={args.means!r}"
+        )
 
     if not args.basic:
         args.limma = True
@@ -140,28 +170,7 @@ def main(args):
         args.prefix = "NoRepSD_" + args.prefix
         print("No replicates, skipping Limma procedure")
         print("Estimating time point variance from arrhythmic genes")
-        try:
-            df = pd.read_table(fn, index_col="ID")
-        except ValueError:
-            df = pd.read_table(fn, index_col="#")
-        except ValueError:
-            print('Header needs to begin with "ID" or with "#"')
-
-        j = pd.read_table(args.jtk, index_col="ID")
-        mean = df.loc[j[j.GammaP > 0.8].index].std(axis=1).dropna().mean()
-
-        df_sds = pd.DataFrame(
-            np.ones(df.shape) * mean, index=df.index, columns=df.columns
-        )
-        df_ns = pd.DataFrame(np.ones(df.shape), index=df.index, columns=df.columns)
-        fn_sds = fn.replace(".txt", "_Sds_noRepsEst.txt")
-        df_sds.to_csv(fn_sds, na_rep=np.nan, sep="\t")
-        fn_ns = fn.replace(".txt", "_Ns_noRepsEst.txt")
-        df_sds.to_csv(fn_ns, na_rep=np.nan, sep="\t")
-
-        args.means = fn
-        args.sds = fn_sds
-        args.ns = fn_ns
+        _setup_noreps_args(fn, args.jtk, args)
 
     elif args.limma:
         pref = fn.replace(".txt", "")
@@ -230,28 +239,7 @@ def main(args):
         if args.noreps:
             print("No replicates, skipping Limma procedure")
             print("Estimating time point variance from arrhythmic genes")
-            try:
-                df = pd.read_table(fn, index_col="ID")
-            except ValueError:
-                df = pd.read_table(fn, index_col="#")
-            except ValueError:
-                print('Header needs to begin with "ID" or with "#"')
-
-            j = pd.read_table(args.jtk, index_col="ID")
-            mean = df.loc[j[j.GammaP > 0.8].index].std(axis=1).dropna().mean()
-
-            df_sds = pd.DataFrame(
-                np.ones(df.shape) * mean, index=df.index, columns=df.columns
-            )
-            df_ns = pd.DataFrame(np.ones(df.shape), index=df.index, columns=df.columns)
-            fn_sds = fn_null.replace(".txt", "_Sds_noRepsEst.txt")
-            df_sds.to_csv(fn_sds, na_rep=np.nan, sep="\t")
-            fn_ns = fn_null.replace(".txt", "_Ns_noRepsEst.txt")
-            df_sds.to_csv(fn_ns, na_rep=np.nan, sep="\t")
-
-            args.means = fn_null
-            args.sds = fn_sds
-            args.ns = fn_ns
+            _setup_noreps_args(fn_null, args.jtk, args)
         elif args.limma:
             pref_null = fn_null.replace(".txt", "")
             if not args.vash:

--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -77,7 +77,7 @@ class simulate:
         pbatch: float = 0.5,
         effect_size: float = 2.0,
         p_miss: float = 0.0,
-        lam_miss: int = 5,
+        lam_miss: float = 5,
         rseed: int = 0,
     ) -> None:
         pconst = 1.0 - pcirc - plin
@@ -128,6 +128,8 @@ class simulate:
                 ]
                 raw[idx] = [v for t in zip(*reps) for v in t]
             else:  # constitutive
+                # Mean of 1 keeps the row non-zero so the unit-SD scaling denominator
+                # is well-defined after scale() is applied.
                 raw[idx] = np.random.normal(1, amp_noise, n_cols)
 
         self._raw = raw

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,10 +4,10 @@
 name = "appnope"
 version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "platform_system == \"Darwin\""
+markers = "extra == \"interactive\" and platform_system == \"Darwin\""
 files = [
     {file = "appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c"},
     {file = "appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee"},
@@ -17,9 +17,10 @@ files = [
 name = "asttokens"
 version = "3.0.1"
 description = "Annotate AST trees with source code positions"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
@@ -33,10 +34,10 @@ test = ["astroid (>=2,<5)", "pytest (<9.0)", "pytest-cov", "pytest-xdist"]
 name = "cffi"
 version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "implementation_name == \"pypy\""
+markers = "extra == \"interactive\" and implementation_name == \"pypy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -138,15 +139,16 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
+markers = {main = "extra == \"interactive\" and sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
 version = "0.2.3"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -386,9 +388,10 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 name = "debugpy"
 version = "1.8.20"
 description = "An implementation of the Debug Adapter Protocol for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64"},
     {file = "debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642"},
@@ -426,9 +429,10 @@ files = [
 name = "decorator"
 version = "5.2.1"
 description = "Decorators for Humans"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
@@ -454,9 +458,10 @@ profile = ["gprof2dot (>=2022.7.29)"]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -554,9 +559,10 @@ files = [
 name = "ipykernel"
 version = "7.2.0"
 description = "IPython Kernel for Jupyter"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "ipykernel-7.2.0-py3-none-any.whl", hash = "sha256:3bbd4420d2b3cc105cbdf3756bfc04500b1e52f090a90716851f3916c62e1661"},
     {file = "ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e"},
@@ -588,9 +594,10 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<10)", "pytest-asyn
 name = "ipython"
 version = "9.13.0"
 description = "IPython: Productive Interactive Computing"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201"},
     {file = "ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967"},
@@ -622,9 +629,10 @@ test-extra = ["curio", "ipykernel (>6.30)", "ipython[matplotlib]", "ipython[test
 name = "ipython-pygments-lexers"
 version = "1.1.1"
 description = "Defines a variety of Pygments lexers for highlighting IPython code."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
@@ -637,9 +645,10 @@ pygments = "*"
 name = "jedi"
 version = "0.19.2"
 description = "An autocompletion tool for Python that can be used for text editors."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9"},
     {file = "jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0"},
@@ -669,9 +678,10 @@ files = [
 name = "jupyter-client"
 version = "8.8.0"
 description = "Jupyter protocol implementation and client libraries"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a"},
     {file = "jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e"},
@@ -693,9 +703,10 @@ test = ["anyio", "coverage", "ipykernel (>=6.14)", "msgpack", "mypy ; platform_p
 name = "jupyter-core"
 version = "5.9.1"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407"},
     {file = "jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508"},
@@ -1056,9 +1067,10 @@ dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setup
 name = "matplotlib-inline"
 version = "0.2.1"
 description = "Inline Matplotlib backend for Jupyter"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76"},
     {file = "matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe"},
@@ -1213,9 +1225,10 @@ sqlframe = ["sqlframe (>=3.22.0,!=3.39.3)"]
 name = "nest-asyncio"
 version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
-optional = false
+optional = true
 python-versions = ">=3.5"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
@@ -1451,9 +1464,10 @@ xml = ["lxml (>=5.3.0)"]
 name = "parso"
 version = "0.8.6"
 description = "A Python Parser"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff"},
     {file = "parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd"},
@@ -1502,10 +1516,10 @@ test = ["pytest", "pytest-cov", "scipy"]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "extra == \"interactive\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -1627,9 +1641,10 @@ xmp = ["defusedxml"]
 name = "platformdirs"
 version = "4.9.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
     {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
@@ -1680,9 +1695,10 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 name = "prompt-toolkit"
 version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -1695,9 +1711,10 @@ wcwidth = "*"
 name = "psutil"
 version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -1730,10 +1747,10 @@ test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_na
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
+markers = "extra == \"interactive\" and sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -1743,9 +1760,10 @@ files = [
 name = "pure-eval"
 version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -1818,10 +1836,10 @@ files = [
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "implementation_name == \"pypy\""
+markers = "extra == \"interactive\" and implementation_name == \"pypy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -1838,6 +1856,7 @@ files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {main = "extra == \"interactive\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -1918,9 +1937,10 @@ six = ">=1.5"
 name = "pyzmq"
 version = "27.1.0"
 description = "Python bindings for 0MQ"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "pyzmq-27.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:508e23ec9bc44c0005c4946ea013d9317ae00ac67778bd47519fdf5a0e930ff4"},
     {file = "pyzmq-27.1.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:507b6f430bdcf0ee48c0d30e734ea89ce5567fd7b8a0f0044a369c176aa44556"},
@@ -2226,9 +2246,10 @@ files = [
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -2316,9 +2337,10 @@ files = [
 name = "tornado"
 version = "6.5.5"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa"},
     {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521"},
@@ -2358,9 +2380,10 @@ telegram = ["requests"]
 name = "traitlets"
 version = "5.14.3"
 description = "Traitlets Python configuration system"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
@@ -2381,7 +2404,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version == \"3.11\""}
+markers = {main = "extra == \"interactive\" and python_version == \"3.11\""}
 
 [[package]]
 name = "tzdata"
@@ -2400,9 +2423,10 @@ files = [
 name = "wcwidth"
 version = "0.6.0"
 description = "Measures the displayed width of unicode strings in a terminal"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"interactive\""
 files = [
     {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
     {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
@@ -2410,9 +2434,9 @@ files = [
 
 [extras]
 fast = ["numba"]
-interactive = ["plotly"]
+interactive = ["ipykernel", "plotly"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "fc84a53f342b65e0792f67b979d4909a3f211f038bf17136799949aafbe1e771"
+content-hash = "ac3752b831fbbb3e577c49bb95100f312f0f5411e337fcbd0bd8c93d998b6de5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,11 @@ dependencies = [
     "matplotlib>=3.10",
     "pyarrow>=23.0.1",
     "seaborn>=0.11",
-    "ipykernel (>=7.2.0,<8.0.0)",
 ]
 
 [project.optional-dependencies]
 fast = ["numba>=0.50.0"]
-interactive = ["plotly>=6.0"]
+interactive = ["plotly>=6.0", "ipykernel>=6.0"]
 
 [project.scripts]
 circ = "circ.cli:main"
@@ -36,7 +35,9 @@ include = ["circ/rhythmicity/ref_files/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=circ --cov-report=term-missing --cov-report=xml"
+# Coverage flags are omitted here so that `poetry run pytest` works without the
+# dev dependency group.  CI passes --cov=circ --cov-report=term-missing
+# --cov-report=xml explicitly via the pytest command in the workflow.
 
 [tool.coverage.run]
 source = ["circ"]

--- a/tests/limbr/test_imputation.py
+++ b/tests/limbr/test_imputation.py
@@ -10,7 +10,6 @@ def test_init_loads_data(imputation_file):
     assert obj.data is not None
     assert obj.miss == 0.5
     assert obj.pats == {}
-    assert obj.notdone is True
 
 
 def test_init_custom_neighbors(imputation_file):

--- a/tests/limbr/test_old_fashioned.py
+++ b/tests/limbr/test_old_fashioned.py
@@ -10,7 +10,6 @@ def test_init_rnaseq(rnaseq_file):
     obj = old_fashioned(rnaseq_file, data_type="r")
     assert obj.data_type == "r"
     assert obj.raw_data is not None
-    assert obj.notdone is True
 
 
 def test_init_proteomics(proteomics_file):


### PR DESCRIPTION
## Summary

- **3 bug fixes**: `est_pi_sig()` string-vs-float return type in `batch_fx`; `params = p0` outside `else` block in `CalcP` (NameError on `.pkl` input); division-by-zero in PIRS precision-recall curve
- **Refactoring**: duplicated `qnorm`/`pool_norm` helpers extracted to `circ/limbr/_normalize.py`; `pipeline.py` noreps block deduplicated into `_setup_noreps_args()`; `Classifier._source` normalised to `pd.DataFrame` at construction; `_REF_DIR` uses `importlib.resources` instead of `os.path`
- **Code quality**: blanket `RuntimeWarning` suppression replaced with conditional pre-filtering; dunder naming fixed; dead code removed; `_TAU_CLIP` constant extracted; descriptive error on malformed column names; `ipykernel` moved out of mandatory deps

## Changes by file

| File | What changed |
|------|-------------|
| `circ/limbr/batch_fx.py` | Fix `est_pi_sig()` return type; use shared `_qnorm`/`_pool_norm` |
| `circ/limbr/_normalize.py` *(new)* | Shared `_qnorm` and `_pool_norm` helpers |
| `circ/limbr/old_fashioned.py` | Use shared helpers; remove dead `notdone` attribute |
| `circ/limbr/imputation.py` | Remove dead `notdone`; add comment for magic index |
| `circ/rhythmicity/CalcP.py` | Fix `params = p0` indentation (was outside `else`) |
| `circ/rhythmicity/pipeline.py` | Extract `_setup_noreps_args()`; fix `assert 0` → `ValueError` |
| `circ/rhythmicity/limma_voom.py` | Replace blanket `RuntimeWarning` suppress with conditional pre-filtering; remove unused `warnings` import |
| `circ/rhythmicity/BooteJTK.py` | Rename `__score_at_percentile__` → `_score_at_percentile`; remove dead commented code |
| `circ/rhythmicity/arbfit.py` | Rename `p` → `params` in model functions |
| `circ/rhythmicity/get_stat_probs.py` | Extract `_TAU_CLIP = 0.99` constant |
| `circ/expression_classification/classify.py` | Use `importlib.resources` for `_REF_DIR`; normalise `_source` to `DataFrame` |
| `circ/pirs/rank.py` | Descriptive `ValueError` in `get_tpoints()`; document zero-row filtering; forkserver comment |
| `circ/pirs/simulations.py` | Fix division-by-zero in PR curve; concat-in-loop → list + single concat |
| `circ/simulations.py` | `lam_miss` annotation `int` → `float`; document constitutive mean |
| `pyproject.toml` | Move `ipykernel` to `[interactive]` optional group; remove `--cov` from `addopts` |
| `tests/limbr/test_imputation.py` | Remove assertion for deleted `notdone` attribute |
| `tests/limbr/test_old_fashioned.py` | Remove assertion for deleted `notdone` attribute |

## Test plan

- [x] `poetry run pytest` — 871 tests pass
- [x] `poetry run ruff check circ/` — no errors
- [x] `poetry run ruff format --check circ/` — no formatting drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)