### PR TITLE
fix: derive simulation sidecar stem with splitext (#45)

### DIFF
--- a/circ/simulations.py
+++ b/circ/simulations.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 
@@ -194,12 +195,12 @@ class simulate:
 
         Writes the scaled clean data to *out_name* and the per-row class
         labels to ``<stem>_true_classes.txt`` (where stem is *out_name*
-        with its final four characters removed).
+        with its extension removed).
         """
         df = pd.DataFrame(self.sim, columns=self.cols)
         df.index.name = "#"
         df.to_csv(out_name, sep="\t")
-        stem = out_name[:-4]
+        stem = os.path.splitext(out_name)[0]
         self._true_classes_df(index=df.index).to_csv(
             stem + "_true_classes.txt", sep="\t"
         )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -234,6 +234,18 @@ class TestWriteOutput:
         row_sums = tc["Circadian"] + tc["Linear"] + tc["Const"]
         assert (row_sums == 1).all()
 
+    def test_sidecar_stem_extensionless(self, tmp_path):
+        sim = simulate(nrows=20, tpoints=4, nreps=2, rseed=0)
+        out = str(tmp_path / "mysim")
+        sim.write_output(out_name=out)
+        assert os.path.exists(str(tmp_path / "mysim_true_classes.txt"))
+
+    def test_sidecar_stem_parquet_extension(self, tmp_path):
+        sim = simulate(nrows=20, tpoints=4, nreps=2, rseed=0)
+        out = str(tmp_path / "out.parquet")
+        sim.write_output(out_name=out)
+        assert os.path.exists(str(tmp_path / "out_true_classes.txt"))
+
 
 # ---------------------------------------------------------------------------
 # write_proteomics


### PR DESCRIPTION
## Summary
- `simulate.write_output` derived the true-classes sidecar filename via `out_name[:-4]`, which only works for 4-character extensions (`.txt`/`.tsv`). Extensionless names (`mysim` → `m_true_classes.txt`) and other extensions (`out.parquet` → `out.par_true_classes.txt`) produced a mangled stem mismatched with the data file.
- Now uses `os.path.splitext(out_name)[0]`.

## Test plan
- Added `test_sidecar_stem_extensionless` and `test_sidecar_stem_parquet_extension`.
- CI: ruff check + ruff format + pytest.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)