### PR TITLE
fix: KNN imputation and SVA correctness + deduplicate index (#39, #40, #46, #48, #49, #50, #61)

### DIFF
--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -1,10 +1,14 @@
 import itertools
+import re
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import multiprocess as _mp
 from circ.limbr._normalize import _pool_norm, _qnorm
+
+# Strips a leading ZT/CT prefix only (not occurrences elsewhere in the name).
+_TPOINT_PREFIX_RE = re.compile(r"^(?:ZT|CT)")
 
 _forkserver_pool = _mp.get_context("forkserver").Pool
 from sklearn import preprocessing
@@ -67,7 +71,7 @@ def _perm_worker(rseed: int) -> np.ndarray:
 
     n = min(len(tkstar), len(_perm_tks))
     out = np.zeros(len(_perm_tks))
-    out[:n] = tkstar[:n] > _perm_tks[:n]
+    out[:n] = tkstar[:n] >= _perm_tks[:n]
     return out
 
 
@@ -190,9 +194,7 @@ class sva:
 
         """
 
-        tpoints = [
-            i.replace("ZT", "").replace("CT", "") for i in self.data.columns.values
-        ]
+        tpoints = [_TPOINT_PREFIX_RE.sub("", str(i)) for i in self.data.columns.values]
         tpoints = [int(i.split("_")[0]) for i in tpoints]
         # deprecated splitting for alternative header syntax
         # tpoints = [int(i.split('.')[0]) for i in tpoints]
@@ -225,7 +227,12 @@ class sva:
             def autocorr_vec(m, shift):
                 """Row-wise autocorrelation of a 2-D array at a given shift."""
                 shifted = np.roll(m, shift, axis=1)
-                return np.einsum("ij,ij->i", m, shifted) / np.einsum("ij,ij->i", m, m)
+                num = np.einsum("ij,ij->i", m, shifted)
+                den = np.einsum("ij,ij->i", m, m)
+                # An all-zero row has zero sum-of-squares; define its
+                # autocorrelation as 0 rather than propagating NaN into the
+                # reduction threshold.
+                return np.divide(num, den, out=np.zeros_like(num), where=den != 0)
 
             tps = np.asarray(self.tpoints)
             unique_tps = np.unique(tps)
@@ -407,7 +414,7 @@ class sva:
             tkstar = self.get_tks(resstar)
             n = min(len(tkstar), len(self.tks))
             out = np.zeros(len(self.tks))
-            out[:n] = tkstar[:n] > self.tks[:n]
+            out[:n] = tkstar[:n] >= self.tks[:n]
             return out
 
         seeds = range(int(nperm))
@@ -429,7 +436,10 @@ class sva:
                 )
         else:
             output = [single_it(s) for s in tqdm(seeds, desc="permuting", smoothing=0)]
-        self.sigs = np.sum(np.asarray(output), axis=0) / float(nperm)
+        # Finite-sample-valid permutation p-value: (count + 1) / (nperm + 1),
+        # counting the observed statistic as one realisation. Avoids an
+        # anti-conservative significance of exactly 0.
+        self.sigs = (np.sum(np.asarray(output), axis=0) + 1) / (float(nperm) + 1)
 
     def eig_reg(self, alpha: float = 0.05) -> None:
         """
@@ -547,11 +557,14 @@ class sva:
             """
 
             pi_0 = est_pi_naught(probs_sig, l)
-            if pi_0 > 1:
-                return np.nan
             sp = np.sort(probs_sig)
-            pi_sig = sp[int(np.floor((1 - pi_0) * len(probs_sig)) - 1)]
-            return pi_sig
+            # Rows associated with the trend ≈ (1 - pi_0)·N. When the trend is
+            # ~null ((1 - pi_0)·N < 1, or pi_0 ≥ 1) this rounds to 0; the clamped
+            # index makes the cutoff the minimum p-value, so the strict `<`
+            # comparison admits no rows. The old code subtracted 1 first, wrapping
+            # to sp[-1] (the maximum) and admitting nearly every row.
+            idx = max(int(np.floor((1 - pi_0) * len(probs_sig))) - 1, 0)
+            return sp[idx]
 
         pt, _, bt = np.linalg.svd(self.res)
         trends: list[np.ndarray] = []
@@ -559,10 +572,8 @@ class sva:
         for j, entry in enumerate(tqdm(self.ps)):
             sub = []
             thresh = est_pi_sig(entry, lam)
-            if np.isnan(thresh):
-                self.ts: list[np.ndarray] = trends
-                self.pepts: list[np.ndarray] = pep_trends
-                return
+            # A ~null trend admits no rows (empty sub) and is simply skipped;
+            # remaining eigentrends must still be evaluated, so do not return.
             for i in range(len(entry)):
                 if entry[i] < thresh:
                     sub.append(self.data_reduced.values[i])

--- a/circ/limbr/batch_fx.py
+++ b/circ/limbr/batch_fx.py
@@ -194,8 +194,8 @@ class sva:
 
         """
 
-        tpoints = [_TPOINT_PREFIX_RE.sub("", str(i)) for i in self.data.columns.values]
-        tpoints = [int(i.split("_")[0]) for i in tpoints]
+        stripped = [_TPOINT_PREFIX_RE.sub("", str(i)) for i in self.data.columns.values]
+        tpoints = [int(s.split("_")[0]) for s in stripped]
         # deprecated splitting for alternative header syntax
         # tpoints = [int(i.split('.')[0]) for i in tpoints]
         self.tpoints = np.asarray(tpoints)

--- a/circ/limbr/imputation.py
+++ b/circ/limbr/imputation.py
@@ -71,9 +71,10 @@ class imputable:
         # Check whether the second column's first value ends in e.g. "T4" or "T24"
         # (a trailing digit preceded by "T"), which indicates peptides with
         # ZT/CT-suffixed charge states that need to be stripped before grouping.
-        if (self.data[self.data.columns.values[1]][0][-2] == "T") & (
-            self.data[self.data.columns.values[1]][0][-1].isdigit()
-        ):
+        # Use positional access — a DataFrame input may carry a non-default index
+        # for which label 0 does not exist.
+        first_val = self.data[self.data.columns.values[1]].iloc[0]
+        if (first_val[-2] == "T") & (first_val[-1].isdigit()):
             self.data[self.data.columns.values[1]] = self.data[
                 self.data.columns.values[1]
             ].apply(lambda x: x.split("T")[0])

--- a/circ/limbr/imputation.py
+++ b/circ/limbr/imputation.py
@@ -163,8 +163,11 @@ class imputable:
 
             # drop missing columns given missingness pattern
             newarr = comparr[:, ~np.array(list(pattern)).astype(int).astype(bool)]
-            # fit nearest neighbors
-            nbrs = NearestNeighbors(n_neighbors=self.NN).fit(newarr)
+            # Clamp neighbor count to the number of complete cases — fewer
+            # complete rows than self.NN is common in proteomics and otherwise
+            # makes kneighbors raise ValueError.
+            k = min(self.NN, len(comparr))
+            nbrs = NearestNeighbors(n_neighbors=k).fit(newarr)
             outa = []
             # iterate over rows matching missingness pattern
             for rowind, row in enumerate(origarr[inds]):
@@ -179,8 +182,10 @@ class imputable:
                     ],
                     return_distance=False,
                 )
-                # get array of nearest neighbors
-                means = np.mean(comparr[indexes[0][1:]], axis=0)
+                # Average all returned neighbors. The rows being imputed have
+                # missing values so are never in the complete-case set, meaning
+                # index 0 is a genuine nearest neighbor and must not be dropped.
+                means = np.mean(comparr[indexes[0]], axis=0)
                 # iterate over entries in each row
                 for ind, v in enumerate(row):
                     if not np.isnan(v):
@@ -220,6 +225,12 @@ class imputable:
         datavals = self.data.values
         # generate array of complete cases
         comparr = datavals[~np.isnan(datavals).any(axis=1)]
+        if len(comparr) == 0:
+            raise ValueError(
+                "KNN imputation requires at least one complete-case row (no "
+                "missing values) to learn from, but none were found. Lower the "
+                "missingness threshold or provide more complete observations."
+            )
 
         # find missingness patterns
         get_patterns(datavals)

--- a/tests/limbr/test_batch_fx.py
+++ b/tests/limbr/test_batch_fx.py
@@ -192,3 +192,61 @@ def test_init_accepts_parquet(tmp_path, rnaseq_file):
     obj = sva(path, design="c", data_type="r")
     assert isinstance(obj.raw_data, pd.DataFrame)
     pd.testing.assert_frame_equal(obj.raw_data, df)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for code-review fixes
+# ---------------------------------------------------------------------------
+
+
+def test_prim_cor_all_zero_row_no_nan(rnaseq_file):
+    # #48: an all-zero per-timepoint-mean row used to divide by zero in the
+    # autocorrelation, propagating NaN into the reduction threshold.
+    obj = sva(rnaseq_file, design="c", data_type="r")
+    obj.pool_normalize()
+    obj.get_tpoints()
+    obj.data.iloc[0, :] = 0.0
+    obj.prim_cor()
+    assert not np.isnan(obj.cors).any()
+
+
+def test_perm_test_sigs_never_zero(rnaseq_file):
+    # #50: significance is (count + 1) / (nperm + 1), so it can never be 0.
+    obj = sva(rnaseq_file, design="c", data_type="r")
+    obj.preprocess_default()
+    nperm = 5
+    obj.perm_test(nperm=nperm)
+    assert (obj.sigs >= 1.0 / (nperm + 1) - 1e-12).all()
+
+
+def test_subset_svd_processes_trends_after_null(rnaseq_file):
+    # #46: a ~null trend (pi_0 > 1) used to trigger an early return, abandoning
+    # all later eigentrends. It must instead admit no rows and continue.
+    obj = sva(rnaseq_file, design="c", data_type="r")
+    rng = np.random.default_rng(0)
+    obj.res = rng.standard_normal((5, 6))
+    obj.data_reduced = pd.DataFrame(
+        rng.standard_normal((5, 6)), index=[f"g{i}" for i in range(5)]
+    )
+    # Trend 0 is ~null (pi_0 > 1 -> admits nothing); trend 1 carries signal.
+    obj.ps = [
+        [0.9, 0.9, 0.9, 0.9, 0.9],
+        [0.001, 0.002, 0.003, 0.004, 0.9],
+    ]
+    obj.subset_svd()
+    assert len(obj.ts) == 1
+    assert len(obj.pepts) == 1
+
+
+def test_get_tpoints_strips_prefix_only(tmp_path):
+    # #61: embedded ZT/CT must not be stripped from the time token.
+    cols = ["ZTZT12_1", "ZTZT18_1"]
+    df = pd.DataFrame(np.random.randn(4, len(cols)), columns=cols)
+    df.index = [f"gene_{i}" for i in range(4)]
+    df.index.name = "#"
+    path = str(tmp_path / "embedded.txt")
+    df.to_csv(path, sep="\t")
+    obj = sva(path, design="c", data_type="r")
+    obj.pool_normalize()
+    with pytest.raises(ValueError):
+        obj.get_tpoints()

--- a/tests/limbr/test_imputation.py
+++ b/tests/limbr/test_imputation.py
@@ -103,8 +103,19 @@ def test_init_accepts_multiindex_dataframe(imputation_file):
 
 
 # ---------------------------------------------------------------------------
-# Regression tests: KNN neighbor handling (#39, #40)
+# Regression tests: deduplicate + KNN neighbor handling (#39, #40, #49)
 # ---------------------------------------------------------------------------
+
+
+def test_deduplicate_with_nondefault_index(imputation_file):
+    # #49: deduplicate() looked up the second column by integer label 0, which
+    # raised KeyError for a DataFrame whose index is neither a RangeIndex nor a
+    # MultiIndex. Positional access fixes it.
+    df = pd.read_csv(imputation_file, sep="\t")
+    df.index = [f"row_{i}" for i in range(len(df))]
+    obj = imputable(df, missingness=0.5)
+    obj.deduplicate()
+    assert isinstance(obj.data.index, pd.MultiIndex)
 
 
 def test_impute_keeps_nearest_neighbor(tmp_path):

--- a/tests/limbr/test_imputation.py
+++ b/tests/limbr/test_imputation.py
@@ -100,3 +100,52 @@ def test_init_accepts_multiindex_dataframe(imputation_file):
     # MultiIndex should have been reset to flat columns for deduplicate()
     assert "Peptide" in obj.data.columns
     assert "Protein" in obj.data.columns
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: KNN neighbor handling (#39, #40)
+# ---------------------------------------------------------------------------
+
+
+def test_impute_keeps_nearest_neighbor(tmp_path):
+    # #39: query q matches a exactly on observed columns (a is the nearest
+    # neighbor) and b is far. With neighbors=2 the imputed value should be
+    # mean(a, b) = 50, not 0 (which is what dropping the nearest neighbor gave).
+    df = pd.DataFrame(
+        [[100.0, 5.0, 5.0], [0.0, 50.0, 50.0], [np.nan, 5.0, 5.0]],
+        columns=["ZT00_1", "ZT06_1", "ZT12_1"],
+    )
+    df.insert(0, "Protein", ["pA", "pB", "pQ"])
+    df.insert(0, "Peptide", ["a", "b", "q"])
+    out = str(tmp_path / "o.txt")
+    imputable(df, missingness=0.5, neighbors=2).impute_data(out)
+    result = pd.read_csv(out, sep="\t")
+    imputed = result.query("Peptide == 'q'")["ZT00_1"].iloc[0]
+    assert imputed == pytest.approx(50.0)
+
+
+def test_impute_clamps_neighbors_to_complete_cases(tmp_path):
+    # #40: fewer complete-case rows than requested neighbors must not raise.
+    cols = [f"ZT{2 * i:02d}_1" for i in range(6)]
+    rows = [list(np.random.RandomState(i).rand(6)) for i in range(4)]  # 4 complete
+    for i in range(4, 6):
+        r = list(np.random.RandomState(i).rand(6))
+        r[0] = np.nan
+        rows.append(r)  # 2 incomplete
+    df = pd.DataFrame(rows, columns=cols)
+    df.insert(0, "Protein", [f"p{i}" for i in range(6)])
+    df.insert(0, "Peptide", [f"pep{i}" for i in range(6)])
+    out = str(tmp_path / "o.txt")
+    imputable(df, missingness=0.5, neighbors=10).impute_data(out)  # must not raise
+    assert pd.read_csv(out, sep="\t").shape[0] == 6
+
+
+def test_impute_raises_without_complete_cases(tmp_path):
+    # Guard: no complete-case row to learn from -> clear error, not a crash.
+    cols = ["ZT00_1", "ZT06_1"]
+    df = pd.DataFrame([[np.nan, 1.0], [2.0, np.nan]], columns=cols)
+    df.insert(0, "Protein", ["pA", "pB"])
+    df.insert(0, "Peptide", ["a", "b"])
+    out = str(tmp_path / "o.txt")
+    with pytest.raises(ValueError, match="complete-case"):
+        imputable(df, missingness=0.9, neighbors=2).impute_data(out)


### PR DESCRIPTION
## Summary
**`imputation.py`**
- **#39:** averaged all returned neighbors instead of dropping index 0. Imputed rows are never in the complete-case set, so the "skip self" assumption discarded a genuine nearest neighbor, biasing every imputed value.
- **#40:** clamp `n_neighbors` to the number of complete cases (fewer than the default 10 is common in proteomics) and raise a clear error when there are zero complete cases.
- **#49:** `deduplicate` looked up the second column by integer label `0`, raising `KeyError` for a DataFrame input with a non-default, non-MultiIndex index. Use positional `.iloc[0]`. (Folded in after the external PR #53 was closed.)

**`batch_fx.py`**
- **#46:** clamp the `est_pi_sig` index so a ~null trend admits *no* rows (the old `floor(...) - 1` wrapped to `sp[-1]`, the max, admitting nearly all), and replace the early `return` with skip-and-continue so later eigentrends are still evaluated.
- **#48:** guard the autocorrelation denominator — an all-zero row now yields `0` instead of propagating `NaN` into the reduction threshold.
- **#50:** finite-sample-valid `(count + 1)/(nperm + 1)` permutation p-value with `>=`.
- **#61:** strip `ZT`/`CT` only as a leading prefix in `get_tpoints` (same class as #52).

## Test plan
- imputation: deduplicate with a non-default index (#49), nearest-neighbor retention (#39), neighbor clamping (#40), zero-complete-case error.
- batch_fx: all-zero-row autocorrelation (#48), non-zero permutation significance (#50), trend processing after a null trend (#46), prefix-only parsing (#61).
- CI: ruff check + ruff format + pytest.

Fixes #39
Fixes #40
Fixes #46
Fixes #48
Fixes #49
Fixes #50
Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)