### PR TITLE
fix: classifier handling of PIRS-dropped genes (#38, #47)

### DIFF
--- a/circ/expression_classification/classify.py
+++ b/circ/expression_classification/classify.py
@@ -314,8 +314,22 @@ class Classifier:
             if src_col in self.rhythm_results.columns:
                 result[dst_col] = self.rhythm_results[src_col]
 
-        pirs_cutoff = np.percentile(result["pirs_score"].dropna(), pirs_percentile)
+        # Genes PIRS dropped (all-zero rows, or ANOVA-filtered) carry a NaN
+        # pirs_score. Guard the percentile against an all-NaN column (#47),
+        # which would otherwise raise IndexError on the empty array.
+        scored = result["pirs_score"].dropna()
+        pirs_cutoff = np.percentile(scored, pirs_percentile) if len(scored) else np.nan
+        # NaN <= cutoff is False, so dropped genes default to non-stable.
         stable = result["pirs_score"] <= pirs_cutoff
+
+        # PIRS drops all-zero (perfectly flat) rows precisely because they are
+        # maximally constitutive; mark them stable so they aren't mislabeled
+        # variable/noisy_rhythmic (#38). ANOVA-dropped genes are left non-stable.
+        missing = result["pirs_score"].isna()
+        if missing.any():
+            common = result.index.intersection(self._source.index)
+            all_zero = (self._source.loc[common] == 0).all(axis=1)
+            stable.loc[all_zero.index[all_zero]] = True
 
         rhythmic = result["tau_mean"] >= tau_threshold
         if "emp_p" in result.columns:

--- a/tests/expression_classification/test_classify.py
+++ b/tests/expression_classification/test_classify.py
@@ -229,6 +229,53 @@ class TestClassify:
         assert n_strict <= n_lenient
 
 
+class TestNanPirsHandling:
+    """PIRS drops some genes (all-zero rows, ANOVA filter), leaving NaN
+    pirs_score after the union with BooteJTK results."""
+
+    def _src(self):
+        src = pd.DataFrame(
+            [[1, 2, 3, 4], [4, 3, 2, 1], [2, 2.5, 2, 2.5], [0, 0, 0, 0]],
+            index=["g1", "g2", "g3", "g_zero"],
+            columns=["ZT00_1", "ZT06_1", "ZT12_1", "ZT18_1"],
+        )
+        src.index.name = "#"
+        return src
+
+    def test_all_zero_row_labeled_constitutive(self):
+        # #38: PIRS drops the all-zero row (maximally constitutive); it must be
+        # labeled constitutive, not variable/noisy_rhythmic.
+        clf = Classifier(self._src())
+        clf.pirs_scores = pd.DataFrame(
+            {"score": [0.1, 0.2, 0.3]}, index=["g1", "g2", "g3"]
+        )
+        clf.pirs_scores.index.name = "#"
+        clf.rhythm_results = pd.DataFrame(
+            {"TauMean": [0.1] * 4}, index=["g1", "g2", "g3", "g_zero"]
+        )
+        out = clf.classify(pirs_percentile=80, tau_threshold=0.5)
+        assert np.isnan(out.loc["g_zero", "pirs_score"])
+        assert out.loc["g_zero", "label"] == "constitutive"
+
+    def test_empty_pirs_scores_does_not_crash(self):
+        # #47: every gene's pirs_score is NaN -> np.percentile on an empty array
+        # used to raise IndexError.
+        src = pd.DataFrame(
+            [[1.0, 2.0, 3.0, 4.0]],
+            index=["g1"],
+            columns=["ZT00_1", "ZT06_1", "ZT12_1", "ZT18_1"],
+        )
+        src.index.name = "#"
+        clf = Classifier(src)
+        clf.pirs_scores = pd.DataFrame(
+            {"score": pd.Series([], dtype=float)}, index=pd.Index([], name="#")
+        )
+        clf.rhythm_results = pd.DataFrame({"TauMean": [0.9]}, index=["g1"])
+        out = clf.classify(pirs_percentile=50, tau_threshold=0.5)
+        assert "label" in out.columns
+        assert len(out) == 1
+
+
 # ---------------------------------------------------------------------------
 # Integration test: run_all()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PIRS drops all-zero rows (maximally constitutive) and ANOVA-filtered genes, so after the union with BooteJTK results those genes carry a `NaN` `pirs_score`.

- **#47:** guard `np.percentile` against an all-`NaN` `pirs_score` column, which raised `IndexError` on the empty array.
- **#38:** `NaN <= cutoff` is `False`, so all-zero genes were mislabeled `variable`/`noisy_rhythmic`. Detect PIRS-dropped all-zero rows from the source and mark them stable so they're labeled `constitutive`.

## Relationship to PR #54
This **supersedes the `classify.py` change** in @vanhci's PR #54. That PR guards the fully-empty case (#47) by labeling everything `unclassified`, but leaves #38 unaddressed (all-zero genes stay mislabeled). This PR fixes both in the same block. The `echo_fit.py` (#43) change in #54 is independent and not touched here — recommend keeping it.

## Test plan
- `TestNanPirsHandling::test_all_zero_row_labeled_constitutive` (reproduces #38).
- `TestNanPirsHandling::test_empty_pirs_scores_does_not_crash` (reproduces #47).
- CI: ruff check + ruff format + pytest.

Fixes #38
Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)