### PR TITLE
fix: pipeline ref-file defaults, ECHO duplicate IDs, and prefix parsing (#41, #43, #52)

### DIFF
--- a/circ/rhythmicity/echo_fit.py
+++ b/circ/rhythmicity/echo_fit.py
@@ -226,6 +226,11 @@ class EchoFitter:
             mask = tpoints == t
             mean_cols[t] = self.data.iloc[:, mask].mean(axis=1)
         means_df = pd.DataFrame(mean_cols, index=self.data.index)
+        # Duplicate gene IDs would make .loc[gene_id] return a 2-D frame and
+        # crash _fit_gene; aggregate them by averaging (matching imputable's
+        # dedup behavior) so each gene yields a single 1-D profile.
+        if means_df.index.has_duplicates:
+            means_df = means_df.groupby(level=0).mean()
 
         t_raw = np.array(unique_times, dtype=float)
         t_min = t_raw[0]

--- a/circ/rhythmicity/echo_fit.py
+++ b/circ/rhythmicity/echo_fit.py
@@ -26,6 +26,7 @@ circadian output. Bioinformatics, 36(3), 773–781.
 """
 
 import multiprocessing
+import re
 
 _mp_ctx = multiprocessing.get_context("forkserver")
 
@@ -37,6 +38,9 @@ import pandas as pd
 from scipy.optimize import curve_fit
 from scipy.stats import kendalltau
 from statsmodels.stats.multitest import multipletests
+
+# Strips a leading ZT/CT prefix only (not occurrences elsewhere in the name).
+_TPOINT_PREFIX_RE = re.compile(r"^(?:ZT|CT)")
 
 # γ classification thresholds (dimensionless; meaningful in normalised time)
 _GAMMA_DAMPED_THRESHOLD = 0.03
@@ -88,7 +92,7 @@ def _parse_timepoints(columns) -> np.ndarray:
     """Extract numeric timepoint values from ZT/CT-prefixed column names."""
     tpoints = []
     for col in columns:
-        c = str(col).replace("ZT", "").replace("CT", "")
+        c = _TPOINT_PREFIX_RE.sub("", str(col))
         tpoints.append(int(c.split("_")[0]))
     return np.array(tpoints, dtype=float)
 

--- a/circ/rhythmicity/pipeline.py
+++ b/circ/rhythmicity/pipeline.py
@@ -40,6 +40,7 @@ from .limma_preprocess import prepare_timeseries, write_limma_outputs
 from .limma_voom import run_vooma_ebayes, run_vooma_vash
 
 _PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_REF_DIR = os.path.join(_PKG_DIR, "ref_files")
 _NULL_CACHE_DIR = Path.home() / ".cache" / "circ" / "null_cache"
 
 
@@ -442,7 +443,7 @@ def __create_parser__():
         type=str,
         metavar="filename string",
         action="store",
-        default="widths_02-22.txt",
+        default=os.path.join(_REF_DIR, "asymmetries_02-22_by2.txt"),
         # choices=["widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"]
         help='Should be a file with asymmetries (widths) you wish to search for listed in a single column separated by newlines.\
                           Provided files include files like "widths_02-22.txt","widths_04-20_by4.txt","widths_04-12-20.txt","widths_08-16.txt","width_12.txt"\nasymmetries=widths',
@@ -454,7 +455,7 @@ def __create_parser__():
         dest="phase",
         metavar="filename string",
         type=str,
-        default="phases_00-22_by2.txt",
+        default=os.path.join(_REF_DIR, "phases_00-22_by2.txt"),
         help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
                           Example files include "phases_00-22_by2.txt" or "phases_00-22_by4.txt" or "phases_00-20_by4.txt"',
     )
@@ -466,9 +467,9 @@ def __create_parser__():
         metavar="filename string",
         type=str,
         action="store",
-        default="period_24.txt",
+        default=os.path.join(_REF_DIR, "period24.txt"),
         help='Should be a file with phases you wish to search for listed in a single column separated by newlines.\
-                          Provided file is "period_24.txt"',
+                          Provided file is "period24.txt"',
     )
 
     analysis.add_argument(

--- a/tests/rhythmicity/test_echo_fit.py
+++ b/tests/rhythmicity/test_echo_fit.py
@@ -139,6 +139,17 @@ class TestEchoFitterInit:
         # 12 unique timepoints → 12 columns in means DataFrame
         assert fitter._y_means.shape == (5, 12)
 
+    def test_duplicate_gene_ids_aggregated(self):
+        # #43: duplicate gene IDs made .loc[gene_id] return a 2-D frame and
+        # crash fit() with IndexError. They are now averaged into one profile.
+        df = _make_oscillation_df(gamma_norm=0.0, n_genes=3)
+        df.index = ["g1", "g1", "g2"]
+        df.index.name = "#"
+        fitter = EchoFitter(df)
+        assert not fitter._y_means.index.has_duplicates
+        result = fitter.fit()  # must not raise
+        assert set(result.index) == {"g1", "g2"}
+
 
 # ---------------------------------------------------------------------------
 # Tests: fit() output structure

--- a/tests/rhythmicity/test_echo_fit.py
+++ b/tests/rhythmicity/test_echo_fit.py
@@ -89,6 +89,13 @@ class TestParseTimepoints:
         result = _parse_timepoints(cols)
         np.testing.assert_array_equal(result, [100.0, 120.0, 140.0])
 
+    def test_strips_prefix_only_not_embedded(self):
+        # #52: the old global .replace("ZT","") turned 'ZTZT12_1' into '12';
+        # anchored stripping removes only the leading ZT, leaving 'ZT12', which
+        # is not a valid timepoint token, so parsing must fail loudly.
+        with pytest.raises(ValueError):
+            _parse_timepoints(["ZTZT12_1"])
+
 
 # ---------------------------------------------------------------------------
 # Tests: EchoFitter instantiation

--- a/tests/rhythmicity/test_pipeline_parser.py
+++ b/tests/rhythmicity/test_pipeline_parser.py
@@ -1,0 +1,27 @@
+"""Tests for the standalone `circ rhythm-calcp` pipeline argument parser."""
+
+import os
+
+from circ.rhythmicity import pipeline
+
+
+class TestParserRefFileDefaults:
+    """#41: default ref-file paths must resolve to files that actually exist
+    in circ/rhythmicity/ref_files/, regardless of the current directory."""
+
+    def test_period_default_exists(self):
+        ns = pipeline.__create_parser__().parse_args([])
+        assert os.path.isfile(ns.period)
+
+    def test_phase_default_exists(self):
+        ns = pipeline.__create_parser__().parse_args([])
+        assert os.path.isfile(ns.phase)
+
+    def test_width_default_exists(self):
+        ns = pipeline.__create_parser__().parse_args([])
+        assert os.path.isfile(ns.width)
+
+    def test_defaults_live_in_ref_dir(self):
+        ns = pipeline.__create_parser__().parse_args([])
+        for path in (ns.period, ns.phase, ns.width):
+            assert os.path.dirname(path) == pipeline._REF_DIR


### PR DESCRIPTION
## Summary
- **#41:** the standalone `circ rhythm-calcp` parser defaulted `--period`/`--asymmetry`/`--phase` to filenames that either don't exist (`period_24.txt`, `widths_02-22.txt`) or weren't joined with the ref dir (read relative to CWD), so running it without explicit paths failed with `FileNotFoundError`. Added `_REF_DIR` and joined the defaults with the correct names (`period24.txt`, `asymmetries_02-22_by2.txt`, `phases_00-22_by2.txt`), mirroring BooteJTK's own parser.
- **#43:** duplicate gene IDs made `_y_means.loc[gene_id]` return a 2-D frame and crash `EchoFitter.fit` with `IndexError`. Aggregate rows sharing a gene ID by averaging (matching `imputable`'s dedup behavior). Folded in after the external PR #54 was closed.
- **#52:** `_parse_timepoints` stripped `ZT`/`CT` from anywhere in a column name; now strips only a leading prefix via an anchored regex.

## Test plan
- `tests/rhythmicity/test_pipeline_parser.py`: parser defaults resolve to existing files in the ref dir.
- `test_duplicate_gene_ids_aggregated` (#43): duplicate IDs averaged, `fit()` no longer crashes.
- `TestParseTimepoints::test_strips_prefix_only_not_embedded` (#52).
- CI: ruff check + ruff format + pytest.

#52 also has a `rank.py` occurrence handled in #58 — close #52 once both land.

Fixes #41
Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)