### PR TITLE
fix: case-insensitive .parquet detection in circ.io (#44)

### DIFF
--- a/circ/io.py
+++ b/circ/io.py
@@ -27,7 +27,7 @@ def read_expression(
     if isinstance(source, pd.DataFrame):
         return source.copy()
     path = str(source)
-    if path.endswith(".parquet"):
+    if Path(path).suffix.lower() == ".parquet":
         return pd.read_parquet(path)
     if data_type == "p":
         return pd.read_csv(path, sep="\t").set_index(["Peptide", "Protein"])
@@ -46,7 +46,7 @@ def write_expression(df: pd.DataFrame, path: str | Path) -> None:
     path : str | Path
     """
     path = str(path)
-    if path.endswith(".parquet"):
+    if Path(path).suffix.lower() == ".parquet":
         df.to_parquet(path)
     else:
         df.to_csv(path, sep="\t")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,6 +71,12 @@ class TestReadExpression:
         result = read_expression(path, data_type="p")
         pd.testing.assert_frame_equal(result, prot_df)
 
+    def test_read_parquet_uppercase_extension(self, tmp_path, expr_df):
+        path = str(tmp_path / "expr.PARQUET")
+        expr_df.to_parquet(path)
+        result = read_expression(path)
+        pd.testing.assert_frame_equal(result, expr_df)
+
 
 # ---------------------------------------------------------------------------
 # write_expression
@@ -101,6 +107,13 @@ class TestWriteExpression:
         write_expression(expr_df, path)
         result = read_expression(path)
         pd.testing.assert_frame_equal(result, expr_df)
+
+    def test_write_parquet_uppercase_extension(self, tmp_path, expr_df):
+        path = str(tmp_path / "out.PARQUET")
+        write_expression(expr_df, path)
+        with open(path, "rb") as fh:
+            assert fh.read(4) == b"PAR1"
+        pd.testing.assert_frame_equal(read_expression(path), expr_df)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `read_expression` / `write_expression` detected Parquet via `path.endswith(".parquet")`, which is case-sensitive. An uppercase/mixed-case extension (`.PARQUET`) was silently treated as tab-separated text in both directions, corrupting round-trips.
- Now compares `Path(path).suffix.lower() == ".parquet"`.

## Test plan
- Added `test_read_parquet_uppercase_extension` and `test_write_parquet_uppercase_extension` (verifies the `PAR1` magic bytes are written).
- CI: ruff check + ruff format + pytest.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)